### PR TITLE
arrayglyph/replace array by masked array

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,4 +127,4 @@ repos:
         name: doctest
         entry: pytest --doctest-modules
         language: system
-        files: \.py$
+        files: cleopatra\.py$

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pip install git+https://github.com/Serapieum-of-alex/cleopatra
 ## pip
 to install the last release, you can easily use pip
 ```
-pip install cleopatra==0.4.4
+pip install cleopatra==0.5.1
 ```
 
 Quick start

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 
 import os
 import sys
-
+from importlib.metadata import version, PackageNotFoundError
 
 # for the auto documentation to work
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -21,7 +21,11 @@ sys.path.insert(0, os.path.abspath("../../cleopatra"))
 project = "cleopatra"
 copyright = "2024, Mostafa Farrag"
 author = "Mostafa Farrag"
-release = "0.4.4"
+# Read the version from the package
+try:
+    release = version("cleopatra")
+except PackageNotFoundError:
+    release = "unknown"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ from importlib.metadata import version, PackageNotFoundError
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("../.."))
+sys.path.insert(0, os.path.abspath("../../cleopatra"))
 
 # General information about the project.
 project = "cleopatra"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ from importlib.metadata import version, PackageNotFoundError
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath("../../cleopatra"))
+sys.path.insert(0, os.path.abspath("../.."))
 
 # General information about the project.
 project = "cleopatra"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,6 +27,7 @@ try:
 except PackageNotFoundError:
     release = "unknown"
 
+version = release
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements_docs = [line.strip() for line in open("docs/requirements.txt").read
 
 setup(
     name="cleopatra",
-    version="0.5.0",
+    version="0.5.1",
     description="visualization package",
     author="Mostafa Farrag",
     author_email="moah.farag@gmail.come",

--- a/tests/test_plot_array.py
+++ b/tests/test_plot_array.py
@@ -23,7 +23,8 @@ class TestCreateArray:
     def test_create_instance(self, arr: np.ndarray, no_data_value: float):
         array = ArrayGlyph(arr, exclude_value=[no_data_value])
         assert isinstance(array.arr, np.ndarray)
-        assert np.isnan(array.arr[0, 0])
+        # check if the first element is masked
+        assert array.arr.mask[0, 0]
         assert array.no_elem == 89
         assert array.vmin == 0
         assert array.vmax == 88


### PR DESCRIPTION
# Internal improvement 

- replace the normal numpy array in the constructor method by masked array in order not to convert all input arrays to float32.
- Now all the arrays will stay the same type as they have ben given, so if the array is int the mask (np.nan) will be stored in the array without converting it to float.
- Now we don't need to use the `prepare_array` method to scale the values if they are already between 0-255 which `matplotlib` already understand.
- the `percentile`/`surface_reflectance` parameters to the constructor method are None by default, so no processing is done to the given array except when the previous parameters are given.

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

all the tests passed plus manual check for the example scripts.


# Checklist:

- [x] updated version number in setup.py/pyproject.toml
- [ ] updated environment.yml and the lock file
- [x] added changes to History.rst
- [x] updated the latest version in README file
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
