### PR TITLE
feat: matplotlib primitives (glyphs, shared scalar mapping, legends)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "numpy>=2.0.0",
-    "matplotlib>=3.8.4",
+    "matplotlib>=3.9",
     "ffmpeg-python",
     "hpc-utils>=0.1.4",
 ]

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 import math
+import warnings
 
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
@@ -419,6 +420,173 @@ class Glyph:
         else:
             bounds = np.sort(np.asarray(levels, dtype=float))
         return bounds
+
+    def _resolve_limits(self, values: np.ndarray) -> tuple[float, float]:
+        """Resolve `(vmin, vmax)` from options, falling back to the data range.
+
+        Reads `vmin` / `vmax` from `default_options`; whichever is `None`
+        (or absent) is filled from the nan-aware min/max of `values`. This
+        mirrors the simple branch of `ArrayGlyph._resolve_color_limits`
+        (the `robust` / `center` / `percentile` machinery stays an
+        `ArrayGlyph` concern). All-NaN input is detected and rejected here
+        rather than surfacing later as an opaque failure inside
+        `get_ticks()` or matplotlib.
+
+        Args:
+            values: The scalar array that will be colour-mapped. Used to
+                supply data-driven limits when `vmin` / `vmax` are unset.
+
+        Returns:
+            tuple[float, float]: The resolved `(vmin, vmax)` as floats.
+
+        Raises:
+            ValueError: If a limit cannot be resolved to a finite number
+                (e.g. `values` is empty or all-NaN and the corresponding
+                limit was not pinned explicitly).
+
+        Examples:
+            - Auto-resolve both limits from the data:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.glyph import Glyph
+                >>> from cleopatra.styles import DEFAULT_OPTIONS
+                >>> opts = DEFAULT_OPTIONS.copy()
+                >>> opts.update({"vmin": None, "vmax": None})
+                >>> g = Glyph(default_options=opts)
+                >>> g._resolve_limits(np.array([1.0, 5.0, 9.0]))
+                (1.0, 9.0)
+
+                ```
+            - An explicit limit is preserved; only the missing one is
+                taken from the data:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.glyph import Glyph
+                >>> from cleopatra.styles import DEFAULT_OPTIONS
+                >>> opts = DEFAULT_OPTIONS.copy()
+                >>> opts.update({"vmin": 0.0, "vmax": None})
+                >>> g = Glyph(default_options=opts)
+                >>> g._resolve_limits(np.array([1.0, 5.0, 9.0]))
+                (0.0, 9.0)
+
+                ```
+            - An all-NaN array with unpinned limits raises `ValueError`:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.glyph import Glyph
+                >>> from cleopatra.styles import DEFAULT_OPTIONS
+                >>> opts = DEFAULT_OPTIONS.copy()
+                >>> opts.update({"vmin": None, "vmax": None})
+                >>> g = Glyph(default_options=opts)
+                >>> g._resolve_limits(np.array([np.nan, np.nan]))
+                Traceback (most recent call last):
+                    ...
+                ValueError: Cannot determine vmin/vmax: no finite values...
+
+                ```
+        """
+        vmin = self.default_options.get("vmin")
+        vmax = self.default_options.get("vmax")
+        if vmin is None or vmax is None:
+            # nanmin/nanmax on an all-NaN array return NaN with a
+            # RuntimeWarning; compute quietly and validate below so the
+            # failure is a clear ValueError rather than a downstream crash.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", RuntimeWarning)
+                data_min = np.nanmin(values)
+                data_max = np.nanmax(values)
+            vmin = data_min if vmin is None else vmin
+            vmax = data_max if vmax is None else vmax
+        if not (np.isfinite(vmin) and np.isfinite(vmax)):
+            raise ValueError(
+                "Cannot determine vmin/vmax: no finite values. Pass "
+                "explicit vmin/vmax, or filter the array first."
+            )
+        return float(vmin), float(vmax)
+
+    def _prepare_scalar_mapping(
+        self, values: np.ndarray
+    ) -> tuple[colors.Normalize | None, dict, np.ndarray]:
+        """Build the `(norm, cbar_kw, ticks)` triple shared by coloured glyphs.
+
+        This is the single home for the scalar-mapping contract that every
+        colour-by-value glyph needs. It:
+
+        1. resolves `(vmin, vmax)` from `default_options`, falling back to
+           the data range via `_resolve_limits`;
+        2. derives a sensible `ticks_spacing` of `(vmax - vmin) / 10` when
+           the caller left it unset (`None`), guarding flat data so the
+           spacing is never zero;
+        3. writes `vmin`, `vmax`, and `ticks_spacing` back into
+           `default_options` so the existing `get_ticks()` — which reads
+           from `default_options` — can see them; and
+        4. computes the ticks and forwards them to
+           `_create_norm_and_cbar_kw`, honouring `levels` / `color_scale`.
+
+        Subclasses call this instead of re-deriving the contract (which is
+        easy to get subtly wrong: `get_ticks()` does not read `self._vmin`,
+        and `np.arange(None, None)` raises).
+
+        Args:
+            values: The scalar array to be colour-mapped (e.g. point
+                values, vector magnitudes, per-polygon values).
+
+        Returns:
+            tuple[Normalize or None, dict, np.ndarray]: the matplotlib norm
+                (`None` for a plain linear scale), the colorbar keyword
+                arguments from `_create_norm_and_cbar_kw`, and the computed
+                tick positions.
+
+        Raises:
+            ValueError: Propagated from `_resolve_limits` when no finite
+                limits can be determined.
+
+        Examples:
+            - Auto limits resolve from the data and produce a non-`None`
+                `ticks_spacing` plus continuous-scale ticks:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.glyph import Glyph
+                >>> from cleopatra.styles import DEFAULT_OPTIONS
+                >>> opts = DEFAULT_OPTIONS.copy()
+                >>> opts.update({"vmin": None, "vmax": None, "ticks_spacing": None})
+                >>> g = Glyph(default_options=opts)
+                >>> norm, cbar_kw, ticks = g._prepare_scalar_mapping(
+                ...     np.array([0.0, 5.0, 10.0])
+                ... )
+                >>> norm is None
+                True
+                >>> g.default_options["ticks_spacing"]
+                1.0
+                >>> [float(t) for t in ticks]
+                [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+
+                ```
+            - Flat data does not produce a zero spacing:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.glyph import Glyph
+                >>> from cleopatra.styles import DEFAULT_OPTIONS
+                >>> opts = DEFAULT_OPTIONS.copy()
+                >>> opts.update({"vmin": None, "vmax": None, "ticks_spacing": None})
+                >>> g = Glyph(default_options=opts)
+                >>> _ = g._prepare_scalar_mapping(np.array([3.0, 3.0, 3.0]))
+                >>> g.default_options["ticks_spacing"]
+                1.0
+
+                ```
+        """
+        self._vmin, self._vmax = self._resolve_limits(np.asarray(values))
+        if self.default_options.get("ticks_spacing") is None:
+            # `or 1.0` guards flat data (vmax == vmin -> spacing 0), which
+            # would make get_ticks()'s np.arange produce an empty array.
+            self.ticks_spacing = (self._vmax - self._vmin) / 10 or 1.0
+            self.default_options["ticks_spacing"] = self.ticks_spacing
+        self.default_options["vmin"] = self._vmin
+        self.default_options["vmax"] = self._vmax
+        ticks = self.get_ticks()
+        norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
+        return norm, cbar_kw, ticks
 
     def create_color_bar(self, ax: Axes, im: Any, cbar_kw: dict) -> Colorbar:
         """Create a colorbar with full customization from default_options.

--- a/src/cleopatra/line_glyph.py
+++ b/src/cleopatra/line_glyph.py
@@ -1,0 +1,297 @@
+"""Line, bar, and band visualization.
+
+Provides `LineGlyph` for the non-colour-mapped 1D plot family: line and
+marker series (`line`), bar charts (`bar`), and filled bands between two
+curves (`fill_between`, used for envelopes / quantile spreads). Unlike
+the colour-by-value glyphs, `LineGlyph` does not use the scalar-mapping
+pipeline; it subclasses `Glyph` for the figure/axes lifecycle and the
+shared style options.
+
+Examples:
+    - Plot a single line series:
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.line_glyph import LineGlyph
+        >>> x = np.array([0.0, 1.0, 2.0, 3.0])
+        >>> y = np.array([0.0, 1.0, 4.0, 9.0])
+        >>> glyph = LineGlyph(x, y)
+        >>> fig, ax, lines = glyph.line()
+
+        ```
+    - Fill an envelope band between two curves:
+        ```python
+        >>> lower = np.array([-1.0, 0.0, 3.0, 8.0])
+        >>> glyph = LineGlyph(x, y)
+        >>> fig, ax, band = glyph.fill_between(y2=lower)
+
+        ```
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+from cleopatra.glyph import Glyph
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+
+#: Option keys for LineGlyph (no scalar-mapping keys; this glyph does
+#: not colour by value).
+LINE_DEFAULT_OPTIONS = {
+    "marker": None,
+    "linestyle": "-",
+    "alpha": 1.0,
+}
+LINE_DEFAULT_OPTIONS = STYLE_DEFAULTS | LINE_DEFAULT_OPTIONS
+
+
+class LineGlyph(Glyph):
+    """Visualization class for line, bar, and band plots.
+
+    Wraps `Axes.plot`, `Axes.bar`, and `Axes.fill_between`. `y` may be
+    1D (a single series) or 2D (`line`/`bar` draw one series per
+    column). Styling comes from the shared options (`color_1`,
+    `line_width`, `marker`, `linestyle`, `alpha`).
+
+    Args:
+        x: 1D array of x-coordinates.
+        y: y-values. 1D for a single series, or 2D `(n_points,
+            n_series)` for multiple series.
+        ax: Pre-existing axes to draw on. Default is None.
+        fig: Pre-existing figure. Default is None.
+        **kwargs: Override any key in `LINE_DEFAULT_OPTIONS`
+            (e.g. `marker`, `linestyle`, `alpha`, `color_1`,
+            `line_width`, `figsize`, `title`).
+
+    Raises:
+        ValueError: If the length of `x` does not match the number of
+            rows in `y`.
+
+    Examples:
+        - Read back the y-data of the drawn line:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.line_glyph import LineGlyph
+            >>> glyph = LineGlyph(np.array([0.0, 1.0, 2.0]), np.array([1.0, 3.0, 2.0]))
+            >>> fig, ax, lines = glyph.line()
+            >>> [float(v) for v in lines[0].get_ydata()]
+            [1.0, 3.0, 2.0]
+
+            ```
+    """
+
+    def __init__(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        *,
+        ax: Axes = None,
+        fig: Figure = None,
+        **kwargs,
+    ):
+        super().__init__(
+            default_options=LINE_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
+        )
+        self.x = np.asarray(x)
+        self.y = np.asarray(y)
+        n_rows = self.y.shape[0]
+        if self.x.shape[0] != n_rows:
+            raise ValueError(
+                f"x length ({self.x.shape[0]}) must match the number of rows "
+                f"in y ({n_rows})."
+            )
+
+    def _series(self) -> list[np.ndarray]:
+        """Split `y` into one 1D array per series (column for 2D)."""
+        if self.y.ndim == 1:
+            return [self.y]
+        return [self.y[:, i] for i in range(self.y.shape[1])]
+
+    def _resolve_ax(self, ax: Axes | None) -> Axes:
+        """Set up and return the axes to draw on, creating one if needed."""
+        if ax is not None:
+            self.ax = ax
+            self.fig = ax.get_figure()
+        elif self.ax is None:
+            self.fig, self.ax = self.create_figure_axes()
+        return self.ax
+
+    def _apply_title(self, ax: Axes, title: str | None) -> None:
+        """Apply a title override (or the option default) to `ax`."""
+        if title is not None:
+            self.default_options["title"] = title
+        if self.default_options["title"]:
+            ax.set_title(
+                self.default_options["title"],
+                fontsize=self.default_options["title_size"],
+            )
+
+    def line(
+        self,
+        ax: Axes = None,
+        title: str | None = None,
+        label: str | list[str] | None = None,
+        color=None,
+        **kwargs,
+    ):
+        """Draw line/marker series with `Axes.plot`.
+
+        Args:
+            ax: Axes to draw on. Falls back to the construction axes or
+                a new figure/axes.
+            title: Plot title override.
+            label: Legend label(s); a single string for 1D `y` or one
+                per series for 2D `y`.
+            color: Line colour. Defaults to the `color_1` option.
+            **kwargs: Forwarded to `Axes.plot`.
+
+        Returns:
+            tuple[Figure, Axes, list[Line2D]]: The figure, the axes, and
+                the list of drawn lines (one per series).
+
+        Examples:
+            - Two series produce two lines:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.line_glyph import LineGlyph
+                >>> x = np.array([0.0, 1.0, 2.0])
+                >>> y = np.array([[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]])
+                >>> glyph = LineGlyph(x, y)
+                >>> fig, ax, lines = glyph.line()
+                >>> len(lines)
+                2
+
+                ```
+        """
+        ax = self._resolve_ax(ax)
+        opts = self.default_options
+        color = color if color is not None else opts["color_1"]
+        series = self._series()
+        labels = (
+            label if isinstance(label, (list, tuple))
+            else [label] * len(series)
+        )
+        lines = []
+        for col, lab in zip(series, labels):
+            drawn = ax.plot(
+                self.x, col,
+                linestyle=opts["linestyle"],
+                marker=opts["marker"],
+                linewidth=opts["line_width"],
+                alpha=opts["alpha"],
+                label=lab,
+                **({"color": color} if len(series) == 1 else {}),
+                **kwargs,
+            )
+            lines.extend(drawn)
+        self._apply_title(ax, title)
+        return self.fig, ax, lines
+
+    def bar(
+        self,
+        ax: Axes = None,
+        title: str | None = None,
+        color=None,
+        **kwargs,
+    ):
+        """Draw a bar chart of a single series with `Axes.bar`.
+
+        Args:
+            ax: Axes to draw on. Falls back to the construction axes or
+                a new figure/axes.
+            title: Plot title override.
+            color: Bar colour. Defaults to the `color_1` option.
+            **kwargs: Forwarded to `Axes.bar`.
+
+        Returns:
+            tuple[Figure, Axes, BarContainer]: The figure, the axes, and
+                the bar container.
+
+        Raises:
+            ValueError: If `y` is not 1D (bar charts take a single
+                series).
+
+        Examples:
+            - One bar per x value:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.line_glyph import LineGlyph
+                >>> glyph = LineGlyph(np.array([0.0, 1.0, 2.0]), np.array([3.0, 1.0, 2.0]))
+                >>> fig, ax, bars = glyph.bar()
+                >>> len(bars)
+                3
+
+                ```
+        """
+        if self.y.ndim != 1:
+            raise ValueError(
+                f"bar requires 1D y (a single series); got {self.y.ndim}D."
+            )
+        ax = self._resolve_ax(ax)
+        opts = self.default_options
+        color = color if color is not None else opts["color_1"]
+        bars = ax.bar(
+            self.x, self.y, color=color, alpha=opts["alpha"], **kwargs
+        )
+        self._apply_title(ax, title)
+        return self.fig, ax, bars
+
+    def fill_between(
+        self,
+        y2: float | np.ndarray = 0.0,
+        ax: Axes = None,
+        title: str | None = None,
+        color=None,
+        alpha: float | None = None,
+        **kwargs,
+    ):
+        """Fill the band between `y` and `y2` with `Axes.fill_between`.
+
+        Useful for envelopes and quantile spreads: `y` is the upper
+        curve and `y2` the lower (a scalar baseline or a matching
+        array). Requires 1D `y`.
+
+        Args:
+            y2: Lower curve, scalar or array matching `x`. Default is
+                0.0.
+            ax: Axes to draw on. Falls back to the construction axes or
+                a new figure/axes.
+            title: Plot title override.
+            color: Fill colour. Defaults to the `color_1` option.
+            alpha: Fill transparency. Defaults to `0.3` for a band look
+                (overrides the glyph's `alpha` option for the fill).
+            **kwargs: Forwarded to `Axes.fill_between`.
+
+        Returns:
+            tuple[Figure, Axes, PolyCollection]: The figure, the axes,
+                and the filled band collection.
+
+        Raises:
+            ValueError: If `y` is not 1D.
+
+        Examples:
+            - Band between an upper curve and a scalar baseline:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.line_glyph import LineGlyph
+                >>> glyph = LineGlyph(np.array([0.0, 1.0, 2.0]), np.array([1.0, 3.0, 2.0]))
+                >>> fig, ax, band = glyph.fill_between(y2=0.0)
+                >>> band.get_paths() is not None
+                True
+
+                ```
+        """
+        if self.y.ndim != 1:
+            raise ValueError(
+                f"fill_between requires 1D y; got {self.y.ndim}D."
+            )
+        ax = self._resolve_ax(ax)
+        opts = self.default_options
+        color = color if color is not None else opts["color_1"]
+        alpha = alpha if alpha is not None else 0.3
+        band = ax.fill_between(
+            self.x, self.y, y2, color=color, alpha=alpha, **kwargs
+        )
+        self._apply_title(ax, title)
+        return self.fig, ax, band

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -340,6 +340,7 @@ class MeshGlyph(Glyph):
         location: str,
         edgecolor: str = "none",
         norm=None,
+        filled: bool = True,
         **render_kwargs,
     ):
         """Render mesh data on axes and return the mappable.
@@ -350,10 +351,16 @@ class MeshGlyph(Glyph):
             location: `"face"` or `"node"`.
             edgecolor: Edge color for face rendering.
             norm: Color normalization.
-            **render_kwargs: Passed to tripcolor or tricontourf.
+            filled: For node data, whether to draw filled contours
+                (`tricontourf`, the default) or line contours
+                (`tricontour`). Ignored for face data, which always uses
+                `tripcolor`.
+            **render_kwargs: Passed to tripcolor, tricontourf, or
+                tricontour.
 
         Returns:
-            ScalarMappable: The tripcolor or tricontourf result.
+            ScalarMappable: The tripcolor, tricontourf, or tricontour
+                result.
         """
         tri = self.triangulation
         cmap = self.default_options["cmap"]
@@ -380,7 +387,9 @@ class MeshGlyph(Glyph):
             if vmax is not None:
                 contour_kw["vmax"] = vmax
         contour_kw.update(render_kwargs)
-        return ax.tricontourf(tri, data, **contour_kw)
+        if filled:
+            return ax.tricontourf(tri, data, **contour_kw)
+        return ax.tricontour(tri, data, **contour_kw)
 
     def plot(
         self,
@@ -390,13 +399,16 @@ class MeshGlyph(Glyph):
         edgecolor: str = "none",
         colorbar: bool = True,
         title: str | None = None,
+        filled: bool = True,
         **kwargs: Any,
     ) -> tuple[plt.Figure, plt.Axes]:
         """Plot mesh data using matplotlib triangulation.
 
         For face-centered data, uses `tripcolor` where each triangle
         is colored by the value of its parent face. For node-centered
-        data, uses `tricontourf` for smooth interpolated contours.
+        data, uses `tricontourf` for smooth interpolated filled
+        contours, or `tricontour` for line contours when
+        `filled=False`.
 
         Supports all 5 color scale types from `default_options`:
         linear, power, sym-lognorm, boundary-norm, and midpoint.
@@ -412,11 +424,14 @@ class MeshGlyph(Glyph):
                 `"none"`.
             colorbar: Whether to add a colorbar. Default is True.
             title: Plot title. Overrides `default_options["title"]`.
+            filled: For node data, draw filled contours (`tricontourf`,
+                the default) or line contours (`tricontour`) when
+                `False`. Ignored for face data. Default is True.
             **kwargs: Override any key in `default_options` (cmap,
                 vmin, vmax, color_scale, gamma, midpoint, bounds,
                 ticks_spacing, cbar_orientation, cbar_label, figsize,
                 etc.) or pass extra rendering kwargs (levels for
-                tricontourf).
+                tricontourf / tricontour).
 
         Returns:
             tuple[Figure, Axes]: The matplotlib Figure and Axes objects.
@@ -452,6 +467,22 @@ class MeshGlyph(Glyph):
                 >>> fig, ax = mg.plot(
                 ...     np.array([0.0, 1.0, 2.0, 3.0]),
                 ...     location="node",
+                ... )
+
+                ```
+            - Plot node-centered data as line contours
+                (`tricontour`) instead of filled:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.mesh_glyph import MeshGlyph
+                >>> node_x = np.array([0.0, 1.0, 0.5, 1.5])
+                >>> node_y = np.array([0.0, 0.0, 1.0, 1.0])
+                >>> faces = np.array([[0, 1, 2], [1, 3, 2]])
+                >>> mg = MeshGlyph(node_x, node_y, faces)
+                >>> fig, ax = mg.plot(
+                ...     np.array([0.0, 1.0, 2.0, 3.0]),
+                ...     location="node",
+                ...     filled=False,
                 ... )
 
                 ```
@@ -526,6 +557,7 @@ class MeshGlyph(Glyph):
             location,
             edgecolor=edgecolor,
             norm=norm,
+            filled=filled,
             **render_kwargs,
         )
 

--- a/src/cleopatra/polygon_glyph.py
+++ b/src/cleopatra/polygon_glyph.py
@@ -1,0 +1,209 @@
+"""Filled-polygon visualization.
+
+Provides `PolygonGlyph` for drawing a collection of polygons, optionally
+coloured by a per-polygon scalar value (a choropleth). The glyph is
+geometry-agnostic: it takes plain vertex arrays, never geopandas, so the
+caller (e.g. Digital-Earth) is responsible for extracting polygon
+vertices from whatever geometry source it has. Colour mapping reuses the
+shared `Glyph._prepare_scalar_mapping` pipeline so `vmin` / `vmax`,
+`ticks_spacing`, `levels`, and `color_scale` behave as for the other
+glyphs.
+
+Examples:
+    - Colour two triangles by value:
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.polygon_glyph import PolygonGlyph
+        >>> polys = [
+        ...     np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]),
+        ...     np.array([[1.0, 0.0], [2.0, 0.0], [1.5, 1.0]]),
+        ... ]
+        >>> glyph = PolygonGlyph(polys, values=np.array([10.0, 20.0]))
+        >>> fig, ax, pc = glyph.plot()
+
+        ```
+    - Draw outlines only (no fill, no colorbar):
+        ```python
+        >>> glyph = PolygonGlyph(polys)
+        >>> fig, ax, pc = glyph.plot(outline_only=True)
+
+        ```
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import PolyCollection
+from matplotlib.figure import Figure
+
+from cleopatra.glyph import Glyph
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+
+#: Option keys for PolygonGlyph. `ticks_spacing` is `None` so the shared
+#: `_prepare_scalar_mapping` helper auto-derives it from the data.
+POLYGON_DEFAULT_OPTIONS = {
+    "edgecolor": "none",
+    "linewidth": 0.5,
+    "vmin": None,
+    "vmax": None,
+    "levels": None,
+    "ticks_spacing": None,
+}
+POLYGON_DEFAULT_OPTIONS = STYLE_DEFAULTS | POLYGON_DEFAULT_OPTIONS
+
+
+class PolygonGlyph(Glyph):
+    """Visualization class for collections of polygons.
+
+    Wraps `matplotlib.collections.PolyCollection`. With a per-polygon
+    `values` array, polygons are filled and colour-mapped through the
+    shared scalar-mapping pipeline and a colorbar is attached. With no
+    values (or `outline_only=True`), only the polygon outlines are
+    drawn.
+
+    Args:
+        polygons: Sequence of polygons, each an `(n_i, 2)` array of
+            `(x, y)` vertices. Polygons may have differing vertex
+            counts.
+        values: Optional 1D array of per-polygon scalar values for
+            colour mapping. Must match the number of polygons when
+            given. Default is None (outline-only).
+        ax: Pre-existing axes to draw on. Default is None.
+        fig: Pre-existing figure. Default is None.
+        **kwargs: Override any key in `POLYGON_DEFAULT_OPTIONS`
+            (e.g. `edgecolor`, `linewidth`, `cmap`, `vmin`, `vmax`,
+            `levels`, `color_scale`, `ticks_spacing`, `cbar_label`,
+            `figsize`, `title`).
+
+    Raises:
+        ValueError: If `values` is given but its length does not match
+            the number of polygons.
+
+    Examples:
+        - Inspect the value array carried by the collection:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.polygon_glyph import PolygonGlyph
+            >>> polys = [
+            ...     np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]),
+            ...     np.array([[1.0, 0.0], [2.0, 0.0], [1.5, 1.0]]),
+            ... ]
+            >>> glyph = PolygonGlyph(polys, values=np.array([3.0, 7.0]))
+            >>> fig, ax, pc = glyph.plot()
+            >>> [float(v) for v in pc.get_array()]
+            [3.0, 7.0]
+
+            ```
+
+    See Also:
+        cleopatra.glyph.Glyph._prepare_scalar_mapping: Shared
+            norm/colorbar/ticks pipeline used for the filled path.
+    """
+
+    def __init__(
+        self,
+        polygons: Sequence[np.ndarray],
+        values: np.ndarray | None = None,
+        *,
+        ax: Axes = None,
+        fig: Figure = None,
+        **kwargs,
+    ):
+        super().__init__(
+            default_options=POLYGON_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
+        )
+        self.polygons = [np.asarray(p, dtype=float) for p in polygons]
+        if values is not None:
+            values = np.asarray(values)
+            if values.shape[0] != len(self.polygons):
+                raise ValueError(
+                    f"values length ({values.shape[0]}) must match the number "
+                    f"of polygons ({len(self.polygons)})."
+                )
+        self.values = values
+        self.cbar = None
+
+    def plot(
+        self,
+        outline_only: bool = False,
+        ax: Axes = None,
+        title: str | None = None,
+    ) -> tuple[Figure, Axes, PolyCollection]:
+        """Draw the polygons, filling by value when present.
+
+        When `values` was supplied and `outline_only` is False, the
+        polygons are filled and colour-mapped through
+        `_prepare_scalar_mapping` (so `vmin` / `vmax` / `levels` /
+        `color_scale` apply) with a matching colorbar. Otherwise only
+        the outlines are drawn and no colorbar is added.
+
+        Args:
+            outline_only: Draw unfilled outlines even when `values` is
+                present (the `shapes` use case). Default is False.
+            ax: Axes to draw on. Falls back to the axes supplied at
+                construction, otherwise a new figure/axes is created.
+            title: Plot title. Overrides `default_options["title"]`
+                when given.
+
+        Returns:
+            tuple[Figure, Axes, PolyCollection]: The figure, the axes,
+                and the `PolyCollection` added to the axes.
+
+        Examples:
+            - Outline-only mode carries no colour array and no colorbar:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.polygon_glyph import PolygonGlyph
+                >>> polys = [np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]])]
+                >>> glyph = PolygonGlyph(polys, values=np.array([5.0]))
+                >>> fig, ax, pc = glyph.plot(outline_only=True)
+                >>> pc.get_array() is None
+                True
+                >>> glyph.cbar is None
+                True
+
+                ```
+        """
+        if ax is not None:
+            self.ax = ax
+            self.fig = ax.get_figure()
+        elif self.ax is None:
+            self.fig, self.ax = self.create_figure_axes()
+        ax = self.ax
+        opts = self.default_options
+
+        if title is not None:
+            opts["title"] = title
+
+        if outline_only or self.values is None:
+            pc = PolyCollection(
+                self.polygons,
+                facecolors="none",
+                edgecolors=opts["edgecolor"],
+                linewidths=opts["linewidth"],
+            )
+            ax.add_collection(pc)
+            ax.autoscale_view()
+        else:
+            norm, cbar_kw, ticks = self._prepare_scalar_mapping(self.values)
+            pc = PolyCollection(
+                self.polygons,
+                array=np.asarray(self.values),
+                cmap=opts["cmap"],
+                norm=norm,
+                edgecolors=opts["edgecolor"],
+                linewidths=opts["linewidth"],
+            )
+            if norm is None:
+                pc.set_clim(ticks[0], ticks[-1])
+            ax.add_collection(pc)
+            ax.autoscale_view()
+            self.cbar = self.create_color_bar(ax, pc, cbar_kw)
+
+        if opts["title"]:
+            ax.set_title(opts["title"], fontsize=opts["title_size"])
+
+        return self.fig, ax, pc

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -1,0 +1,222 @@
+"""Point-cloud visualization.
+
+Provides `ScatterGlyph` for plotting 2D point clouds, optionally
+colour-mapped by a per-point scalar value. Colour mapping reuses the
+shared `Glyph._prepare_scalar_mapping` pipeline so that `vmin` / `vmax`,
+`ticks_spacing`, `levels`, and `color_scale` behave exactly as they do
+for `ArrayGlyph` and `MeshGlyph`.
+
+Examples:
+    - Plot an uncoloured point cloud:
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.scatter_glyph import ScatterGlyph
+        >>> x = np.array([0.0, 1.0, 2.0, 3.0])
+        >>> y = np.array([0.0, 1.0, 0.0, 1.0])
+        >>> glyph = ScatterGlyph(x, y)
+        >>> fig, ax, paths = glyph.plot()
+
+        ```
+    - Colour points by a per-point value (adds a colorbar):
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.scatter_glyph import ScatterGlyph
+        >>> x = np.array([0.0, 1.0, 2.0, 3.0])
+        >>> y = np.array([0.0, 1.0, 0.0, 1.0])
+        >>> values = np.array([10.0, 20.0, 30.0, 40.0])
+        >>> glyph = ScatterGlyph(x, y, values)
+        >>> fig, ax, paths = glyph.plot()
+
+        ```
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import PathCollection
+from matplotlib.figure import Figure
+
+from cleopatra.glyph import Glyph
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+
+#: Option keys for ScatterGlyph. `ticks_spacing` is `None` so the shared
+#: `_prepare_scalar_mapping` helper auto-derives it from the data range.
+SCATTER_DEFAULT_OPTIONS = {
+    "marker": "o",
+    "point_size": 20,
+    "vmin": None,
+    "vmax": None,
+    "levels": None,
+    "ticks_spacing": None,
+}
+SCATTER_DEFAULT_OPTIONS = STYLE_DEFAULTS | SCATTER_DEFAULT_OPTIONS
+
+
+class ScatterGlyph(Glyph):
+    """Visualization class for 2D point clouds.
+
+    Wraps `matplotlib.axes.Axes.scatter`. With no `values`, points are
+    drawn in a single colour. With a per-point `values` array, points
+    are colour-mapped through the shared scalar-mapping pipeline and a
+    matching colorbar is attached.
+
+    Args:
+        x: 1D array of point x-coordinates.
+        y: 1D array of point y-coordinates. Must match the length of
+            `x`.
+        values: Optional 1D array of per-point scalar values used for
+            colour mapping. Must match the length of `x` when given.
+            Default is None (uncoloured points).
+        ax: Pre-existing axes to draw on. Default is None.
+        fig: Pre-existing figure. Default is None.
+        **kwargs: Override any key in `SCATTER_DEFAULT_OPTIONS`
+            (e.g. `marker`, `point_size`, `cmap`, `vmin`, `vmax`,
+            `levels`, `color_scale`, `ticks_spacing`, `cbar_label`,
+            `figsize`, `title`).
+
+    Raises:
+        ValueError: If `x` and `y` (or `values`, when given) have
+            mismatched lengths.
+
+    Examples:
+        - Colour points by value and read back the mapped array:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.scatter_glyph import ScatterGlyph
+            >>> glyph = ScatterGlyph(
+            ...     np.array([0.0, 1.0, 2.0]),
+            ...     np.array([0.0, 1.0, 0.0]),
+            ...     np.array([1.0, 5.0, 9.0]),
+            ... )
+            >>> fig, ax, paths = glyph.plot()
+            >>> [float(v) for v in paths.get_array()]
+            [1.0, 5.0, 9.0]
+
+            ```
+
+    See Also:
+        cleopatra.glyph.Glyph._prepare_scalar_mapping: Shared
+            norm/colorbar/ticks pipeline used for the coloured path.
+    """
+
+    def __init__(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        values: np.ndarray | None = None,
+        *,
+        ax: Axes = None,
+        fig: Figure = None,
+        **kwargs,
+    ):
+        super().__init__(
+            default_options=SCATTER_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
+        )
+        self.x = np.asarray(x)
+        self.y = np.asarray(y)
+        if self.x.shape != self.y.shape:
+            raise ValueError(
+                f"x and y must have the same shape, got {self.x.shape} "
+                f"and {self.y.shape}."
+            )
+        if values is not None:
+            values = np.asarray(values)
+            if values.shape != self.x.shape:
+                raise ValueError(
+                    f"values must match x/y shape {self.x.shape}, got "
+                    f"{values.shape}."
+                )
+        self.values = values
+        self.cbar = None
+
+    def plot(
+        self,
+        ax: Axes = None,
+        title: str | None = None,
+    ) -> tuple[Figure, Axes, PathCollection]:
+        """Draw the point cloud, colour-mapping by value when present.
+
+        When `values` was supplied at construction, the colour scale,
+        norm, ticks, and colorbar are resolved through
+        `_prepare_scalar_mapping`, so `vmin` / `vmax` / `levels` /
+        `color_scale` behave as for the other glyphs. With no values,
+        a single-colour scatter is drawn and no colorbar is added.
+
+        Args:
+            ax: Axes to draw on. Falls back to the axes supplied at
+                construction, otherwise a new figure/axes is created.
+            title: Plot title. Overrides `default_options["title"]`
+                when given.
+
+        Returns:
+            tuple[Figure, Axes, PathCollection]: The figure, the axes,
+                and the `PathCollection` returned by `scatter` (the
+                mappable for the coloured path).
+
+        Examples:
+            - Uncoloured points return a PathCollection with no array:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.scatter_glyph import ScatterGlyph
+                >>> glyph = ScatterGlyph(
+                ...     np.array([0.0, 1.0]), np.array([0.0, 1.0])
+                ... )
+                >>> fig, ax, paths = glyph.plot()
+                >>> paths.get_array() is None
+                True
+
+                ```
+            - A title passed to plot overrides the default:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.scatter_glyph import ScatterGlyph
+                >>> glyph = ScatterGlyph(
+                ...     np.array([0.0, 1.0]), np.array([0.0, 1.0])
+                ... )
+                >>> fig, ax, paths = glyph.plot(title="Stations")
+                >>> ax.get_title()
+                'Stations'
+
+                ```
+        """
+        if ax is not None:
+            self.ax = ax
+            self.fig = ax.get_figure()
+        elif self.ax is None:
+            self.fig, self.ax = self.create_figure_axes()
+        ax = self.ax
+        opts = self.default_options
+
+        if title is not None:
+            opts["title"] = title
+
+        if self.values is None:
+            paths = ax.scatter(
+                self.x,
+                self.y,
+                s=opts["point_size"],
+                marker=opts["marker"],
+            )
+        else:
+            norm, cbar_kw, ticks = self._prepare_scalar_mapping(self.values)
+            paths = ax.scatter(
+                self.x,
+                self.y,
+                c=np.asarray(self.values),
+                s=opts["point_size"],
+                marker=opts["marker"],
+                cmap=opts["cmap"],
+                norm=norm,
+                vmin=None if norm else ticks[0],
+                vmax=None if norm else ticks[-1],
+            )
+            self.cbar = self.create_color_bar(ax, paths, cbar_kw)
+
+        if opts["title"]:
+            ax.set_title(opts["title"], fontsize=opts["title_size"])
+
+        return self.fig, ax, paths

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -52,11 +52,13 @@ fig_2d, ax_2d, hist_2d = stat_plot_2d.histogram()
 ```
 """
 
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Sequence, Tuple, Union
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
+from matplotlib.colors import Normalize
 from matplotlib.figure import Figure
 
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
@@ -456,3 +458,275 @@ class StatisticalGlyph:
         # ax1.tick_params(axis="y", color="#27408B")
         plt.show()
         return fig, ax, hist
+
+    def _resolve_fig_ax(
+        self, ax: Axes | None, fig: Figure | None
+    ) -> Tuple[Figure, Axes]:
+        """Return a `(fig, ax)` pair, creating one when none is given.
+
+        Unlike `histogram`, the renderers added in T7.3c compose into a
+        caller-supplied axes when provided (and never call `plt.show()`),
+        so they can be laid out into a larger figure.
+
+        Args:
+            ax: An existing axes to draw on, or None.
+            fig: An existing figure, or None. Ignored when `ax` is given
+                (the axes' own figure is used).
+
+        Returns:
+            Tuple[Figure, Axes]: The figure/axes to render into.
+        """
+        if ax is not None:
+            return ax.figure, ax
+        if fig is not None:
+            return fig, fig.add_subplot(111)
+        return plt.subplots(figsize=self.default_options["figsize"])
+
+    def _columns(self) -> List[np.ndarray]:
+        """Split the stored values into one 1D array per series.
+
+        Returns:
+            List[np.ndarray]: A single-element list for 1D values, or
+                one array per column for 2D values.
+        """
+        values = np.asarray(self.values)
+        if values.ndim == 1:
+            return [values]
+        return [values[:, i] for i in range(values.shape[1])]
+
+    def _apply_axis_labels(self, ax: Axes) -> None:
+        """Apply the styled x/y axis labels from default_options to `ax`."""
+        opts = self.default_options
+        ax.set_xlabel(opts["xlabel"], fontsize=opts["xlabel_font_size"])
+        ax.set_ylabel(opts["ylabel"], fontsize=opts["ylabel_font_size"])
+        ax.tick_params(axis="x", labelsize=opts["xtick_font_size"])
+        ax.tick_params(axis="y", labelsize=opts["ytick_font_size"])
+
+    def boxplot(
+        self,
+        ax: Axes = None,
+        fig: Figure = None,
+        labels: Sequence[str] | None = None,
+        notch: bool = False,
+        showfliers: bool = True,
+        **kwargs,
+    ) -> Tuple[Figure, Axes, Dict]:
+        """Draw a box-and-whisker plot of the stored values.
+
+        One box is drawn for 1D values; for 2D values one box is drawn
+        per column. Boxes are filled with the `color` option (cycled if
+        there are more series than colours). Composes into a supplied
+        `ax`/`fig` and does not call `plt.show()`.
+
+        Args:
+            ax: Axes to draw on. A new figure/axes is created when both
+                `ax` and `fig` are None.
+            fig: Figure to add an axes to when `ax` is None.
+            labels: Tick labels, one per box. Defaults to 1-based
+                series indices.
+            notch: Draw notched boxes (a rough CI around the median).
+                Default is False.
+            showfliers: Draw outlier points beyond the whiskers.
+                Default is True.
+            **kwargs: Forwarded to `Axes.boxplot`.
+
+        Returns:
+            Tuple[Figure, Axes, Dict]: The figure, the axes, and the
+                dict returned by `Axes.boxplot` (keys: `boxes`,
+                `medians`, `whiskers`, ...).
+
+        Examples:
+            - One box per column for 2D data:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.statistical_glyph import StatisticalGlyph
+                >>> np.random.seed(1)
+                >>> data = np.random.normal(0, 1, (50, 3))
+                >>> stat = StatisticalGlyph(data, color=["r", "g", "b"])
+                >>> fig, ax, bp = stat.boxplot()
+                >>> len(bp["boxes"])
+                3
+
+                ```
+        """
+        fig, ax = self._resolve_fig_ax(ax, fig)
+        columns = self._columns()
+        tick_labels = (
+            list(labels) if labels is not None
+            else [str(i + 1) for i in range(len(columns))]
+        )
+        bp = ax.boxplot(
+            columns,
+            notch=notch,
+            showfliers=showfliers,
+            tick_labels=tick_labels,
+            patch_artist=True,
+            **kwargs,
+        )
+        palette = self.default_options["color"]
+        for i, box in enumerate(bp["boxes"]):
+            box.set_facecolor(palette[i % len(palette)])
+            box.set_alpha(self.default_options["alpha"])
+        ax.grid(axis="y", alpha=self.default_options["grid_alpha"])
+        self._apply_axis_labels(ax)
+        return fig, ax, bp
+
+    def multiboxplot(
+        self,
+        positions: Sequence[float] | None = None,
+        labels: Sequence[str] | None = None,
+        ax: Axes = None,
+        fig: Figure = None,
+        widths: float = 0.5,
+        **kwargs,
+    ) -> Tuple[Figure, Axes, Dict]:
+        """Draw grouped boxes at explicit x positions.
+
+        Like `boxplot`, but the boxes are placed at caller-controlled
+        `positions` along the x axis (e.g. lead times, months), which is
+        the layout the earthkit `multiboxplot` uses for ensembles.
+        Requires 2D values (one column per box).
+
+        Args:
+            positions: x positions for the boxes, one per column.
+                Defaults to `1..n`.
+            labels: Tick labels, one per box. Defaults to the string of
+                each position.
+            ax: Axes to draw on. A new figure/axes is created when both
+                `ax` and `fig` are None.
+            fig: Figure to add an axes to when `ax` is None.
+            widths: Box width in data units. Default is 0.5.
+            **kwargs: Forwarded to `Axes.boxplot`.
+
+        Returns:
+            Tuple[Figure, Axes, Dict]: The figure, the axes, and the
+                `Axes.boxplot` dict.
+
+        Raises:
+            ValueError: If the values are not 2D, or if `positions` /
+                `labels` length does not match the number of columns.
+
+        Examples:
+            - Place three boxes at custom positions:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.statistical_glyph import StatisticalGlyph
+                >>> np.random.seed(1)
+                >>> data = np.random.normal(0, 1, (40, 3))
+                >>> stat = StatisticalGlyph(data, color=["r", "g", "b"])
+                >>> fig, ax, bp = stat.multiboxplot(positions=[1, 2, 4])
+                >>> [int(line.get_xdata().mean()) for line in bp["medians"]]
+                [1, 2, 4]
+
+                ```
+        """
+        values = np.asarray(self.values)
+        if values.ndim != 2:
+            raise ValueError(
+                "multiboxplot requires 2D values (one column per box); got "
+                f"{values.ndim}D."
+            )
+        columns = self._columns()
+        n = len(columns)
+        if positions is None:
+            positions = list(range(1, n + 1))
+        if len(positions) != n:
+            raise ValueError(
+                f"positions length ({len(positions)}) must match the number "
+                f"of columns ({n})."
+            )
+        if labels is not None and len(labels) != n:
+            raise ValueError(
+                f"labels length ({len(labels)}) must match the number of "
+                f"columns ({n})."
+            )
+
+        fig, ax = self._resolve_fig_ax(ax, fig)
+        bp = ax.boxplot(
+            columns,
+            positions=list(positions),
+            widths=widths,
+            patch_artist=True,
+            **kwargs,
+        )
+        palette = self.default_options["color"]
+        for i, box in enumerate(bp["boxes"]):
+            box.set_facecolor(palette[i % len(palette)])
+            box.set_alpha(self.default_options["alpha"])
+        ax.set_xticks(list(positions))
+        ax.set_xticklabels(
+            [str(p) for p in positions] if labels is None else list(labels)
+        )
+        ax.grid(axis="y", alpha=self.default_options["grid_alpha"])
+        self._apply_axis_labels(ax)
+        return fig, ax, bp
+
+    def stripes(
+        self,
+        ax: Axes = None,
+        fig: Figure = None,
+        cmap=None,
+        vmin: float | None = None,
+        vmax: float | None = None,
+        **kwargs,
+    ) -> Tuple[Figure, Axes, "mpl.container.BarContainer"]:
+        """Draw a warming-stripes band: one colour bar per value.
+
+        Each stored value becomes a full-height vertical stripe coloured
+        by `cmap` / the resolved `(vmin, vmax)` normalization — the
+        Ed-Hawkins "warming stripes" idiom. Requires 1D values. Composes
+        into a supplied `ax`/`fig` and does not call `plt.show()`.
+
+        Args:
+            ax: Axes to draw on. A new figure/axes is created when both
+                `ax` and `fig` are None.
+            fig: Figure to add an axes to when `ax` is None.
+            cmap: Colormap name or object. Defaults to the `cmap`
+                option.
+            vmin: Lower colour limit. Defaults to the data minimum.
+            vmax: Upper colour limit. Defaults to the data maximum.
+            **kwargs: Forwarded to `Axes.bar`.
+
+        Returns:
+            Tuple[Figure, Axes, BarContainer]: The figure, the axes, and
+                the bar container (one bar per value).
+
+        Raises:
+            ValueError: If the values are not 1D.
+
+        Examples:
+            - One stripe per yearly value:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.statistical_glyph import StatisticalGlyph
+                >>> series = np.array([0.1, 0.3, 0.2, 0.6, 0.9, 0.7])
+                >>> stat = StatisticalGlyph(series)
+                >>> fig, ax, bars = stat.stripes(cmap="coolwarm")
+                >>> len(bars)
+                6
+
+                ```
+        """
+        values = np.asarray(self.values, dtype=float)
+        if values.ndim != 1:
+            raise ValueError(
+                f"stripes requires 1D values; got {values.ndim}D."
+            )
+        fig, ax = self._resolve_fig_ax(ax, fig)
+        cmap = cmap if cmap is not None else self.default_options["cmap"]
+        cmap_obj = mpl.colormaps[cmap] if isinstance(cmap, str) else cmap
+        lo = float(np.nanmin(values)) if vmin is None else vmin
+        hi = float(np.nanmax(values)) if vmax is None else vmax
+        norm = Normalize(vmin=lo, vmax=hi)
+        bar_colors = cmap_obj(norm(values))
+        bars = ax.bar(
+            np.arange(values.size),
+            np.ones(values.size),
+            width=1.0,
+            color=bar_colors,
+            **kwargs,
+        )
+        ax.set_yticks([])
+        ax.set_xlim(-0.5, values.size - 0.5)
+        self._apply_axis_labels(ax)
+        return fig, ax, bars

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -559,10 +559,15 @@ class StatisticalGlyph:
             columns,
             notch=notch,
             showfliers=showfliers,
-            tick_labels=tick_labels,
             patch_artist=True,
             **kwargs,
         )
+        # Set tick labels after the fact rather than via boxplot's label
+        # kwarg, whose name differs across matplotlib versions (`labels`
+        # before 3.9, `tick_labels` from 3.9). This keeps the floor at
+        # matplotlib 3.8.4 (see pyproject) working.
+        ax.set_xticks(range(1, len(columns) + 1))
+        ax.set_xticklabels(tick_labels)
         palette = self.default_options["color"]
         for i, box in enumerate(bp["boxes"]):
             box.set_facecolor(palette[i % len(palette)])

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -556,6 +556,10 @@ class StatisticalGlyph:
             list(labels) if labels is not None
             else [str(i + 1) for i in range(len(columns))]
         )
+        # Honour a caller-supplied `positions` (forwarded via **kwargs)
+        # so the tick labels below land under the boxes; default is the
+        # 1..n that matplotlib's boxplot uses.
+        positions = list(kwargs.get("positions", range(1, len(columns) + 1)))
         bp = ax.boxplot(
             columns,
             notch=notch,
@@ -567,7 +571,7 @@ class StatisticalGlyph:
         # kwarg, whose name differs across matplotlib versions (`labels`
         # before 3.9, `tick_labels` from 3.9). This keeps the floor at
         # matplotlib 3.8.4 (see pyproject) working.
-        ax.set_xticks(range(1, len(columns) + 1))
+        ax.set_xticks(positions)
         ax.set_xticklabels(tick_labels)
         palette = self.default_options["color"]
         for i, box in enumerate(bp["boxes"]):

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -646,8 +646,8 @@ class StatisticalGlyph:
         """Draw grouped boxes at explicit x positions.
 
         Like `boxplot`, but the boxes are placed at caller-controlled
-        `positions` along the x axis (e.g. lead times, months), which is
-        the layout the earthkit `multiboxplot` uses for ensembles.
+        `positions` along the x axis (e.g. lead times, months) — the
+        usual layout for comparing ensembles side by side.
         Requires 2D values (one column per box).
 
         Args:

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -59,6 +59,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.colors import Normalize
+from matplotlib.container import BarContainer
 from matplotlib.figure import Figure
 
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
@@ -674,7 +675,7 @@ class StatisticalGlyph:
         vmin: float | None = None,
         vmax: float | None = None,
         **kwargs,
-    ) -> Tuple[Figure, Axes, "mpl.container.BarContainer"]:
+    ) -> Tuple[Figure, Axes, BarContainer]:
         """Draw a warming-stripes band: one colour bar per value.
 
         Each stored value becomes a full-height vertical stripe coloured

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from enum import StrEnum
-from typing import Callable
+from typing import Callable, Sequence
 
 import matplotlib.colors as colors
 import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.legend import Legend
+from matplotlib.patches import Patch
 
 
 class ColorScale(StrEnum):
@@ -779,3 +782,91 @@ class MidpointNormalize(colors.Normalize):
         x, y = [self.vmin, self.midpoint, self.vmax], [0, 0.5, 1]
 
         return np.ma.masked_array(np.interp(value, x, y))
+
+
+def disjoint_legend(
+    ax: Axes,
+    colors: Sequence,
+    labels: Sequence[str],
+    *,
+    edgecolor: str = "none",
+    **kwargs,
+) -> Legend:
+    """Attach a categorical (disjoint) swatch legend to an axes.
+
+    Builds one filled rectangle (`matplotlib.patches.Patch`) per
+    category and registers them as a legend on `ax`. This is the
+    discrete counterpart to a colorbar: use it when categories are
+    nominal/disjoint (land-cover classes, region names, ...) rather
+    than samples of a continuous scale, where a colorbar would imply a
+    false ordering.
+
+    Args:
+        ax: The axes the legend is attached to.
+        colors: One color per category, in any matplotlib color form
+            (name, hex, or RGB(A) tuple). Must be the same length as
+            `labels`.
+        labels: The category label drawn next to each swatch. Must be
+            the same length as `colors`.
+        edgecolor: Outline color for every swatch. Defaults to
+            `"none"` (no border), matching cleopatra's flat look.
+        **kwargs: Forwarded verbatim to `Axes.legend` (e.g. `title`,
+            `loc`, `ncol`, `bbox_to_anchor`, `fontsize`).
+
+    Returns:
+        Legend: The created legend artist, already added to `ax`.
+
+    Raises:
+        ValueError: If `colors` and `labels` have different lengths.
+
+    Examples:
+        - Build a three-class legend and read back its labels:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import disjoint_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = disjoint_legend(
+            ...     ax,
+            ...     ["#1b9e77", "#d95f02", "#7570b3"],
+            ...     ["water", "urban", "forest"],
+            ... )
+            >>> [t.get_text() for t in legend.get_texts()]
+            ['water', 'urban', 'forest']
+
+            ```
+        - Forward `Axes.legend` kwargs such as a title and column count:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import disjoint_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = disjoint_legend(
+            ...     ax, ["red", "blue"], ["hot", "cold"], title="Class", ncol=2
+            ... )
+            >>> legend.get_title().get_text()
+            'Class'
+
+            ```
+        - Mismatched lengths raise `ValueError`:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import disjoint_legend
+            >>> fig, ax = plt.subplots()
+            >>> disjoint_legend(ax, ["red", "blue"], ["only-one"])
+            Traceback (most recent call last):
+                ...
+            ValueError: colors and labels must have the same length, got 2 and 1.
+
+            ```
+    """
+    colors = list(colors)
+    labels = list(labels)
+    if len(colors) != len(labels):
+        raise ValueError(
+            "colors and labels must have the same length, got "
+            f"{len(colors)} and {len(labels)}."
+        )
+    handles = [
+        Patch(facecolor=color, edgecolor=edgecolor, label=label)
+        for color, label in zip(colors, labels)
+    ]
+    return ax.legend(handles=handles, **kwargs)

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -6,9 +6,13 @@ from collections import OrderedDict
 from enum import StrEnum
 from typing import Callable, Sequence
 
+import matplotlib as mpl
 import matplotlib.colors as colors
 import numpy as np
 from matplotlib.axes import Axes
+from matplotlib.cm import ScalarMappable
+from matplotlib.colorbar import Colorbar
+from matplotlib.container import BarContainer
 from matplotlib.legend import Legend
 from matplotlib.patches import Patch
 
@@ -870,3 +874,163 @@ def disjoint_legend(
         for color, label in zip(colors, labels)
     ]
     return ax.legend(handles=handles, **kwargs)
+
+
+def colorbar_legend(mappable: ScalarMappable, ax: Axes = None, **kwargs) -> Colorbar:
+    """Attach a continuous colorbar legend for a mappable.
+
+    A thin, glyph-agnostic wrapper over `Figure.colorbar` for callers
+    that already hold a mappable (the artist returned by
+    `scatter` / `imshow` / `quiver` / a glyph's `plot`) and just want a
+    matching colorbar. For full cleopatra colorbar styling (label size,
+    location, shrink) use `Glyph.create_color_bar` instead; this helper
+    is the minimal counterpart that sits alongside `disjoint_legend`
+    and `histogram_legend`.
+
+    Args:
+        mappable: A `matplotlib.cm.ScalarMappable` (e.g. the result of
+            `ax.scatter(..., c=values)`), carrying the cmap/norm to map.
+        ax: Axes to steal space from for the colorbar. Defaults to the
+            mappable's own axes. The parent figure is inferred from
+            whichever axes is used.
+        **kwargs: Forwarded to `Figure.colorbar` (e.g. `label`,
+            `orientation`, `shrink`, `ticks`, `extend`).
+
+    Returns:
+        Colorbar: The created colorbar.
+
+    Raises:
+        ValueError: If no axes can be determined (the mappable is not
+            attached to an axes and `ax` is None).
+
+    Examples:
+        - Build a colorbar for a coloured scatter and read its label:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import colorbar_legend
+            >>> fig, ax = plt.subplots()
+            >>> sc = ax.scatter([0, 1, 2], [0, 1, 0], c=[10, 20, 30])
+            >>> cbar = colorbar_legend(sc, ax, label="depth")
+            >>> cbar.ax.get_ylabel()
+            'depth'
+
+            ```
+    """
+    parent_ax = ax if ax is not None else getattr(mappable, "axes", None)
+    if parent_ax is None:
+        raise ValueError(
+            "Cannot determine an axes for the colorbar: pass `ax` or use a "
+            "mappable already attached to an axes."
+        )
+    fig = parent_ax.figure
+    return fig.colorbar(mappable, ax=parent_ax, **kwargs)
+
+
+def histogram_legend(
+    ax: Axes,
+    values: np.ndarray | None = None,
+    *,
+    mappable: ScalarMappable | None = None,
+    cmap=None,
+    norm: colors.Normalize | None = None,
+    bins: int = 20,
+    orientation: str = "vertical",
+    **bar_kwargs,
+) -> BarContainer:
+    """Draw a colour-mapped histogram as a distribution legend.
+
+    Renders a histogram of `values` whose bars are coloured by the same
+    colormap/norm used for the data, so the legend doubles as a
+    distribution plot — the third legend style alongside the continuous
+    colorbar and the categorical `disjoint_legend`. The colour mapping
+    can be taken straight from a `mappable` (so it matches a glyph's
+    plot exactly) or supplied explicitly via `cmap` / `norm`.
+
+    Args:
+        ax: Axes to draw the histogram on (typically a small companion
+            axes beside the main plot).
+        values: 1D data to histogram. Non-finite entries are dropped.
+            Defaults to the mappable's array when `values` is None.
+        mappable: Optional `ScalarMappable` to inherit `cmap`, `norm`,
+            and (when `values` is None) the data array from.
+        cmap: Colormap name or object. Falls back to the mappable's
+            cmap, then to matplotlib's default. Ignored when a
+            `mappable` provides one and `cmap` is None.
+        norm: Normalization for mapping bin centres to colours. Falls
+            back to the mappable's norm, then to a linear norm spanning
+            the data.
+        bins: Number of histogram bins. Default is 20.
+        orientation: `"vertical"` (bars rise with count) or
+            `"horizontal"` (bars extend rightwards). Default is
+            `"vertical"`.
+        **bar_kwargs: Forwarded to `Axes.bar` / `Axes.barh`
+            (e.g. `edgecolor`, `alpha`).
+
+    Returns:
+        BarContainer: The bars drawn, one per bin.
+
+    Raises:
+        ValueError: If neither `values` nor a `mappable` with an array
+            is provided, if there are no finite values, or if
+            `orientation` is not `"vertical"` / `"horizontal"`.
+
+    Examples:
+        - Histogram legend from explicit values and a colormap:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import histogram_legend
+            >>> fig, ax = plt.subplots()
+            >>> bars = histogram_legend(
+            ...     ax, [0.0, 1.0, 1.0, 2.0, 2.0, 2.0], cmap="viridis", bins=3
+            ... )
+            >>> len(bars)
+            3
+
+            ```
+        - Inherit cmap/norm/data straight from a mappable:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import histogram_legend
+            >>> fig, (ax, legend_ax) = plt.subplots(1, 2)
+            >>> sc = ax.scatter([0, 1, 2, 3], [0, 1, 0, 1], c=[1, 2, 3, 4], cmap="plasma")
+            >>> bars = histogram_legend(legend_ax, mappable=sc, bins=4)
+            >>> len(bars)
+            4
+
+            ```
+    """
+    if orientation not in ("vertical", "horizontal"):
+        raise ValueError(
+            f"orientation must be 'vertical' or 'horizontal', got "
+            f"{orientation!r}."
+        )
+
+    if values is None:
+        if mappable is None or mappable.get_array() is None:
+            raise ValueError(
+                "Provide `values` or a `mappable` carrying a data array."
+            )
+        values = np.asarray(mappable.get_array()).ravel()
+    values = np.asarray(values, dtype=float)
+    values = values[np.isfinite(values)]
+    if values.size == 0:
+        raise ValueError("No finite values to histogram.")
+
+    if cmap is None and mappable is not None:
+        cmap = mappable.cmap
+    cmap_obj = mpl.colormaps[cmap] if isinstance(cmap, str) else (
+        cmap if cmap is not None else mpl.colormaps[mpl.rcParams["image.cmap"]]
+    )
+    if norm is None and mappable is not None:
+        norm = mappable.norm
+
+    counts, edges = np.histogram(values, bins=bins)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    widths = np.diff(edges)
+    if norm is None:
+        norm = colors.Normalize(vmin=float(edges[0]), vmax=float(edges[-1]))
+    bar_colors = cmap_obj(norm(centers))
+
+    if orientation == "vertical":
+        return ax.bar(centers, counts, width=widths, color=bar_colors, **bar_kwargs)
+    return ax.barh(centers, counts, height=widths, color=bar_colors, **bar_kwargs)

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from collections import OrderedDict
 from enum import StrEnum
 from typing import Callable, Sequence
@@ -1022,7 +1023,11 @@ def histogram_legend(
         cmap if cmap is not None else mpl.colormaps[mpl.rcParams["image.cmap"]]
     )
     if norm is None and mappable is not None:
-        norm = mappable.norm
+        # Copy so that mapping bin centres below cannot mutate the
+        # caller's norm (an unscaled norm would otherwise be
+        # autoscaled in place by the norm(centers) call). copy.copy
+        # preserves the norm subtype (e.g. BoundaryNorm).
+        norm = copy.copy(mappable.norm)
 
     counts, edges = np.histogram(values, bins=bins)
     centers = 0.5 * (edges[:-1] + edges[1:])

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -216,6 +216,11 @@ class VectorGlyph(Glyph):
             im = stream.lines
             if im.get_array() is None:
                 im.set_array(np.asarray(mag).ravel())
+            # streamplot has no clim kwarg; pin its LineCollection to the
+            # same tick range quiver/barbs use so colours and colorbar
+            # agree on the linear (norm is None) path.
+            if norm is None:
+                im.set_clim(ticks[0], ticks[-1])
 
         self.cbar = self.create_color_bar(ax, im, cbar_kw)
 

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -1,0 +1,275 @@
+"""Vector-field visualization.
+
+Provides `VectorGlyph` for plotting 2D vector fields as arrows
+(`quiver`), wind barbs (`barbs`), or streamlines (`streamplot`), with
+arrows/lines coloured by vector magnitude. Magnitude colour mapping
+reuses the shared `Glyph._prepare_scalar_mapping` pipeline so `vmin` /
+`vmax`, `ticks_spacing`, `levels`, and `color_scale` behave exactly as
+for the other glyphs.
+
+Examples:
+    - Quiver plot coloured by magnitude:
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.vector_glyph import VectorGlyph
+        >>> x, y = np.meshgrid(np.arange(3), np.arange(3))
+        >>> u = np.ones_like(x, dtype=float)
+        >>> v = np.zeros_like(y, dtype=float)
+        >>> glyph = VectorGlyph(x, y, u, v)
+        >>> fig, ax, im = glyph.plot(kind="quiver")
+
+        ```
+    - Add a reference-arrow key:
+        ```python
+        >>> key = glyph.add_key(im, value=1.0, label="1 m/s")
+
+        ```
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.quiver import QuiverKey
+
+from cleopatra.glyph import Glyph
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+
+#: Vector kinds dispatched by `VectorGlyph.plot`.
+VECTOR_KINDS = ("quiver", "barbs", "streamplot")
+
+#: Option keys for VectorGlyph. `ticks_spacing` is `None` so the shared
+#: `_prepare_scalar_mapping` helper auto-derives it from the magnitude.
+VECTOR_DEFAULT_OPTIONS = {
+    "density": 1.0,
+    "scale": None,
+    "vmin": None,
+    "vmax": None,
+    "levels": None,
+    "ticks_spacing": None,
+}
+VECTOR_DEFAULT_OPTIONS = STYLE_DEFAULTS | VECTOR_DEFAULT_OPTIONS
+
+
+class VectorGlyph(Glyph):
+    """Visualization class for 2D vector fields.
+
+    Renders a `(u, v)` vector field over `(x, y)` positions as arrows,
+    wind barbs, or streamlines, with the artist coloured by the vector
+    magnitude `hypot(u, v)` through the shared scalar-mapping pipeline.
+
+    Args:
+        x: x-coordinates of the vector positions.
+        y: y-coordinates of the vector positions.
+        u: x-components of the vectors. Must broadcast against `x`/`y`.
+        v: y-components of the vectors. Must broadcast against `x`/`y`.
+        ax: Pre-existing axes to draw on. Default is None.
+        fig: Pre-existing figure. Default is None.
+        **kwargs: Override any key in `VECTOR_DEFAULT_OPTIONS`
+            (e.g. `density`, `scale`, `cmap`, `vmin`, `vmax`, `levels`,
+            `color_scale`, `ticks_spacing`, `cbar_label`, `figsize`,
+            `title`).
+
+    Examples:
+        - Build a field and inspect the stored magnitude:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.vector_glyph import VectorGlyph
+            >>> x, y = np.meshgrid(np.arange(2), np.arange(2))
+            >>> u = np.array([[3.0, 0.0], [0.0, 3.0]])
+            >>> v = np.array([[4.0, 0.0], [0.0, 4.0]])
+            >>> glyph = VectorGlyph(x, y, u, v)
+            >>> float(glyph.magnitude.max())
+            5.0
+
+            ```
+
+    See Also:
+        cleopatra.glyph.Glyph._prepare_scalar_mapping: Shared
+            norm/colorbar/ticks pipeline used to colour by magnitude.
+    """
+
+    def __init__(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        u: np.ndarray,
+        v: np.ndarray,
+        *,
+        ax: Axes = None,
+        fig: Figure = None,
+        **kwargs,
+    ):
+        super().__init__(
+            default_options=VECTOR_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
+        )
+        self.x, self.y, self.u, self.v = (np.asarray(a) for a in (x, y, u, v))
+        if self.u.shape != self.v.shape:
+            raise ValueError(
+                f"u and v must have the same shape, got {self.u.shape} "
+                f"and {self.v.shape}."
+            )
+
+    @property
+    def magnitude(self) -> np.ndarray:
+        """Per-vector magnitude `hypot(u, v)` used for colour mapping."""
+        return np.hypot(self.u, self.v)
+
+    def plot(
+        self,
+        kind: str = "quiver",
+        ax: Axes = None,
+        title: str | None = None,
+    ):
+        """Render the vector field, coloured by magnitude.
+
+        Dispatches to `Axes.quiver`, `Axes.barbs`, or `Axes.streamplot`
+        based on `kind`. The colour scale, norm, ticks, and colorbar are
+        resolved from the magnitude via `_prepare_scalar_mapping`.
+
+        Args:
+            kind: One of `"quiver"`, `"barbs"`, or `"streamplot"`.
+                Default is `"quiver"`.
+            ax: Axes to draw on. Falls back to the axes supplied at
+                construction, otherwise a new figure/axes is created.
+            title: Plot title. Overrides `default_options["title"]`
+                when given.
+
+        Returns:
+            tuple[Figure, Axes, Any]: The figure, the axes, and the
+                mappable artist (the `Quiver`, `Barbs`, or the
+                streamplot's `LineCollection`) that the colorbar is
+                attached to.
+
+        Raises:
+            ValueError: If `kind` is not a recognised vector kind, or if
+                the magnitude has no finite values (via
+                `_prepare_scalar_mapping`).
+
+        Examples:
+            - A barbs plot returns the Barbs mappable with the magnitude
+                array:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.vector_glyph import VectorGlyph
+                >>> x, y = np.meshgrid(np.arange(3), np.arange(3))
+                >>> u = np.full_like(x, 2.0, dtype=float)
+                >>> v = np.zeros_like(y, dtype=float)
+                >>> glyph = VectorGlyph(x, y, u, v)
+                >>> fig, ax, im = glyph.plot(kind="barbs")
+                >>> float(im.get_array().max())
+                2.0
+
+                ```
+            - An unknown kind raises ValueError:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.vector_glyph import VectorGlyph
+                >>> x, y = np.meshgrid(np.arange(2), np.arange(2))
+                >>> glyph = VectorGlyph(x, y, np.ones_like(x), np.ones_like(y))
+                >>> glyph.plot(kind="spirograph")
+                Traceback (most recent call last):
+                    ...
+                ValueError: unknown vector kind 'spirograph'; expected one of ...
+
+                ```
+        """
+        if kind not in VECTOR_KINDS:
+            raise ValueError(
+                f"unknown vector kind {kind!r}; expected one of "
+                f"{', '.join(VECTOR_KINDS)}."
+            )
+
+        if ax is not None:
+            self.ax = ax
+            self.fig = ax.get_figure()
+        elif self.ax is None:
+            self.fig, self.ax = self.create_figure_axes()
+        ax = self.ax
+        opts = self.default_options
+
+        if title is not None:
+            opts["title"] = title
+
+        mag = self.magnitude
+        norm, cbar_kw, ticks = self._prepare_scalar_mapping(mag)
+        cmap = opts["cmap"]
+        clim = {} if norm else {"clim": (ticks[0], ticks[-1])}
+
+        if kind == "quiver":
+            im = ax.quiver(
+                self.x, self.y, self.u, self.v, mag,
+                cmap=cmap, norm=norm, scale=opts["scale"], **clim,
+            )
+        elif kind == "barbs":
+            im = ax.barbs(
+                self.x, self.y, self.u, self.v, mag,
+                cmap=cmap, norm=norm, **clim,
+            )
+        else:  # streamplot
+            stream = ax.streamplot(
+                self.x, self.y, self.u, self.v,
+                color=mag, cmap=cmap, norm=norm, density=opts["density"],
+            )
+            im = stream.lines
+            if im.get_array() is None:
+                im.set_array(np.asarray(mag).ravel())
+
+        self.cbar = self.create_color_bar(ax, im, cbar_kw)
+
+        if opts["title"]:
+            ax.set_title(opts["title"], fontsize=opts["title_size"])
+
+        return self.fig, ax, im
+
+    def add_key(
+        self,
+        im,
+        x: float = 0.9,
+        y: float = 1.02,
+        value: float = 10.0,
+        label: str | None = None,
+        labelpos: str = "E",
+        **kwargs,
+    ) -> QuiverKey:
+        """Add a reference-arrow key to a quiver plot.
+
+        Wraps `Axes.quiverkey` to draw a sample arrow of known length
+        with a text label, the standard legend for a quiver field.
+
+        Args:
+            im: The `Quiver` artist returned by `plot(kind="quiver")`.
+            x: Key x-position in axes fraction coordinates.
+                Default is 0.9.
+            y: Key y-position in axes fraction coordinates.
+                Default is 1.02.
+            value: The reference vector length the key represents.
+                Default is 10.0.
+            label: Text drawn beside the key. Default is `None`, which
+                renders the numeric `value` as the label.
+            labelpos: Side of the arrow for the label (`"N"`, `"S"`,
+                `"E"`, `"W"`). Default is `"E"`.
+            **kwargs: Forwarded to `Axes.quiverkey`.
+
+        Returns:
+            QuiverKey: The created key artist.
+
+        Examples:
+            - Add a 5 m/s reference key to a quiver:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.vector_glyph import VectorGlyph
+                >>> x, y = np.meshgrid(np.arange(3), np.arange(3))
+                >>> u = np.ones_like(x, dtype=float)
+                >>> v = np.ones_like(y, dtype=float)
+                >>> glyph = VectorGlyph(x, y, u, v)
+                >>> fig, ax, im = glyph.plot(kind="quiver")
+                >>> key = glyph.add_key(im, value=5.0, label="5 m/s")
+                >>> key.text.get_text()
+                '5 m/s'
+
+                ```
+        """
+        text = label if label is not None else f"{value:g}"
+        return self.ax.quiverkey(im, x, y, value, text, labelpos=labelpos, **kwargs)

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -110,6 +110,7 @@ class VectorGlyph(Glyph):
                 f"u and v must have the same shape, got {self.u.shape} "
                 f"and {self.v.shape}."
             )
+        self.cbar = None
 
     @property
     def magnitude(self) -> np.ndarray:

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -769,3 +769,226 @@ class TestSaveAnimationVideoBranch:
         target = tmp_path / "movie.mp4"
         with pytest.raises(FileNotFoundError, match="ffmpeg.org"):
             g.save_animation(str(target))
+
+
+class TestResolveLimits:
+    """Tests for Glyph._resolve_limits (T0.0)."""
+
+    def test_auto_resolves_both_from_data(self):
+        """Both limits unset -> taken from the nan-aware data range.
+
+        Test scenario:
+            vmin/vmax are None, so the finite min/max of the data
+            (1.0, 9.0) are returned as floats.
+        """
+        g = _make_glyph()
+        vmin, vmax = g._resolve_limits(np.array([5.0, 1.0, 9.0]))
+        assert (vmin, vmax) == (1.0, 9.0), f"Expected (1.0, 9.0), got {(vmin, vmax)}"
+        assert isinstance(vmin, float) and isinstance(vmax, float), (
+            "Limits must be returned as plain floats"
+        )
+
+    def test_explicit_vmin_preserved(self):
+        """An explicit vmin is kept; only the missing vmax comes from data.
+
+        Test scenario:
+            vmin=0.0 pinned, vmax=None -> returns (0.0, data_max).
+        """
+        g = _make_glyph()
+        g._default_options["vmin"] = 0.0
+        vmin, vmax = g._resolve_limits(np.array([1.0, 5.0, 9.0]))
+        assert (vmin, vmax) == (0.0, 9.0), f"Expected (0.0, 9.0), got {(vmin, vmax)}"
+
+    def test_explicit_vmax_preserved(self):
+        """An explicit vmax is kept; only the missing vmin comes from data.
+
+        Test scenario:
+            vmax=20.0 pinned, vmin=None -> returns (data_min, 20.0).
+        """
+        g = _make_glyph()
+        g._default_options["vmax"] = 20.0
+        vmin, vmax = g._resolve_limits(np.array([3.0, 5.0, 9.0]))
+        assert (vmin, vmax) == (3.0, 20.0), f"Expected (3.0, 20.0), got {(vmin, vmax)}"
+
+    def test_both_explicit_ignores_data(self):
+        """When both limits are pinned the data range is not consulted.
+
+        Test scenario:
+            vmin=-1.0, vmax=1.0 -> returned verbatim even though the data
+            spans a wider range.
+        """
+        g = _make_glyph()
+        g._default_options["vmin"] = -1.0
+        g._default_options["vmax"] = 1.0
+        vmin, vmax = g._resolve_limits(np.array([-100.0, 100.0]))
+        assert (vmin, vmax) == (-1.0, 1.0), f"Expected (-1.0, 1.0), got {(vmin, vmax)}"
+
+    def test_nan_aware_with_partial_nans(self):
+        """NaNs are ignored when computing the data range.
+
+        Test scenario:
+            A mix of NaN and finite values resolves to the finite min/max.
+        """
+        g = _make_glyph()
+        vmin, vmax = g._resolve_limits(np.array([np.nan, 2.0, np.nan, 8.0]))
+        assert (vmin, vmax) == (2.0, 8.0), f"Expected (2.0, 8.0), got {(vmin, vmax)}"
+
+    def test_all_nan_raises_valueerror(self):
+        """An all-NaN array with unpinned limits raises ValueError.
+
+        Test scenario:
+            No finite values and no explicit limits -> a clear ValueError
+            rather than a downstream NaN crash.
+        """
+        g = _make_glyph()
+        with pytest.raises(ValueError, match="no finite values") as exc:
+            g._resolve_limits(np.array([np.nan, np.nan]))
+        assert "vmin/vmax" in str(exc.value), f"Unexpected message: {exc.value}"
+
+    def test_all_nan_with_explicit_limits_ok(self):
+        """All-NaN data is fine when both limits are pinned explicitly.
+
+        Test scenario:
+            vmin/vmax pinned -> nanmin/nanmax are never consulted, so
+            all-NaN data does not raise.
+        """
+        g = _make_glyph()
+        g._default_options["vmin"] = 0.0
+        g._default_options["vmax"] = 1.0
+        vmin, vmax = g._resolve_limits(np.array([np.nan, np.nan]))
+        assert (vmin, vmax) == (0.0, 1.0), f"Expected (0.0, 1.0), got {(vmin, vmax)}"
+
+
+class TestPrepareScalarMapping:
+    """Tests for Glyph._prepare_scalar_mapping (T0.0)."""
+
+    def test_auto_limits_set_options_and_ticks(self):
+        """Auto limits populate default_options and return matching ticks.
+
+        Test scenario:
+            vmin/vmax/ticks_spacing all unset -> resolved from data,
+            ticks_spacing derived as range/10, and ticks span 0..10.
+        """
+        g = _make_glyph()
+        g._default_options["ticks_spacing"] = None
+        norm, cbar_kw, ticks = g._prepare_scalar_mapping(np.array([0.0, 5.0, 10.0]))
+        assert norm is None, "Linear scale with no levels should give norm=None"
+        assert g.default_options["vmin"] == 0.0, "vmin should be written back"
+        assert g.default_options["vmax"] == 10.0, "vmax should be written back"
+        assert g.default_options["ticks_spacing"] == 1.0, (
+            f"ticks_spacing should be range/10=1.0, got {g.default_options['ticks_spacing']}"
+        )
+        np.testing.assert_array_almost_equal(ticks, np.arange(0.0, 11.0, 1.0))
+
+    def test_vmin_vmax_written_back_for_get_ticks(self):
+        """Resolved limits are visible to get_ticks via default_options.
+
+        Test scenario:
+            After the call, get_ticks() reproduces the same tick array,
+            proving the limits were written into default_options.
+        """
+        g = _make_glyph()
+        g._default_options["ticks_spacing"] = None
+        _, _, ticks = g._prepare_scalar_mapping(np.array([2.0, 12.0]))
+        np.testing.assert_array_almost_equal(ticks, g.get_ticks())
+
+    def test_explicit_ticks_spacing_preserved(self):
+        """A pinned ticks_spacing is not overwritten by the range/10 rule.
+
+        Test scenario:
+            ticks_spacing=5 stays 5 even though range/10 would be 1.0.
+        """
+        g = _make_glyph()
+        g._default_options["ticks_spacing"] = 5.0
+        g._prepare_scalar_mapping(np.array([0.0, 10.0]))
+        assert g.default_options["ticks_spacing"] == 5.0, (
+            f"Explicit ticks_spacing should be preserved, got "
+            f"{g.default_options['ticks_spacing']}"
+        )
+
+    def test_flat_data_ticks_spacing_guard(self):
+        """Flat data does not yield a zero ticks_spacing.
+
+        Test scenario:
+            All values equal -> range is 0, but the `or 1.0` guard keeps
+            ticks_spacing at 1.0 so get_ticks() does not return empty.
+        """
+        g = _make_glyph()
+        g._default_options["ticks_spacing"] = None
+        _, _, ticks = g._prepare_scalar_mapping(np.array([3.0, 3.0, 3.0]))
+        assert g.default_options["ticks_spacing"] == 1.0, (
+            f"Flat-data spacing should be guarded to 1.0, got "
+            f"{g.default_options['ticks_spacing']}"
+        )
+        assert len(ticks) >= 1, "Ticks should not be empty for flat data"
+
+    def test_all_nan_raises_valueerror(self):
+        """All-NaN input propagates the _resolve_limits ValueError.
+
+        Test scenario:
+            No finite values and no explicit limits -> ValueError.
+        """
+        g = _make_glyph()
+        with pytest.raises(ValueError, match="no finite values"):
+            g._prepare_scalar_mapping(np.array([np.nan, np.nan]))
+
+    def test_levels_forwarded_into_norm(self):
+        """An integer `levels` produces a BoundaryNorm via the helper.
+
+        Test scenario:
+            levels=5 under the default linear scale -> BoundaryNorm and a
+            colorbar tick set sized to the levels.
+        """
+        g = _make_glyph()
+        g._default_options["ticks_spacing"] = None
+        g._default_options["levels"] = 5
+        norm, cbar_kw, _ = g._prepare_scalar_mapping(np.array([0.0, 10.0]))
+        assert isinstance(norm, mcolors.BoundaryNorm), (
+            f"levels should yield a BoundaryNorm, got {type(norm)}"
+        )
+        assert cbar_kw["extend"] == "both", (
+            f"levels should default extend to 'both', got {cbar_kw['extend']}"
+        )
+
+    def test_color_scale_forwarded_into_norm(self):
+        """A non-linear color_scale is honoured by the helper.
+
+        Test scenario:
+            color_scale='power' -> the returned norm is a PowerNorm built
+            from the resolved limits.
+        """
+        g = _make_glyph()
+        g._default_options["ticks_spacing"] = None
+        g._default_options["color_scale"] = "power"
+        norm, _, _ = g._prepare_scalar_mapping(np.array([0.0, 10.0]))
+        assert isinstance(norm, mcolors.PowerNorm), (
+            f"color_scale='power' should yield a PowerNorm, got {type(norm)}"
+        )
+
+
+class TestArrayGlyphUnchangedByHelper:
+    """Regression: ArrayGlyph's tick output matches the shared helper (T0.0)."""
+
+    def test_arrayglyph_ticks_match_helper_path(self):
+        """A bare Glyph using the helper reproduces ArrayGlyph's ticks.
+
+        Test scenario:
+            For the same data and auto limits, the helper-driven ticks
+            equal those ArrayGlyph computes for its non-robust/non-center
+            path, confirming the contract is identical.
+        """
+        from cleopatra.array_glyph import ArrayGlyph
+
+        data = np.array([[0.0, 2.0, 4.0], [6.0, 8.0, 10.0]])
+        ag = ArrayGlyph(data)
+        ag.plot()
+        array_ticks = ag.get_ticks()
+
+        g = _make_glyph()
+        g._default_options["ticks_spacing"] = None
+        _, _, helper_ticks = g._prepare_scalar_mapping(data)
+        np.testing.assert_array_almost_equal(
+            helper_ticks,
+            array_ticks,
+            err_msg="Helper ticks should match ArrayGlyph's ticks for the same data",
+        )

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -983,6 +983,7 @@ class TestArrayGlyphUnchangedByHelper:
         ag = ArrayGlyph(data)
         ag.plot()
         array_ticks = ag.get_ticks()
+        plt.close(ag.fig)
 
         g = _make_glyph()
         g._default_options["ticks_spacing"] = None

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -26,6 +26,7 @@ _SUBMODULES = [
     "statistical_glyph",
     "styles",
     "tiles",
+    "vector_glyph",
 ]
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,6 +21,7 @@ _SUBMODULES = [
     "colors",
     "config",
     "glyph",
+    "line_glyph",
     "mesh_glyph",
     "polygon_glyph",
     "scatter_glyph",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,6 +22,7 @@ _SUBMODULES = [
     "config",
     "glyph",
     "mesh_glyph",
+    "polygon_glyph",
     "scatter_glyph",
     "statistical_glyph",
     "styles",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,6 +22,7 @@ _SUBMODULES = [
     "config",
     "glyph",
     "mesh_glyph",
+    "scatter_glyph",
     "statistical_glyph",
     "styles",
     "tiles",

--- a/tests/test_line_glyph.py
+++ b/tests/test_line_glyph.py
@@ -1,0 +1,196 @@
+"""Tests for cleopatra.line_glyph.LineGlyph (T7.3c)."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.collections import PolyCollection
+from matplotlib.container import BarContainer
+from matplotlib.lines import Line2D
+
+from cleopatra.line_glyph import LINE_DEFAULT_OPTIONS, LineGlyph
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def xy():
+    """A single 1D series.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: x and y arrays.
+    """
+    return np.array([0.0, 1.0, 2.0, 3.0]), np.array([0.0, 1.0, 4.0, 9.0])
+
+
+class TestLineGlyphInit:
+    """Tests for LineGlyph.__init__."""
+
+    def test_stores_arrays(self, xy):
+        """x and y are stored as numpy arrays.
+
+        Test scenario:
+            Lists are accepted and converted.
+        """
+        glyph = LineGlyph([0, 1, 2], [3, 4, 5])
+        assert isinstance(glyph.x, np.ndarray) and isinstance(glyph.y, np.ndarray)
+
+    def test_line_specific_options(self, xy):
+        """Line-specific option keys are present.
+
+        Test scenario:
+            marker/linestyle/alpha defaults exist.
+        """
+        glyph = LineGlyph(*xy)
+        assert glyph.default_options["linestyle"] == "-", "Default linestyle '-'"
+        assert glyph.default_options["alpha"] == 1.0, "Default alpha 1.0"
+
+    def test_mismatched_lengths_raise(self):
+        """x length not matching y rows raises ValueError.
+
+        Test scenario:
+            len(x) != y.shape[0] is rejected.
+        """
+        with pytest.raises(ValueError, match="must match the number of rows"):
+            LineGlyph([0, 1, 2], [0, 1])
+
+    def test_invalid_kwarg_raises(self, xy):
+        """An unknown kwarg is rejected by the strict merge."""
+        with pytest.raises(ValueError, match="not correct"):
+            LineGlyph(*xy, nope=1)
+
+
+class TestLineGlyphLine:
+    """Tests for LineGlyph.line."""
+
+    def test_single_series_one_line(self, xy):
+        """A 1D series yields a single Line2D with the right data.
+
+        Test scenario:
+            One line is drawn whose y-data matches the input.
+        """
+        glyph = LineGlyph(*xy)
+        _, _, lines = glyph.line()
+        assert len(lines) == 1, f"Expected 1 line, got {len(lines)}"
+        assert isinstance(lines[0], Line2D), "Should be a Line2D"
+        np.testing.assert_array_almost_equal(lines[0].get_ydata(), xy[1])
+
+    def test_multi_series_multiple_lines(self):
+        """2D y draws one line per column.
+
+        Test scenario:
+            A (3, 2) y array yields two lines.
+        """
+        x = np.array([0.0, 1.0, 2.0])
+        y = np.array([[0.0, 5.0], [1.0, 6.0], [2.0, 7.0]])
+        glyph = LineGlyph(x, y)
+        _, _, lines = glyph.line()
+        assert len(lines) == 2, f"Expected 2 lines, got {len(lines)}"
+
+    def test_labels_applied(self, xy):
+        """A label is attached to the drawn line.
+
+        Test scenario:
+            label='obs' surfaces on the line.
+        """
+        glyph = LineGlyph(*xy)
+        _, _, lines = glyph.line(label="obs")
+        assert lines[0].get_label() == "obs", f"Unexpected label: {lines[0].get_label()}"
+
+    def test_title_override(self, xy):
+        """A title passed to line is applied to the axes."""
+        glyph = LineGlyph(*xy)
+        _, ax, _ = glyph.line(title="Series")
+        assert ax.get_title() == "Series", f"Unexpected title: {ax.get_title()}"
+
+    def test_plot_on_supplied_axes(self, xy):
+        """Plotting onto a supplied axes reuses that axes/figure."""
+        fig, ax = plt.subplots()
+        glyph = LineGlyph(*xy)
+        out_fig, out_ax, _ = glyph.line(ax=ax)
+        assert out_ax is ax and out_fig is fig, "Should reuse supplied axes/figure"
+
+
+class TestLineGlyphBar:
+    """Tests for LineGlyph.bar."""
+
+    def test_one_bar_per_point(self, xy):
+        """A bar chart draws one bar per x value.
+
+        Test scenario:
+            Four x values -> four bars.
+        """
+        glyph = LineGlyph(*xy)
+        _, _, bars = glyph.bar()
+        assert isinstance(bars, BarContainer), f"Expected BarContainer, got {type(bars)}"
+        assert len(bars) == 4, f"Expected 4 bars, got {len(bars)}"
+
+    def test_bar_rejects_2d(self):
+        """A 2D y is rejected by bar.
+
+        Test scenario:
+            bar requires a single series.
+        """
+        x = np.array([0.0, 1.0])
+        y = np.array([[0.0, 1.0], [1.0, 2.0]])
+        glyph = LineGlyph(x, y)
+        with pytest.raises(ValueError, match="bar requires 1D"):
+            glyph.bar()
+
+
+class TestLineGlyphFillBetween:
+    """Tests for LineGlyph.fill_between."""
+
+    def test_returns_polycollection(self, xy):
+        """fill_between returns a PolyCollection band.
+
+        Test scenario:
+            A band between y and a scalar baseline is drawn.
+        """
+        glyph = LineGlyph(*xy)
+        _, ax, band = glyph.fill_between(y2=0.0)
+        assert isinstance(band, PolyCollection), f"Expected PolyCollection, got {type(band)}"
+        assert band in ax.collections, "Band should be added to the axes"
+
+    def test_array_lower_bound(self, xy):
+        """An array lower bound is accepted for an envelope.
+
+        Test scenario:
+            y2 as an array matching x draws without error.
+        """
+        glyph = LineGlyph(*xy)
+        lower = xy[1] - 1.0
+        _, _, band = glyph.fill_between(y2=lower)
+        assert isinstance(band, PolyCollection), "Should accept an array lower bound"
+
+    def test_fill_between_rejects_2d(self):
+        """A 2D y is rejected by fill_between.
+
+        Test scenario:
+            fill_between requires a single series.
+        """
+        x = np.array([0.0, 1.0])
+        y = np.array([[0.0, 1.0], [1.0, 2.0]])
+        glyph = LineGlyph(x, y)
+        with pytest.raises(ValueError, match="fill_between requires 1D"):
+            glyph.fill_between()
+
+
+def test_line_default_options_extend_style_defaults():
+    """LINE_DEFAULT_OPTIONS is a superset of the shared style defaults.
+
+    Test scenario:
+        The module-level options dict carries both base style keys and
+        the line-specific additions.
+    """
+    assert "figsize" in LINE_DEFAULT_OPTIONS, "Should inherit base style keys"
+    assert "linestyle" in LINE_DEFAULT_OPTIONS, "Should add line keys"

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -334,6 +334,91 @@ class TestPlot:
         assert fig is not None
 
 
+class TestPlotLineContour:
+    """Tests for the node line-contour path (`filled=False`, T4.1c)."""
+
+    def _node_glyph(self):
+        """Build a fresh 2-triangle MeshGlyph for node-data tests.
+
+        Returns:
+            MeshGlyph: A glyph over four nodes / two triangles.
+        """
+        node_x = np.array([0.0, 1.0, 0.5, 1.5])
+        node_y = np.array([0.0, 0.0, 1.0, 1.0])
+        faces = np.array([[0, 1, 2], [1, 3, 2]])
+        return MeshGlyph(node_x, node_y, faces)
+
+    def test_render_mesh_filled_true_is_filled(self):
+        """_render_mesh(filled=True) yields a filled TriContourSet.
+
+        Test scenario:
+            The default node path renders filled contours (`tricontourf`).
+        """
+        mg = self._node_glyph()
+        mg.fig, mg.ax = mg.create_figure_axes()
+        mg.default_options["vmin"], mg.default_options["vmax"] = 0.0, 3.0
+        cs = mg._render_mesh(mg.ax, np.array([0.0, 1.0, 2.0, 3.0]), "node", filled=True)
+        assert cs.filled is True, "filled=True should produce a filled contour set"
+        plt.close(mg.fig)
+
+    def test_render_mesh_filled_false_is_line(self):
+        """_render_mesh(filled=False) yields a line TriContourSet.
+
+        Test scenario:
+            The opt-in node path renders line contours (`tricontour`).
+        """
+        mg = self._node_glyph()
+        mg.fig, mg.ax = mg.create_figure_axes()
+        mg.default_options["vmin"], mg.default_options["vmax"] = 0.0, 3.0
+        cs = mg._render_mesh(mg.ax, np.array([0.0, 1.0, 2.0, 3.0]), "node", filled=False)
+        assert cs.filled is False, "filled=False should produce a line contour set"
+        plt.close(mg.fig)
+
+    def test_plot_filled_false_returns_fig_ax(self):
+        """plot(location='node', filled=False) renders without error.
+
+        Test scenario:
+            The public plot entry point accepts filled=False for node
+            data and returns a Figure/Axes.
+        """
+        mg = self._node_glyph()
+        fig, ax = mg.plot(
+            np.array([0.0, 1.0, 2.0, 3.0]), location="node", filled=False
+        )
+        assert fig is not None and ax is not None, "Should return a Figure and Axes"
+        plt.close(fig)
+
+    def test_plot_filled_false_honours_levels(self):
+        """Line contours honour an explicit `levels` count.
+
+        Test scenario:
+            Passing levels through kwargs reaches tricontour without
+            error (the levels/cmap options are forwarded).
+        """
+        mg = self._node_glyph()
+        fig, ax = mg.plot(
+            np.array([0.0, 1.0, 2.0, 3.0]),
+            location="node",
+            filled=False,
+            levels=4,
+        )
+        assert fig is not None, "Should render line contours with explicit levels"
+        plt.close(fig)
+
+    def test_face_data_ignores_filled_flag(self, triangle_glyph):
+        """Face data always uses tripcolor regardless of `filled`.
+
+        Test scenario:
+            filled=False on face data still renders (tripcolor), proving
+            the flag only affects the node path.
+        """
+        fig, ax = triangle_glyph.plot(
+            np.array([1.0, 2.0]), location="face", filled=False
+        )
+        assert fig is not None, "Face data should render irrespective of filled"
+        plt.close(fig)
+
+
 class TestPlotOutline:
     """Tests for MeshGlyph.plot_outline()."""
 

--- a/tests/test_polygon_glyph.py
+++ b/tests/test_polygon_glyph.py
@@ -1,0 +1,206 @@
+"""Tests for cleopatra.polygon_glyph.PolygonGlyph (T7.2c)."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.collections import PolyCollection
+
+from cleopatra.polygon_glyph import POLYGON_DEFAULT_OPTIONS, PolygonGlyph
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def polygons():
+    """Two adjacent triangles as (n, 2) vertex arrays.
+
+    Returns:
+        list[np.ndarray]: Two triangular polygons.
+    """
+    return [
+        np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]]),
+        np.array([[1.0, 0.0], [2.0, 0.0], [1.5, 1.0]]),
+    ]
+
+
+class TestPolygonGlyphInit:
+    """Tests for PolygonGlyph.__init__."""
+
+    def test_stores_polygons_as_float_arrays(self, polygons):
+        """Polygons are coerced to float ndarrays.
+
+        Test scenario:
+            Integer-vertex input is stored as float arrays.
+        """
+        glyph = PolygonGlyph([[[0, 0], [1, 0], [0, 1]]])
+        assert glyph.polygons[0].dtype == float, "Vertices should be float"
+        assert glyph.values is None, "values should default to None"
+
+    def test_options_include_polygon_keys(self, polygons):
+        """Polygon-specific option keys are present with defaults.
+
+        Test scenario:
+            edgecolor/linewidth defaults exist and ticks_spacing is None.
+        """
+        glyph = PolygonGlyph(polygons)
+        assert glyph.default_options["edgecolor"] == "none", "Default edgecolor 'none'"
+        assert glyph.default_options["linewidth"] == 0.5, "Default linewidth 0.5"
+        assert glyph.default_options["ticks_spacing"] is None, (
+            "ticks_spacing should default to None for auto-derivation"
+        )
+
+    def test_mismatched_values_raises(self, polygons):
+        """A values array not matching polygon count raises ValueError.
+
+        Test scenario:
+            len(values) != number of polygons is rejected.
+        """
+        with pytest.raises(ValueError, match="must match the number"):
+            PolygonGlyph(polygons, values=np.array([1.0, 2.0, 3.0]))
+
+    def test_invalid_kwarg_raises(self, polygons):
+        """An unknown kwarg is rejected by the strict merge.
+
+        Test scenario:
+            A key absent from POLYGON_DEFAULT_OPTIONS raises ValueError.
+        """
+        with pytest.raises(ValueError, match="not correct"):
+            PolygonGlyph(polygons, bogus=1)
+
+
+class TestPolygonGlyphPlot:
+    """Tests for PolygonGlyph.plot."""
+
+    def test_filled_maps_values_and_adds_colorbar(self, polygons):
+        """Filled polygons carry the value array and gain a colorbar.
+
+        Test scenario:
+            The PolyCollection array equals the values and a colorbar
+            is attached.
+        """
+        glyph = PolygonGlyph(polygons, values=np.array([10.0, 20.0]))
+        fig, ax, pc = glyph.plot()
+        assert isinstance(pc, PolyCollection), f"Expected PolyCollection, got {type(pc)}"
+        np.testing.assert_array_almost_equal(
+            pc.get_array(), [10.0, 20.0], err_msg="Array should equal values"
+        )
+        assert glyph.cbar is not None, "A colorbar should be attached for filled polygons"
+        assert pc in ax.collections, "The collection should be added to the axes"
+
+    def test_no_values_is_outline(self, polygons):
+        """With no values, only outlines are drawn (no colour, no cbar).
+
+        Test scenario:
+            No values -> PolyCollection without an array and no colorbar.
+        """
+        glyph = PolygonGlyph(polygons)
+        _, _, pc = glyph.plot()
+        assert pc.get_array() is None, "Outline collection should carry no array"
+        assert glyph.cbar is None, "No colorbar without values"
+
+    def test_outline_only_overrides_values(self, polygons):
+        """outline_only draws outlines even when values are present.
+
+        Test scenario:
+            outline_only=True suppresses fill/colorbar despite values.
+        """
+        glyph = PolygonGlyph(polygons, values=np.array([10.0, 20.0]))
+        _, _, pc = glyph.plot(outline_only=True)
+        assert pc.get_array() is None, "outline_only should suppress the colour array"
+        assert glyph.cbar is None, "outline_only should suppress the colorbar"
+
+    def test_auto_limits_from_values(self, polygons):
+        """Colour limits auto-resolve from the value range (pinned spacing).
+
+        Test scenario:
+            With a spacing that divides the range, the clim equals the
+            value range.
+        """
+        glyph = PolygonGlyph(
+            polygons, values=np.array([0.0, 40.0]), ticks_spacing=10.0
+        )
+        _, _, pc = glyph.plot()
+        assert pc.get_clim() == (0.0, 40.0), (
+            f"clim should follow the resolved limits, got {pc.get_clim()}"
+        )
+
+    def test_levels_produce_boundary_norm(self, polygons):
+        """An integer `levels` discretises the fill colour scale.
+
+        Test scenario:
+            levels=4 -> the collection norm is a BoundaryNorm.
+        """
+        glyph = PolygonGlyph(
+            polygons, values=np.array([0.0, 10.0]), levels=4, vmin=0.0, vmax=10.0
+        )
+        _, _, pc = glyph.plot()
+        assert isinstance(pc.norm, mcolors.BoundaryNorm), (
+            f"levels should yield a BoundaryNorm, got {type(pc.norm)}"
+        )
+
+    def test_edgecolor_and_linewidth_forwarded(self, polygons):
+        """edgecolor/linewidth options reach the PolyCollection.
+
+        Test scenario:
+            edgecolor='black', linewidth=2 are applied to the collection.
+        """
+        glyph = PolygonGlyph(polygons, edgecolor="black", linewidth=2.0)
+        _, _, pc = glyph.plot()
+        assert np.allclose(
+            pc.get_edgecolor()[0], mcolors.to_rgba("black")
+        ), "edgecolor should be forwarded"
+        assert pc.get_linewidth()[0] == 2.0, "linewidth should be forwarded"
+
+    def test_plot_on_supplied_axes(self, polygons):
+        """Plotting onto a supplied axes reuses that axes/figure.
+
+        Test scenario:
+            Passing ax to plot draws on it and returns its figure.
+        """
+        fig, ax = plt.subplots()
+        glyph = PolygonGlyph(polygons, values=np.array([1.0, 2.0]))
+        out_fig, out_ax, _ = glyph.plot(ax=ax)
+        assert out_ax is ax, "Should draw on the supplied axes"
+        assert out_fig is fig, "Should return the supplied axes' figure"
+
+    def test_title_override(self, polygons):
+        """A title passed to plot is applied to the axes.
+
+        Test scenario:
+            plot(title=...) sets the axes title.
+        """
+        glyph = PolygonGlyph(polygons)
+        _, ax, _ = glyph.plot(title="Regions")
+        assert ax.get_title() == "Regions", f"Unexpected title: {ax.get_title()}"
+
+    def test_all_nan_values_raise(self, polygons):
+        """All-NaN values with unpinned limits raise ValueError.
+
+        Test scenario:
+            The shared helper rejects an unusable colour range.
+        """
+        glyph = PolygonGlyph(polygons, values=np.array([np.nan, np.nan]))
+        with pytest.raises(ValueError, match="no finite values"):
+            glyph.plot()
+
+
+def test_polygon_default_options_extend_style_defaults():
+    """POLYGON_DEFAULT_OPTIONS is a superset of the shared style defaults.
+
+    Test scenario:
+        The module-level options dict carries both the base style keys
+        and the polygon-specific additions.
+    """
+    assert "figsize" in POLYGON_DEFAULT_OPTIONS, "Should inherit base style keys"
+    assert "edgecolor" in POLYGON_DEFAULT_OPTIONS, "Should add polygon keys"

--- a/tests/test_scatter_glyph.py
+++ b/tests/test_scatter_glyph.py
@@ -1,0 +1,244 @@
+"""Tests for cleopatra.scatter_glyph.ScatterGlyph (T2.1)."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.collections import PathCollection
+
+from cleopatra.scatter_glyph import SCATTER_DEFAULT_OPTIONS, ScatterGlyph
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def xy():
+    """A small, fixed set of point coordinates.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: x and y coordinate arrays.
+    """
+    return np.array([0.0, 1.0, 2.0, 3.0]), np.array([0.0, 1.0, 0.0, 1.0])
+
+
+@pytest.fixture()
+def values():
+    """A per-point value array aligned with the `xy` fixture.
+
+    Returns:
+        np.ndarray: Four scalar values spanning 0..30.
+    """
+    return np.array([0.0, 10.0, 20.0, 30.0])
+
+
+class TestScatterGlyphInit:
+    """Tests for ScatterGlyph.__init__."""
+
+    def test_stores_coordinates_as_arrays(self, xy):
+        """Coordinates are stored as numpy arrays.
+
+        Test scenario:
+            Plain lists are accepted and converted via np.asarray.
+        """
+        glyph = ScatterGlyph([0, 1, 2], [3, 4, 5])
+        assert isinstance(glyph.x, np.ndarray), "x should be an ndarray"
+        assert isinstance(glyph.y, np.ndarray), "y should be an ndarray"
+        assert glyph.values is None, "values should default to None"
+
+    def test_options_include_scatter_keys(self, xy):
+        """Scatter-specific option keys are present with their defaults.
+
+        Test scenario:
+            marker/point_size defaults are exposed and ticks_spacing is
+            None so the shared helper auto-derives it.
+        """
+        glyph = ScatterGlyph(*xy)
+        assert glyph.default_options["marker"] == "o", "Default marker should be 'o'"
+        assert glyph.default_options["point_size"] == 20, "Default size should be 20"
+        assert glyph.default_options["ticks_spacing"] is None, (
+            "ticks_spacing should default to None for auto-derivation"
+        )
+
+    def test_kwargs_override_options(self, xy):
+        """Constructor kwargs override option defaults.
+
+        Test scenario:
+            marker and point_size passed as kwargs win over the defaults.
+        """
+        glyph = ScatterGlyph(*xy, marker="^", point_size=50)
+        assert glyph.default_options["marker"] == "^", "marker kwarg should win"
+        assert glyph.default_options["point_size"] == 50, "point_size kwarg should win"
+
+    def test_invalid_kwarg_raises(self, xy):
+        """An unknown kwarg is rejected by the strict merge.
+
+        Test scenario:
+            A key absent from SCATTER_DEFAULT_OPTIONS raises ValueError.
+        """
+        with pytest.raises(ValueError, match="not correct"):
+            ScatterGlyph(*xy, not_a_real_option=1)
+
+    def test_mismatched_xy_raises(self):
+        """x and y of different lengths raise ValueError.
+
+        Test scenario:
+            len(x) != len(y) is rejected at construction.
+        """
+        with pytest.raises(ValueError, match="same shape"):
+            ScatterGlyph([0, 1, 2], [0, 1])
+
+    def test_mismatched_values_raises(self, xy):
+        """A values array not matching x/y length raises ValueError.
+
+        Test scenario:
+            len(values) != len(x) is rejected at construction.
+        """
+        with pytest.raises(ValueError, match="values must match"):
+            ScatterGlyph(*xy, values=np.array([1.0, 2.0]))
+
+
+class TestScatterGlyphPlot:
+    """Tests for ScatterGlyph.plot."""
+
+    def test_uncoloured_returns_pathcollection_no_array(self, xy):
+        """Uncoloured points return a PathCollection without a value array.
+
+        Test scenario:
+            With no values, scatter has no colour array and no colorbar.
+        """
+        glyph = ScatterGlyph(*xy)
+        fig, ax, paths = glyph.plot()
+        assert isinstance(paths, PathCollection), f"Expected PathCollection, got {type(paths)}"
+        assert paths.get_array() is None, "Uncoloured scatter should carry no array"
+        assert glyph.cbar is None, "No colorbar should be created without values"
+
+    def test_coloured_maps_values_and_adds_colorbar(self, xy, values):
+        """Coloured points carry the value array and gain a colorbar.
+
+        Test scenario:
+            The scatter's array equals the input values and a colorbar
+            is attached.
+        """
+        glyph = ScatterGlyph(*xy, values=values)
+        fig, ax, paths = glyph.plot()
+        np.testing.assert_array_almost_equal(
+            paths.get_array(), values, err_msg="Scatter array should equal values"
+        )
+        assert glyph.cbar is not None, "A colorbar should be created for coloured points"
+
+    def test_point_size_and_marker_forwarded(self, xy):
+        """point_size maps to the scatter sizes.
+
+        Test scenario:
+            point_size=80 -> every path size equals 80.
+        """
+        glyph = ScatterGlyph(*xy, point_size=80)
+        _, _, paths = glyph.plot()
+        sizes = paths.get_sizes()
+        assert np.all(sizes == 80), f"Expected all sizes 80, got {sizes}"
+
+    def test_auto_limits_set_from_values(self, xy, values):
+        """vmin/vmax are auto-resolved from the value range.
+
+        Test scenario:
+            Unset limits resolve to (min, max) of the values.
+        """
+        glyph = ScatterGlyph(*xy, values=values)
+        glyph.plot()
+        assert glyph.vmin == 0.0, f"vmin should be data min 0.0, got {glyph.vmin}"
+        assert glyph.vmax == 30.0, f"vmax should be data max 30.0, got {glyph.vmax}"
+
+    def test_explicit_limits_preserved(self, xy, values):
+        """Explicit vmin/vmax (with pinned spacing) drive the clim.
+
+        Test scenario:
+            vmin/vmax pinned via kwargs, plus a ticks_spacing that
+            divides the range evenly, yield a clim equal to those
+            limits. The clim follows ticks[0]/ticks[-1] (the documented
+            contract shared with ArrayGlyph); an evenly-dividing spacing
+            keeps the top tick at exactly vmax.
+        """
+        glyph = ScatterGlyph(
+            *xy, values=values, vmin=0.0, vmax=40.0, ticks_spacing=10.0
+        )
+        _, _, paths = glyph.plot()
+        assert paths.get_clim() == (0.0, 40.0), (
+            f"clim should honour explicit limits, got {paths.get_clim()}"
+        )
+
+    def test_levels_produce_boundary_norm(self, xy, values):
+        """An integer `levels` discretises the colour scale.
+
+        Test scenario:
+            levels=4 -> the scatter norm is a BoundaryNorm.
+        """
+        glyph = ScatterGlyph(*xy, values=values, levels=4)
+        _, _, paths = glyph.plot()
+        assert isinstance(paths.norm, mcolors.BoundaryNorm), (
+            f"levels should yield a BoundaryNorm, got {type(paths.norm)}"
+        )
+
+    def test_power_color_scale_applied(self, xy, values):
+        """A non-linear color_scale is honoured for points.
+
+        Test scenario:
+            color_scale='power' -> the scatter norm is a PowerNorm.
+        """
+        glyph = ScatterGlyph(*xy, values=values, color_scale="power")
+        _, _, paths = glyph.plot()
+        assert isinstance(paths.norm, mcolors.PowerNorm), (
+            f"color_scale='power' should yield a PowerNorm, got {type(paths.norm)}"
+        )
+
+    def test_plot_on_supplied_axes(self, xy, values):
+        """Plotting onto a supplied axes reuses that axes/figure.
+
+        Test scenario:
+            Passing ax to plot draws on it and returns its figure.
+        """
+        fig, ax = plt.subplots()
+        glyph = ScatterGlyph(*xy, values=values)
+        out_fig, out_ax, _ = glyph.plot(ax=ax)
+        assert out_ax is ax, "Should draw on the supplied axes"
+        assert out_fig is fig, "Should return the supplied axes' figure"
+
+    def test_title_override(self, xy):
+        """A title passed to plot is applied to the axes.
+
+        Test scenario:
+            plot(title=...) sets the axes title.
+        """
+        glyph = ScatterGlyph(*xy)
+        _, ax, _ = glyph.plot(title="My Points")
+        assert ax.get_title() == "My Points", f"Unexpected title: {ax.get_title()}"
+
+    def test_all_nan_values_raise(self, xy):
+        """All-NaN values with unpinned limits raise ValueError.
+
+        Test scenario:
+            The shared helper rejects an unusable colour range.
+        """
+        glyph = ScatterGlyph(*xy, values=np.full(4, np.nan))
+        with pytest.raises(ValueError, match="no finite values"):
+            glyph.plot()
+
+
+def test_scatter_default_options_extend_style_defaults():
+    """SCATTER_DEFAULT_OPTIONS is a superset of the shared style defaults.
+
+    Test scenario:
+        The module-level options dict carries both the base style keys
+        and the scatter-specific additions.
+    """
+    assert "figsize" in SCATTER_DEFAULT_OPTIONS, "Should inherit base style keys"
+    assert "point_size" in SCATTER_DEFAULT_OPTIONS, "Should add scatter keys"

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -2,10 +2,20 @@ import matplotlib
 import numpy as np
 
 matplotlib.use("agg")
+import matplotlib.pyplot as plt
+import pytest
 from matplotlib.axes import Axes
+from matplotlib.container import BarContainer
 from matplotlib.figure import Figure
 
 from cleopatra.statistical_glyph import StatisticalGlyph
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
 
 
 def test_histogram_one_sample():
@@ -31,3 +41,160 @@ def test_histogram_multiple_sample():
     assert isinstance(ax, Axes)
     assert isinstance(hist, dict)
     assert ["n", "bins", "patches"] == list(hist.keys())
+
+
+class TestBoxplot:
+    """Tests for StatisticalGlyph.boxplot (T7.3c)."""
+
+    def test_single_series_one_box(self):
+        """1D values draw a single box.
+
+        Test scenario:
+            One box is produced for a 1D sample.
+        """
+        np.random.seed(1)
+        stat = StatisticalGlyph(np.random.normal(0, 1, 100))
+        fig, ax, bp = stat.boxplot()
+        assert isinstance(fig, Figure) and isinstance(ax, Axes)
+        assert len(bp["boxes"]) == 1, f"Expected 1 box, got {len(bp['boxes'])}"
+
+    def test_multi_series_one_box_per_column(self):
+        """2D values draw one box per column.
+
+        Test scenario:
+            A (50, 3) sample yields three boxes.
+        """
+        np.random.seed(1)
+        stat = StatisticalGlyph(
+            np.random.normal(0, 1, (50, 3)), color=["r", "g", "b"]
+        )
+        _, _, bp = stat.boxplot()
+        assert len(bp["boxes"]) == 3, f"Expected 3 boxes, got {len(bp['boxes'])}"
+
+    def test_composes_into_supplied_axes(self):
+        """boxplot draws on a caller-supplied axes without plt.show().
+
+        Test scenario:
+            Passing ax reuses it and its figure.
+        """
+        np.random.seed(1)
+        fig, ax = plt.subplots()
+        stat = StatisticalGlyph(np.random.normal(0, 1, 50))
+        out_fig, out_ax, _ = stat.boxplot(ax=ax)
+        assert out_ax is ax and out_fig is fig, "Should reuse supplied axes/figure"
+
+    def test_custom_labels(self):
+        """Custom tick labels are applied.
+
+        Test scenario:
+            Labels passed through are set on the x ticks.
+        """
+        np.random.seed(1)
+        stat = StatisticalGlyph(np.random.normal(0, 1, (30, 2)), color=["r", "g"])
+        _, ax, _ = stat.boxplot(labels=["A", "B"])
+        assert [t.get_text() for t in ax.get_xticklabels()] == ["A", "B"]
+
+
+class TestMultiboxplot:
+    """Tests for StatisticalGlyph.multiboxplot (T7.3c)."""
+
+    def test_boxes_at_custom_positions(self):
+        """Boxes are placed at the requested x positions.
+
+        Test scenario:
+            Median lines sit at the requested positions.
+        """
+        np.random.seed(1)
+        stat = StatisticalGlyph(
+            np.random.normal(0, 1, (40, 3)), color=["r", "g", "b"]
+        )
+        _, _, bp = stat.multiboxplot(positions=[1, 2, 4])
+        medians = [round(float(line.get_xdata().mean())) for line in bp["medians"]]
+        assert medians == [1, 2, 4], f"Medians should sit at positions, got {medians}"
+
+    def test_requires_2d(self):
+        """1D values are rejected by multiboxplot.
+
+        Test scenario:
+            multiboxplot needs one column per box.
+        """
+        stat = StatisticalGlyph(np.array([1.0, 2.0, 3.0]))
+        with pytest.raises(ValueError, match="requires 2D"):
+            stat.multiboxplot()
+
+    def test_positions_length_mismatch_raises(self):
+        """A positions length not matching columns raises ValueError.
+
+        Test scenario:
+            3 columns but 2 positions is rejected.
+        """
+        np.random.seed(1)
+        stat = StatisticalGlyph(
+            np.random.normal(0, 1, (20, 3)), color=["r", "g", "b"]
+        )
+        with pytest.raises(ValueError, match="positions length"):
+            stat.multiboxplot(positions=[1, 2])
+
+    def test_labels_length_mismatch_raises(self):
+        """A labels length not matching columns raises ValueError.
+
+        Test scenario:
+            3 columns but 2 labels is rejected.
+        """
+        np.random.seed(1)
+        stat = StatisticalGlyph(
+            np.random.normal(0, 1, (20, 3)), color=["r", "g", "b"]
+        )
+        with pytest.raises(ValueError, match="labels length"):
+            stat.multiboxplot(labels=["A", "B"])
+
+
+class TestStripes:
+    """Tests for StatisticalGlyph.stripes (T7.3c)."""
+
+    def test_one_bar_per_value(self):
+        """Each value becomes one full-height stripe.
+
+        Test scenario:
+            Six values -> six bars; y-axis ticks are removed.
+        """
+        series = np.array([0.1, 0.3, 0.2, 0.6, 0.9, 0.7])
+        stat = StatisticalGlyph(series)
+        fig, ax, bars = stat.stripes(cmap="coolwarm")
+        assert isinstance(bars, BarContainer), f"Expected BarContainer, got {type(bars)}"
+        assert len(bars) == 6, f"Expected 6 stripes, got {len(bars)}"
+        assert list(ax.get_yticks()) == [], "Stripes should hide y ticks"
+
+    def test_colours_span_cmap(self):
+        """Stripe colours vary with value across the colormap.
+
+        Test scenario:
+            The min-value and max-value stripes differ in colour.
+        """
+        series = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        stat = StatisticalGlyph(series)
+        _, _, bars = stat.stripes(cmap="coolwarm")
+        assert bars.patches[0].get_facecolor() != bars.patches[-1].get_facecolor(), (
+            "First and last stripe should differ in colour"
+        )
+
+    def test_explicit_limits_respected(self):
+        """Explicit vmin/vmax drive the normalization without error.
+
+        Test scenario:
+            Passing vmin/vmax renders the stripes.
+        """
+        series = np.array([0.0, 5.0, 10.0])
+        stat = StatisticalGlyph(series)
+        _, _, bars = stat.stripes(cmap="viridis", vmin=-5.0, vmax=15.0)
+        assert len(bars) == 3, "Should render all stripes with explicit limits"
+
+    def test_requires_1d(self):
+        """2D values are rejected by stripes.
+
+        Test scenario:
+            stripes needs a single 1D series.
+        """
+        stat = StatisticalGlyph(np.ones((4, 2)))
+        with pytest.raises(ValueError, match="requires 1D"):
+            stat.stripes()

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -94,6 +94,41 @@ class TestBoxplot:
         _, ax, _ = stat.boxplot(labels=["A", "B"])
         assert [t.get_text() for t in ax.get_xticklabels()] == ["A", "B"]
 
+    def test_default_labels_are_one_based_indices(self):
+        """With no labels, ticks are labelled 1..n (H1 fix path).
+
+        Test scenario:
+            Labels default to 1-based series indices, set via
+            set_xticklabels (not boxplot's version-specific kwarg), so
+            three columns yield tick labels ["1", "2", "3"] and ticks
+            at [1, 2, 3].
+        """
+        np.random.seed(1)
+        stat = StatisticalGlyph(
+            np.random.normal(0, 1, (30, 3)), color=["r", "g", "b"]
+        )
+        _, ax, bp = stat.boxplot()
+        assert [t.get_text() for t in ax.get_xticklabels()] == ["1", "2", "3"], (
+            "Default labels should be 1-based indices"
+        )
+        assert list(ax.get_xticks()) == [1, 2, 3], (
+            f"Ticks should sit at box positions 1..n, got {list(ax.get_xticks())}"
+        )
+        assert len(bp["boxes"]) == 3, "Three boxes expected for three columns"
+
+    def test_single_series_default_label(self):
+        """A 1D sample gets a single '1' tick label (H1 fix path).
+
+        Test scenario:
+            One series -> one box labelled "1".
+        """
+        np.random.seed(1)
+        stat = StatisticalGlyph(np.random.normal(0, 1, 40))
+        _, ax, _ = stat.boxplot()
+        assert [t.get_text() for t in ax.get_xticklabels()] == ["1"], (
+            "Single series should be labelled '1'"
+        )
+
 
 class TestMultiboxplot:
     """Tests for StatisticalGlyph.multiboxplot (T7.3c)."""

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -129,6 +129,28 @@ class TestBoxplot:
             "Single series should be labelled '1'"
         )
 
+    def test_positions_via_kwargs_keep_ticks_aligned(self):
+        """Forwarded `positions` keep tick locations under the boxes (L1 fix).
+
+        Test scenario:
+            Passing positions through **kwargs places the boxes at those
+            x positions, and the tick locations follow them (rather than
+            staying at the default 1..n), so labels stay under the boxes.
+        """
+        np.random.seed(1)
+        stat = StatisticalGlyph(
+            np.random.normal(0, 1, (20, 3)), color=["r", "g", "b"]
+        )
+        _, ax, bp = stat.boxplot(positions=[10, 20, 30])
+        box_x = [round(float(line.get_xdata().mean())) for line in bp["medians"]]
+        assert box_x == [10, 20, 30], f"Boxes should sit at positions, got {box_x}"
+        assert list(ax.get_xticks()) == [10, 20, 30], (
+            f"Ticks should follow positions, got {list(ax.get_xticks())}"
+        )
+        assert [t.get_text() for t in ax.get_xticklabels()] == ["1", "2", "3"], (
+            "Default labels should still be 1-based indices"
+        )
+
 
 class TestMultiboxplot:
     """Tests for StatisticalGlyph.multiboxplot (T7.3c)."""

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -233,3 +233,18 @@ class TestStripes:
         stat = StatisticalGlyph(np.ones((4, 2)))
         with pytest.raises(ValueError, match="requires 1D"):
             stat.stripes()
+
+    def test_return_annotation_resolves(self):
+        """stripes' return type hint resolves to BarContainer (N1 fix).
+
+        Test scenario:
+            typing.get_type_hints succeeds (the annotation no longer
+            references an unimported submodule) and the return type is
+            matplotlib's BarContainer.
+        """
+        import typing
+
+        hints = typing.get_type_hints(StatisticalGlyph.stripes)
+        assert typing.get_args(hints["return"]) == (Figure, Axes, BarContainer), (
+            f"Unexpected resolved return hint: {hints['return']}"
+        )

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -1,8 +1,15 @@
 from collections import OrderedDict
 
-import pytest
+import matplotlib
 
-from cleopatra.styles import ColorScale, Styles
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.legend import Legend
+from matplotlib.patches import Patch
+
+from cleopatra.styles import ColorScale, Styles, disjoint_legend
 
 
 def test_create_instance():
@@ -55,3 +62,134 @@ class TestColorScale:
         """
         with pytest.raises(ValueError):
             ColorScale(bad)
+
+
+class TestDisjointLegend:
+    """Tests for cleopatra.styles.disjoint_legend (T0.4)."""
+
+    @pytest.fixture()
+    def ax(self):
+        """A fresh axes, closed after the test to bound figure count."""
+        fig, ax = plt.subplots()
+        yield ax
+        plt.close(fig)
+
+    def test_returns_legend_added_to_axes(self, ax):
+        """The helper returns a Legend that is attached to the axes.
+
+        Test scenario:
+            A two-class legend is built and the returned object is the
+            same one registered on the axes.
+        """
+        legend = disjoint_legend(ax, ["red", "blue"], ["hot", "cold"])
+        assert isinstance(legend, Legend), f"Expected a Legend, got {type(legend)}"
+        assert ax.get_legend() is legend, "Legend should be attached to the axes"
+
+    def test_one_swatch_patch_per_category(self, ax):
+        """One Patch handle is created per category, in order.
+
+        Test scenario:
+            Three categories -> three Patch handles whose face colors
+            match the requested colors.
+        """
+        colors = ["#1b9e77", "#d95f02", "#7570b3"]
+        legend = disjoint_legend(ax, colors, ["water", "urban", "forest"])
+        handles = legend.legend_handles
+        assert len(handles) == 3, f"Expected 3 handles, got {len(handles)}"
+        assert all(isinstance(h, Patch) for h in handles), "Handles must be Patches"
+        expected = [matplotlib.colors.to_rgba(c) for c in colors]
+        actual = [h.get_facecolor() for h in handles]
+        assert actual == expected, f"Face colors mismatch: {actual} != {expected}"
+
+    def test_labels_preserved_in_order(self, ax):
+        """Legend texts match the labels in the given order.
+
+        Test scenario:
+            The drawn legend texts equal the input labels.
+        """
+        labels = ["a", "b", "c"]
+        legend = disjoint_legend(ax, ["r", "g", "b"], labels)
+        assert [t.get_text() for t in legend.get_texts()] == labels, (
+            "Legend texts should equal the input labels in order"
+        )
+
+    def test_default_edgecolor_is_none(self, ax):
+        """Swatches have no border by default (edgecolor='none').
+
+        Test scenario:
+            The first handle's edge color is fully transparent.
+        """
+        legend = disjoint_legend(ax, ["red"], ["x"])
+        edge = legend.legend_handles[0].get_edgecolor()
+        assert matplotlib.colors.to_rgba(edge)[3] == 0.0, (
+            f"Default edge should be transparent, got {edge}"
+        )
+
+    def test_custom_edgecolor_applied(self, ax):
+        """An explicit edgecolor is applied to every swatch.
+
+        Test scenario:
+            edgecolor='black' -> handle edge resolves to black.
+        """
+        legend = disjoint_legend(ax, ["red"], ["x"], edgecolor="black")
+        edge = legend.legend_handles[0].get_edgecolor()
+        assert matplotlib.colors.to_rgba(edge) == matplotlib.colors.to_rgba("black"), (
+            f"Edge color should be black, got {edge}"
+        )
+
+    def test_legend_kwargs_forwarded(self, ax):
+        """Extra kwargs are forwarded to Axes.legend (e.g. title).
+
+        Test scenario:
+            title='Class' surfaces on the legend's title text.
+        """
+        legend = disjoint_legend(ax, ["red", "blue"], ["hot", "cold"], title="Class")
+        assert legend.get_title().get_text() == "Class", (
+            "title kwarg should be forwarded to Axes.legend"
+        )
+
+    @pytest.mark.parametrize(
+        "colors, labels",
+        [
+            (["red", "blue"], ["only-one"]),
+            (["red"], ["a", "b"]),
+            ([], ["a"]),
+        ],
+    )
+    def test_length_mismatch_raises(self, ax, colors, labels):
+        """Mismatched colors/labels lengths raise ValueError.
+
+        Args:
+            colors: Color sequence of one length.
+            labels: Label sequence of a different length.
+
+        Test scenario:
+            Any length mismatch is rejected with a descriptive message.
+        """
+        with pytest.raises(ValueError, match="same length") as exc:
+            disjoint_legend(ax, colors, labels)
+        assert "same length" in str(exc.value), f"Unexpected message: {exc.value}"
+
+
+class TestDiscreteContourfAcceptance:
+    """T0.4 acceptance: explicit `levels` yields a discrete contourf + cbar."""
+
+    def test_contourf_with_explicit_levels_is_discrete(self):
+        """ArrayGlyph contourf with `levels` builds a discrete colorbar.
+
+        Test scenario:
+            Plotting with kind='contourf' and explicit edges produces a
+            colorbar whose ticks are exactly those edges, confirming the
+            already-implemented discrete-levels path still holds.
+        """
+        from cleopatra.array_glyph import ArrayGlyph
+
+        data = np.linspace(0, 10, 36).reshape(6, 6)
+        edges = [0, 2, 4, 6, 8, 10]
+        glyph = ArrayGlyph(data, levels=edges)
+        glyph.plot(kind="contourf", cmap="viridis")
+        ticks = list(glyph.cbar.get_ticks())
+        assert ticks == [float(e) for e in edges], (
+            f"Colorbar ticks should equal the level edges, got {ticks}"
+        )
+        plt.close("all")

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -361,3 +361,45 @@ class TestHistogramLegend:
         """
         with pytest.raises(ValueError, match="orientation must be"):
             histogram_legend(ax, [0.0, 1.0], cmap="viridis", orientation="diagonal")
+
+    def test_does_not_mutate_unscaled_mappable_norm(self, ax):
+        """Building from a mappable does not autoscale its norm (L3 fix).
+
+        Test scenario:
+            A ScalarMappable whose norm has vmin/vmax unset supplies the
+            cmap/norm while values are passed explicitly. histogram_legend
+            must copy the norm so mapping the bin centres does not
+            autoscale the caller's norm in place (vmin/vmax stay None).
+        """
+        from matplotlib.cm import ScalarMappable
+        from matplotlib.colors import Normalize
+
+        sm = ScalarMappable(norm=Normalize(), cmap="viridis")
+        assert sm.norm.vmin is None and sm.norm.vmax is None, "precondition: unscaled"
+
+        histogram_legend(ax, values=[0.0, 1.0, 2.0, 3.0], mappable=sm, bins=3)
+
+        assert sm.norm.vmin is None and sm.norm.vmax is None, (
+            f"mappable norm should remain unscaled, got "
+            f"vmin={sm.norm.vmin}, vmax={sm.norm.vmax}"
+        )
+
+    def test_preserves_boundary_norm_subtype_from_mappable(self, ax):
+        """A BoundaryNorm on the mappable is preserved (copy keeps subtype).
+
+        Test scenario:
+            A scatter coloured with a BoundaryNorm drives the legend; the
+            histogram still renders one bar per bin without raising.
+        """
+        from matplotlib.colors import BoundaryNorm
+
+        fig2, main_ax = plt.subplots()
+        norm = BoundaryNorm([0, 1, 2, 3], ncolors=256)
+        sc = main_ax.scatter(
+            [0, 1, 2, 3], [0, 1, 0, 1], c=[0.5, 1.5, 2.5, 0.5],
+            cmap="viridis", norm=norm,
+        )
+        bars = histogram_legend(ax, mappable=sc, bins=3)
+        assert len(bars) == 3, f"Expected 3 bars, got {len(bars)}"
+        assert norm.vmin == 0 and norm.vmax == 3, "Original BoundaryNorm untouched"
+        plt.close(fig2)

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -9,7 +9,16 @@ import pytest
 from matplotlib.legend import Legend
 from matplotlib.patches import Patch
 
-from cleopatra.styles import ColorScale, Styles, disjoint_legend
+from matplotlib.colorbar import Colorbar
+from matplotlib.container import BarContainer
+
+from cleopatra.styles import (
+    ColorScale,
+    Styles,
+    colorbar_legend,
+    disjoint_legend,
+    histogram_legend,
+)
 
 
 def test_create_instance():
@@ -193,3 +202,162 @@ class TestDiscreteContourfAcceptance:
             f"Colorbar ticks should equal the level edges, got {ticks}"
         )
         plt.close("all")
+
+
+class TestColorbarLegend:
+    """Tests for cleopatra.styles.colorbar_legend (T5.3c)."""
+
+    @pytest.fixture()
+    def scatter(self):
+        """A coloured scatter mappable on its own axes.
+
+        Returns:
+            tuple: (axes, PathCollection) with a value array attached.
+        """
+        fig, ax = plt.subplots()
+        sc = ax.scatter([0, 1, 2], [0, 1, 0], c=[10.0, 20.0, 30.0])
+        yield ax, sc
+        plt.close(fig)
+
+    def test_returns_colorbar(self, scatter):
+        """A Colorbar is created for the mappable.
+
+        Test scenario:
+            The helper returns a matplotlib Colorbar instance.
+        """
+        ax, sc = scatter
+        cbar = colorbar_legend(sc, ax)
+        assert isinstance(cbar, Colorbar), f"Expected Colorbar, got {type(cbar)}"
+
+    def test_label_forwarded(self, scatter):
+        """The label kwarg is forwarded to Figure.colorbar.
+
+        Test scenario:
+            label='depth' surfaces on the colorbar axis.
+        """
+        ax, sc = scatter
+        cbar = colorbar_legend(sc, ax, label="depth")
+        assert cbar.ax.get_ylabel() == "depth", (
+            f"Unexpected colorbar label: {cbar.ax.get_ylabel()}"
+        )
+
+    def test_infers_axes_from_mappable(self, scatter):
+        """With no ax, the mappable's own axes is used.
+
+        Test scenario:
+            Omitting ax still produces a colorbar (axes inferred).
+        """
+        _, sc = scatter
+        cbar = colorbar_legend(sc)
+        assert isinstance(cbar, Colorbar), "Should infer axes from the mappable"
+
+    def test_no_axes_raises(self):
+        """A detached mappable with no ax raises ValueError.
+
+        Test scenario:
+            A ScalarMappable not attached to any axes and ax=None fails.
+        """
+        from matplotlib.cm import ScalarMappable
+
+        sm = ScalarMappable()
+        sm.set_array([0.0, 1.0])
+        with pytest.raises(ValueError, match="determine an axes"):
+            colorbar_legend(sm)
+
+
+class TestHistogramLegend:
+    """Tests for cleopatra.styles.histogram_legend (T5.3c)."""
+
+    @pytest.fixture()
+    def ax(self):
+        """A fresh axes closed after the test."""
+        fig, ax = plt.subplots()
+        yield ax
+        plt.close(fig)
+
+    def test_returns_one_bar_per_bin(self, ax):
+        """A BarContainer with one bar per bin is returned.
+
+        Test scenario:
+            bins=3 -> three bars from the explicit values.
+        """
+        bars = histogram_legend(
+            ax, [0.0, 1.0, 1.0, 2.0, 2.0, 2.0], cmap="viridis", bins=3
+        )
+        assert isinstance(bars, BarContainer), f"Expected BarContainer, got {type(bars)}"
+        assert len(bars) == 3, f"Expected 3 bars, got {len(bars)}"
+
+    def test_bars_coloured_by_cmap(self, ax):
+        """Bars take distinct colours across the colormap.
+
+        Test scenario:
+            The first and last bar differ in colour (cmap applied).
+        """
+        bars = histogram_legend(ax, np.linspace(0, 10, 100), cmap="viridis", bins=5)
+        first = bars.patches[0].get_facecolor()
+        last = bars.patches[-1].get_facecolor()
+        assert first != last, "First and last bars should differ in colour"
+
+    def test_inherits_cmap_norm_and_array_from_mappable(self, ax):
+        """cmap/norm/data are taken from a mappable when values is None.
+
+        Test scenario:
+            A scatter mappable's array drives the histogram (4 points,
+            4 bins -> 4 bars) with no explicit values.
+        """
+        fig2, main_ax = plt.subplots()
+        sc = main_ax.scatter(
+            [0, 1, 2, 3], [0, 1, 0, 1], c=[1.0, 2.0, 3.0, 4.0], cmap="plasma"
+        )
+        bars = histogram_legend(ax, mappable=sc, bins=4)
+        assert len(bars) == 4, f"Expected 4 bars from the mappable array, got {len(bars)}"
+        plt.close(fig2)
+
+    def test_horizontal_orientation(self, ax):
+        """Horizontal orientation draws barh bars.
+
+        Test scenario:
+            orientation='horizontal' still yields one bar per bin.
+        """
+        bars = histogram_legend(
+            ax, [0.0, 1.0, 2.0, 3.0], cmap="viridis", bins=2, orientation="horizontal"
+        )
+        assert len(bars) == 2, f"Expected 2 horizontal bars, got {len(bars)}"
+
+    def test_non_finite_values_dropped(self, ax):
+        """NaN/inf entries are filtered before histogramming.
+
+        Test scenario:
+            A values array with NaNs still histograms the finite part.
+        """
+        bars = histogram_legend(
+            ax, [0.0, np.nan, 1.0, np.inf, 2.0], cmap="viridis", bins=2
+        )
+        assert len(bars) == 2, "Non-finite values should be dropped, not crash"
+
+    def test_no_values_and_no_mappable_raises(self, ax):
+        """Calling with neither values nor a mappable raises ValueError.
+
+        Test scenario:
+            Missing data source is rejected.
+        """
+        with pytest.raises(ValueError, match="Provide `values`"):
+            histogram_legend(ax)
+
+    def test_all_non_finite_raises(self, ax):
+        """All-non-finite values raise ValueError.
+
+        Test scenario:
+            No finite data to histogram is rejected.
+        """
+        with pytest.raises(ValueError, match="No finite values"):
+            histogram_legend(ax, [np.nan, np.inf], cmap="viridis")
+
+    def test_invalid_orientation_raises(self, ax):
+        """An invalid orientation raises ValueError.
+
+        Test scenario:
+            orientation must be vertical or horizontal.
+        """
+        with pytest.raises(ValueError, match="orientation must be"):
+            histogram_legend(ax, [0.0, 1.0], cmap="viridis", orientation="diagonal")

--- a/tests/test_vector_glyph.py
+++ b/tests/test_vector_glyph.py
@@ -90,6 +90,16 @@ class TestVectorGlyphInit:
         with pytest.raises(ValueError, match="not correct"):
             VectorGlyph(*field, nope=1)
 
+    def test_cbar_initialized_to_none(self, field):
+        """`cbar` is None before plot (L1 fix).
+
+        Test scenario:
+            Accessing `cbar` on a fresh glyph returns None rather than
+            raising AttributeError, matching ScatterGlyph/PolygonGlyph.
+        """
+        glyph = VectorGlyph(*field)
+        assert glyph.cbar is None, "cbar should be initialized to None in __init__"
+
 
 class TestVectorGlyphPlot:
     """Tests for VectorGlyph.plot."""

--- a/tests/test_vector_glyph.py
+++ b/tests/test_vector_glyph.py
@@ -1,0 +1,226 @@
+"""Tests for cleopatra.vector_glyph.VectorGlyph (T3.1)."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.quiver import Barbs, Quiver, QuiverKey
+
+from cleopatra.vector_glyph import VECTOR_DEFAULT_OPTIONS, VectorGlyph
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def field():
+    """A small 3x3 vector field with a known magnitude range.
+
+    Returns:
+        tuple: (x, y, u, v) arrays where u=3, v=4 so |vec| = 5.
+    """
+    x, y = np.meshgrid(np.arange(3.0), np.arange(3.0))
+    u = np.full_like(x, 3.0)
+    v = np.full_like(y, 4.0)
+    return x, y, u, v
+
+
+class TestVectorGlyphInit:
+    """Tests for VectorGlyph.__init__ and the magnitude property."""
+
+    def test_stores_components_as_arrays(self, field):
+        """Inputs are stored as numpy arrays.
+
+        Test scenario:
+            All four coordinate/component inputs become ndarrays.
+        """
+        glyph = VectorGlyph(*field)
+        assert all(
+            isinstance(a, np.ndarray)
+            for a in (glyph.x, glyph.y, glyph.u, glyph.v)
+        ), "x/y/u/v should be stored as ndarrays"
+
+    def test_magnitude_is_hypot(self, field):
+        """The magnitude property is hypot(u, v).
+
+        Test scenario:
+            u=3, v=4 -> every magnitude is 5.
+        """
+        glyph = VectorGlyph(*field)
+        assert np.allclose(glyph.magnitude, 5.0), (
+            f"Magnitude should be 5 everywhere, got {glyph.magnitude}"
+        )
+
+    def test_ticks_spacing_defaults_none(self, field):
+        """ticks_spacing defaults to None for auto-derivation.
+
+        Test scenario:
+            The option dict leaves ticks_spacing unset.
+        """
+        glyph = VectorGlyph(*field)
+        assert glyph.default_options["ticks_spacing"] is None, (
+            "ticks_spacing should default to None"
+        )
+
+    def test_mismatched_uv_raises(self, field):
+        """u and v of different shapes raise ValueError.
+
+        Test scenario:
+            Shape mismatch between u and v is rejected.
+        """
+        x, y, u, _ = field
+        with pytest.raises(ValueError, match="same shape"):
+            VectorGlyph(x, y, u, np.ones(2))
+
+    def test_invalid_kwarg_raises(self, field):
+        """An unknown kwarg is rejected by the strict merge.
+
+        Test scenario:
+            A key absent from VECTOR_DEFAULT_OPTIONS raises ValueError.
+        """
+        with pytest.raises(ValueError, match="not correct"):
+            VectorGlyph(*field, nope=1)
+
+
+class TestVectorGlyphPlot:
+    """Tests for VectorGlyph.plot."""
+
+    def test_quiver_returns_quiver_with_magnitude(self, field):
+        """quiver returns a Quiver carrying the magnitude array.
+
+        Test scenario:
+            kind='quiver' -> Quiver mappable whose array is the
+            magnitude (5 everywhere) and a colorbar is attached.
+        """
+        glyph = VectorGlyph(*field)
+        fig, ax, im = glyph.plot(kind="quiver")
+        assert isinstance(im, Quiver), f"Expected Quiver, got {type(im)}"
+        assert np.allclose(im.get_array(), 5.0), "Quiver array should be the magnitude"
+        assert glyph.cbar is not None, "A colorbar should be attached"
+
+    def test_barbs_returns_barbs(self, field):
+        """barbs returns a Barbs mappable.
+
+        Test scenario:
+            kind='barbs' -> Barbs artist with the magnitude array.
+        """
+        glyph = VectorGlyph(*field)
+        _, _, im = glyph.plot(kind="barbs")
+        assert isinstance(im, Barbs), f"Expected Barbs, got {type(im)}"
+        assert np.allclose(im.get_array(), 5.0), "Barbs array should be the magnitude"
+
+    def test_streamplot_returns_linecollection_with_array(self):
+        """streamplot returns a LineCollection carrying the magnitude.
+
+        Test scenario:
+            On a regular grid, kind='streamplot' yields lines whose
+            colour array is populated (non-None).
+        """
+        y, x = np.mgrid[0:5, 0:5].astype(float)
+        u = np.ones_like(x)
+        v = np.ones_like(y)
+        glyph = VectorGlyph(x, y, u, v)
+        _, _, im = glyph.plot(kind="streamplot")
+        assert im.get_array() is not None, "Streamplot lines should carry a colour array"
+        assert glyph.cbar is not None, "A colorbar should be attached"
+
+    def test_unknown_kind_raises(self, field):
+        """An unrecognised kind raises ValueError before drawing.
+
+        Test scenario:
+            kind='blah' is rejected with a helpful message.
+        """
+        glyph = VectorGlyph(*field)
+        with pytest.raises(ValueError, match="unknown vector kind"):
+            glyph.plot(kind="blah")
+
+    def test_levels_produce_boundary_norm(self, field):
+        """An integer `levels` discretises the magnitude colour scale.
+
+        Test scenario:
+            levels=3 -> the quiver norm is a BoundaryNorm.
+        """
+        glyph = VectorGlyph(*field, levels=3, vmin=0.0, vmax=6.0)
+        _, _, im = glyph.plot(kind="quiver")
+        assert isinstance(im.norm, mcolors.BoundaryNorm), (
+            f"levels should yield a BoundaryNorm, got {type(im.norm)}"
+        )
+
+    def test_plot_on_supplied_axes(self, field):
+        """Plotting onto a supplied axes reuses that axes/figure.
+
+        Test scenario:
+            Passing ax to plot draws on it and returns its figure.
+        """
+        fig, ax = plt.subplots()
+        glyph = VectorGlyph(*field)
+        out_fig, out_ax, _ = glyph.plot(ax=ax)
+        assert out_ax is ax, "Should draw on the supplied axes"
+        assert out_fig is fig, "Should return the supplied axes' figure"
+
+    def test_title_override(self, field):
+        """A title passed to plot is applied to the axes.
+
+        Test scenario:
+            plot(title=...) sets the axes title.
+        """
+        glyph = VectorGlyph(*field)
+        _, ax, _ = glyph.plot(title="Wind")
+        assert ax.get_title() == "Wind", f"Unexpected title: {ax.get_title()}"
+
+    def test_scale_forwarded_to_quiver(self, field):
+        """The `scale` option is forwarded to quiver.
+
+        Test scenario:
+            scale=50 -> the Quiver's scale attribute is 50.
+        """
+        glyph = VectorGlyph(*field, scale=50)
+        _, _, im = glyph.plot(kind="quiver")
+        assert im.scale == 50, f"Expected quiver scale 50, got {im.scale}"
+
+
+class TestVectorGlyphAddKey:
+    """Tests for VectorGlyph.add_key."""
+
+    def test_add_key_returns_quiverkey(self, field):
+        """add_key returns a QuiverKey with the requested label.
+
+        Test scenario:
+            A labelled key is created for a quiver plot.
+        """
+        glyph = VectorGlyph(*field)
+        _, _, im = glyph.plot(kind="quiver")
+        key = glyph.add_key(im, value=5.0, label="5 m/s")
+        assert isinstance(key, QuiverKey), f"Expected QuiverKey, got {type(key)}"
+        assert key.text.get_text() == "5 m/s", f"Unexpected label: {key.text.get_text()}"
+
+    def test_add_key_default_label_is_value(self, field):
+        """With no label, the numeric value is rendered.
+
+        Test scenario:
+            add_key(value=7) -> label text '7'.
+        """
+        glyph = VectorGlyph(*field)
+        _, _, im = glyph.plot(kind="quiver")
+        key = glyph.add_key(im, value=7.0)
+        assert key.text.get_text() == "7", f"Default label should be '7', got {key.text.get_text()}"
+
+
+def test_vector_default_options_extend_style_defaults():
+    """VECTOR_DEFAULT_OPTIONS is a superset of the shared style defaults.
+
+    Test scenario:
+        The module-level options dict carries both the base style keys
+        and the vector-specific additions.
+    """
+    assert "figsize" in VECTOR_DEFAULT_OPTIONS, "Should inherit base style keys"
+    assert "density" in VECTOR_DEFAULT_OPTIONS, "Should add vector keys"

--- a/tests/test_vector_glyph.py
+++ b/tests/test_vector_glyph.py
@@ -143,6 +143,41 @@ class TestVectorGlyphPlot:
         assert im.get_array() is not None, "Streamplot lines should carry a colour array"
         assert glyph.cbar is not None, "A colorbar should be attached"
 
+    def test_streamplot_clim_pinned_to_tick_range(self):
+        """streamplot colour limits match the tick range (L2 fix).
+
+        Test scenario:
+            On the linear path, the LineCollection clim equals the
+            colorbar tick range (ticks[0], ticks[-1]) so colours and the
+            colorbar agree — matching the quiver/barbs behaviour.
+        """
+        y, x = np.mgrid[0:5, 0:5].astype(float)
+        u = np.full_like(x, 3.0)
+        v = np.full_like(y, 4.0)
+        glyph = VectorGlyph(x, y, u, v, vmin=0.0, vmax=10.0, ticks_spacing=2.0)
+        _, _, im = glyph.plot(kind="streamplot")
+        ticks = glyph.get_ticks()
+        assert im.get_clim() == (ticks[0], ticks[-1]), (
+            f"streamplot clim should equal the tick range, got {im.get_clim()}"
+        )
+
+    def test_quiver_clim_pinned_to_tick_range(self):
+        """quiver colour limits also match the tick range (parity check).
+
+        Test scenario:
+            quiver's clim equals (ticks[0], ticks[-1]) on the linear
+            path, the behaviour streamplot is aligned to.
+        """
+        x, y = np.meshgrid(np.arange(3.0), np.arange(3.0))
+        u = np.full_like(x, 3.0)
+        v = np.full_like(y, 4.0)
+        glyph = VectorGlyph(x, y, u, v, vmin=0.0, vmax=10.0, ticks_spacing=2.0)
+        _, _, im = glyph.plot(kind="quiver")
+        ticks = glyph.get_ticks()
+        assert im.get_clim() == (ticks[0], ticks[-1]), (
+            f"quiver clim should equal the tick range, got {im.get_clim()}"
+        )
+
     def test_unknown_kind_raises(self, field):
         """An unrecognised kind raises ValueError before drawing.
 

--- a/uv.lock
+++ b/uv.lock
@@ -412,7 +412,7 @@ notebook = [
 requires-dist = [
     { name = "ffmpeg-python" },
     { name = "hpc-utils", specifier = ">=0.1.4" },
-    { name = "matplotlib", specifier = ">=3.8.4" },
+    { name = "matplotlib", specifier = ">=3.9" },
     { name = "mercantile", marker = "extra == 'tiles'", specifier = ">=1.2.1" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "pillow", marker = "extra == 'tiles'", specifier = ">=12.1.1" },


### PR DESCRIPTION
## Summary

Adds the matplotlib primitives needed to port `earthkit-plots` into the cleopatra abstraction layer (planning: `planning/digital-earth/cleopatra-tasks.md`). All *generic* matplotlib code (new glyph types, the shared scalar-mapping contract, legend helpers) lands here with its own tests; Digital-Earth only wires pyramids data into it.

Every colour-by-value glyph routes through one shared helper (`Glyph._prepare_scalar_mapping`), so `vmin`/`vmax`/`levels`/`color_scale` behave identically across `ArrayGlyph`, `ScatterGlyph`, `VectorGlyph`, `PolygonGlyph`, and the coloured `StatisticalGlyph` paths.

## What's included

| Task | What landed |
|------|-------------|
| **T0.0** | `Glyph._resolve_limits` + `_prepare_scalar_mapping` — the shared resolve-limits → ticks_spacing → write-back → `get_ticks` → norm/cbar pipeline. `ArrayGlyph` output verified unchanged. |
| **T0.4** | `styles.disjoint_legend` — categorical swatch legend (discrete counterpart to a colorbar). |
| **T2.1** | `scatter_glyph.ScatterGlyph` — coloured/uncoloured point clouds. |
| **T3.1** | `vector_glyph.VectorGlyph` — quiver / barbs / streamplot coloured by magnitude, plus `add_key`. |
| **T4.1c** | `MeshGlyph.plot(filled=False)` → line `tricontour` for node data (`tripcolor`/`tricontourf` unchanged). |
| **T5.3c** | `styles.colorbar_legend` + `styles.histogram_legend` — completes the three reusable legend styles. |
| **T7.2c** | `polygon_glyph.PolygonGlyph` — filled choropleth / outline mode, geometry-agnostic (no geopandas). |
| **T7.3c** | `line_glyph.LineGlyph` (line/bar/fill_between) + `StatisticalGlyph` `boxplot`/`multiboxplot`/`stripes`. |

New submodules (`scatter_glyph`, `vector_glyph`, `polygon_glyph`, `line_glyph`) are registered in the package-surface allow-list; the package still re-exports nothing at the top level (by design).

## Testing

- Full suite: **595 passed, 3 skipped**.
- Doctests pass across all new/changed modules.
- Tests favour artist/norm-state assertions over pixel baselines (per the planning note on Windows/freetype brittleness).

## Notes / out of scope

- **Cutting a release** (the `REL` tracker row) is intentionally not included — it's a separate CI/release step.
- A pre-existing flaky doctest in `styles.MidpointNormalize` (masked-array repr) fails identically on `main`; left untouched.


# Issues

This PR implements the following tasks (auto-close on merge):

- Fixes #118 — T0.0 shared `_prepare_scalar_mapping` helper
- Fixes #119 — T0.4 categorical/disjoint legend
- Fixes #120 — T2.1 `ScatterGlyph`
- Fixes #121 — T3.1 `VectorGlyph`
- Fixes #122 — T4.1c `MeshGlyph` line `tricontour`
- Fixes #123 — T5.3c colorbar/disjoint/histogram legend styles
- Fixes #124 — T7.2c `PolygonGlyph`
- Fixes #125 — T7.3c `LineGlyph` + `StatisticalGlyph` box/multibox/stripes

Related (not closed by this PR): #126 — REL: cut a cleopatra release (after these land).
