### PR TITLE
feat(glyph)!: mappable + add_colorbar toggle, and ax-on-plot / fig-on-constructor standardization

### DIFF
--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -58,6 +58,7 @@ DEFAULT_OPTIONS = {
     "center": None,
     "extend": None,
     "cbar_kwargs": None,
+    "add_colorbar": True,
 }
 DEFAULT_OPTIONS = STYLE_DEFAULTS | DEFAULT_OPTIONS
 
@@ -520,6 +521,11 @@ class ArrayGlyph(Glyph):
         # match; `MaskedArray.count()` would miss NaN cells.
         first_frame = array[0, :, :] if len(shape) == 3 else array
         self.num_domain_cells = len(get_indices2(first_frame, [np.nan]))
+        # Mappable (the colour-mapped artist) and colorbar handles are
+        # populated by `plot`/`animate`. Initialised here so they are always
+        # reachable as public attributes, even before the first render.
+        self.im = None
+        self.cbar = None
 
     @property
     def arr(self):
@@ -1563,6 +1569,13 @@ class ArrayGlyph(Glyph):
                         Maximum value for color scaling, by default max(array).
 
                 Color bar options:
+                    add_colorbar : bool, optional
+                        Whether to draw the glyph's own color bar, by
+                        default True. Set to False for shared-axes
+                        composition, where the host owns a single
+                        aggregated color bar; then `self.cbar` stays
+                        None and no axes space is taken by a color bar.
+                        The mappable is still reachable via `self.im`.
                     cbar_orientation : str, optional
                         Orientation of the color bar, by default 'vertical'.
                         Can be 'horizontal' or 'vertical'.
@@ -1659,6 +1672,14 @@ class ArrayGlyph(Glyph):
             tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]: A tuple containing:
                 - fig: The matplotlib Figure object
                 - ax: The matplotlib Axes object
+
+            The colour-mapped artist (the ``ScalarMappable`` — e.g. the
+            ``AxesImage`` for ``imshow``, the ``QuadMesh`` for
+            ``pcolormesh``, the ``QuadContourSet`` for
+            ``contour``/``contourf``, or the RGB ``AxesImage``) is also
+            stored on the instance as ``self.im`` after this call, so a
+            caller can attach a colorbar/legend or query the colour
+            limits without scraping ``ax.images``/``ax.collections``.
 
         Raises:
             ValueError: If an invalid keyword argument is provided.
@@ -1996,7 +2017,8 @@ class ArrayGlyph(Glyph):
         fig, ax = self.fig, self.ax
 
         if self.rgb:
-            ax.imshow(arr, extent=self.extent)
+            self.im = ax.imshow(arr, extent=self.extent)
+            self.cbar = None
         else:
             # if user did not input ticks spacing use the calculated one.
             if "ticks_spacing" in kwargs.keys():
@@ -2045,9 +2067,13 @@ class ArrayGlyph(Glyph):
             im, cbar_kw = self._plot_im_get_cbar_kw(
                 ax, arr, ticks, kind=effective_kind
             )
+            self.im = im
 
-            # Create colorbar
-            self.cbar = self.create_color_bar(ax, im, cbar_kw)
+            # Create colorbar, unless the caller opted out (e.g. shared-axes
+            # composition where the host owns a single aggregated colorbar).
+            self.cbar = None
+            if self.default_options["add_colorbar"]:
+                self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
         ax.set_title(
             self.default_options["title"], fontsize=self.default_options["title_size"]
@@ -2454,6 +2480,13 @@ class ArrayGlyph(Glyph):
                         Maximum value for color scaling, by default max(array).
 
                 Color bar options:
+                    add_colorbar : bool, optional
+                        Whether to draw the glyph's own color bar, by
+                        default True. Set to False for shared-axes
+                        composition, where the host owns a single
+                        aggregated color bar; then `self.cbar` stays
+                        None and no axes space is taken by a color bar.
+                        The mappable is still reachable via `self.im`.
                     cbar_orientation : str, optional
                         Orientation of the color bar, by default 'vertical'.
                         Can be 'horizontal' or 'vertical'.
@@ -2677,9 +2710,13 @@ class ArrayGlyph(Glyph):
 
         ticks = self.get_ticks()
         im, cbar_kw = self._plot_im_get_cbar_kw(ax, frame_0, ticks)
+        self.im = im
 
-        # Create colorbar (stored on the instance, mirroring `plot`).
-        self.cbar = self.create_color_bar(ax, im, cbar_kw)
+        # Create colorbar (stored on the instance, mirroring `plot`), unless
+        # the caller opted out via `add_colorbar=False`.
+        self.cbar = None
+        if self.default_options["add_colorbar"]:
+            self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
         ax.set_title(
             self.default_options["title"], fontsize=self.default_options["title_size"]

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -192,6 +192,14 @@ class ArrayGlyph(Glyph):
             of per-cell value labels drawn when `display_cell_value=True`.
             (The legacy alias `no_elem` still works but is deprecated.)
         anim (matplotlib.animation.FuncAnimation): The animation object if created.
+        im (matplotlib.cm.ScalarMappable): The colour-mapped artist produced by
+            the most recent `plot`/`animate` call (e.g. the `AxesImage` for
+            `imshow`, the `QuadMesh` for `pcolormesh`, the `QuadContourSet`
+            for `contour`/`contourf`, or the RGB `AxesImage`). `None` before
+            the first render. Lets a caller attach a colorbar/legend or query
+            the colour limits without scraping `ax.images`/`ax.collections`.
+        cbar (matplotlib.colorbar.Colorbar): The colorbar drawn by the glyph,
+            or `None` when none was drawn (RGB, or `add_colorbar=False`).
 
     Notes:
         This class provides methods for:
@@ -2541,6 +2549,11 @@ class ArrayGlyph(Glyph):
         Returns:
             matplotlib.animation.FuncAnimation: The animation object that can be displayed
                 in a notebook or saved to a file.
+
+            As with `plot`, the first-frame colour-mapped artist is stored on
+            the instance as ``self.im`` (and the colorbar, when drawn, on
+            ``self.cbar``), so a caller can attach a host-owned
+            colorbar/legend without scraping the axes.
 
         Raises:
             ValueError: If an invalid keyword argument is provided.

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -273,10 +273,16 @@ class ArrayGlyph(Glyph):
             cutoff: Clip the range of pixel values for each band, by default None.
                 Takes only pixel values from 0 to the value of the cutoff and scales them back to between 0 and 1.
                 Should be a list with one value per band.
-            ax: A pre-existing axes to plot on, by default None.
-                If None, a new axes will be created.
-            fig: A pre-existing figure to plot on, by default None.
-                If None, a new figure will be created.
+            ax: A pre-existing axes to plot on, by default None. Bound to
+                the glyph and used by `plot`/`animate` unless `plot(ax=...)`
+                overrides it. Passing `ax` alone is enough — its parent
+                figure is derived automatically; if None (and no axes is
+                given to `plot`), a new axes is created.
+            fig: A pre-existing figure to bind, by default None. `fig` is a
+                construction-time binding only (it is never a `plot`
+                parameter — `plot` derives the figure from its axes). When
+                `ax` is given, `fig` is optional; if both are None a new
+                figure is created at render time.
             percentile: The percentile value to be used for scaling the array values, by default None.
                 Used to enhance contrast by stretching the histogram.
             **kwargs: Additional keyword arguments for customizing the plot.
@@ -1518,6 +1524,8 @@ class ArrayGlyph(Glyph):
         pid_color: str = "blue",
         pid_size: int | float = 10,
         kind: str = "auto",
+        ax: Axes | None = None,
+        title: str | None = None,
         **kwargs,
     ) -> tuple[Figure, Axes]:
         """Plot the array with customizable visualization options.
@@ -1562,6 +1570,17 @@ class ArrayGlyph(Glyph):
                 skipped for `"contour"` and `"contourf"` (which have
                 no per-cell grid). RGB compositing requires
                 `kind="imshow"`.
+            ax: Target axes to draw on, by default None. When given,
+                the plot is composed into this axes (and its parent
+                figure, via `ax.get_figure()`), mirroring the other
+                glyphs' `plot(ax=...)`. Resolution priority is
+                `plot(ax=)` > the axes bound at construction > a fresh
+                figure/axes. `fig` is intentionally not a parameter
+                here — it is a construction-time binding derived from
+                the axes.
+            title: Plot title, by default None. A convenience shortcut
+                equivalent to the `title` option; when given it
+                overrides the `title` set at construction.
             **kwargs: Additional keyword arguments for customizing the plot.
 
                 Plot appearance:
@@ -2018,8 +2037,18 @@ class ArrayGlyph(Glyph):
         else:
             effective_kind = kind
 
-        if self.fig is None:
+        # Axes resolution priority: explicit `plot(ax=)` wins, then the
+        # axes/figure bound at construction, otherwise a fresh figure/axes.
+        # `fig` is never a plot parameter — it is derived from the axes
+        # (`ax.get_figure()`), keeping `fig` a construction-time binding.
+        if ax is not None:
+            self.ax = ax
+            self.fig = ax.get_figure()
+        elif self.fig is None:
             self.fig, self.ax = self.create_figure_axes()
+
+        if title is not None:
+            self.default_options["title"] = title
 
         arr = self.arr
         fig, ax = self.fig, self.ax

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -235,6 +235,10 @@ class ArrayGlyph(Glyph):
     ```
     """
 
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    #: The right-hand side is the module-level ``DEFAULT_OPTIONS`` dict.
+    DEFAULT_OPTIONS = DEFAULT_OPTIONS
+
     def __init__(
         self,
         array: np.ndarray,

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -39,11 +39,11 @@ from matplotlib.colors import Colormap
 from matplotlib.figure import Figure
 from PIL import Image
 
-from cleopatra.glyph import Glyph
+from cleopatra.glyph import Glyph, _root_figure
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale  # re-exported for convenience  # noqa: F401
 
-DEFAULT_OPTIONS = {
+ARRAY_DEFAULT_OPTIONS = {
     "vmin": None,
     "vmax": None,
     "num_size": 8,
@@ -60,7 +60,10 @@ DEFAULT_OPTIONS = {
     "cbar_kwargs": None,
     "add_colorbar": True,
 }
-DEFAULT_OPTIONS = STYLE_DEFAULTS | DEFAULT_OPTIONS
+ARRAY_DEFAULT_OPTIONS = STYLE_DEFAULTS | ARRAY_DEFAULT_OPTIONS
+#: Backwards-compatible alias for the array glyph's default options
+#: (named like the other glyphs' `*_DEFAULT_OPTIONS` constants).
+DEFAULT_OPTIONS = ARRAY_DEFAULT_OPTIONS
 
 #: Tuple of accepted `kind=` values for `ArrayGlyph.plot`.
 VALID_PLOT_KINDS = ("auto", "imshow", "pcolormesh", "contour", "contourf")
@@ -236,8 +239,7 @@ class ArrayGlyph(Glyph):
     """
 
     #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
-    #: The right-hand side is the module-level ``DEFAULT_OPTIONS`` dict.
-    DEFAULT_OPTIONS = DEFAULT_OPTIONS
+    DEFAULT_OPTIONS = ARRAY_DEFAULT_OPTIONS
 
     def __init__(
         self,
@@ -457,7 +459,9 @@ class ArrayGlyph(Glyph):
 
         ```
         """
-        super().__init__(default_options=DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs)
+        super().__init__(
+            default_options=ARRAY_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
+        )
         # first replace the no_data_value by nan
         # convert the array to float32 to be able to replace the no data value with nan
         if exclude_value is not np.nan:
@@ -2047,7 +2051,7 @@ class ArrayGlyph(Glyph):
         # (`ax.get_figure()`), keeping `fig` a construction-time binding.
         if ax is not None:
             self.ax = ax
-            self.fig = ax.get_figure()
+            self.fig = _root_figure(ax)
         elif self.fig is None:
             self.fig, self.ax = self.create_figure_axes()
 

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -34,6 +34,27 @@ SUPPORTED_VIDEO_FORMAT = ["gif", "mov", "avi", "mp4"]
 MAX_DISCRETE_LEVELS = 1000
 
 
+def _root_figure(ax: Axes) -> Figure:
+    """Return the top-level `Figure` that owns `ax`, across matplotlib versions.
+
+    Prefers `Axes.get_figure(root=True)` (matplotlib >= 3.10), which returns
+    the root `Figure` even when the axes lives on a `SubFigure` and avoids the
+    3.10 deprecation warning attached to the bare `get_figure()`. Falls back to
+    the plain `get_figure()` on older matplotlib where the `root` keyword does
+    not exist (the project's 3.8.4 floor).
+
+    Args:
+        ax: The axes whose owning figure is wanted.
+
+    Returns:
+        Figure: The top-level figure for `ax`.
+    """
+    try:
+        return ax.get_figure(root=True)
+    except TypeError:
+        return ax.get_figure()
+
+
 class Glyph:
     """Base class for cleopatra visualization glyphs.
 
@@ -139,7 +160,19 @@ class Glyph:
         # given); passing neither leaves both unset until render time.
         if ax is not None:
             self.ax = ax
-            self.fig = fig if fig is not None else ax.get_figure()
+            if fig is not None:
+                # A mismatched (fig, ax) pair leaves self.fig and
+                # self.ax.figure disagreeing — almost always a caller mistake.
+                if fig is not _root_figure(ax):
+                    warnings.warn(
+                        "The given `fig` is not the figure that owns `ax`; "
+                        "the axes' own figure is what will be drawn on. Pass "
+                        "only `ax` (its figure is derived automatically).",
+                        stacklevel=2,
+                    )
+                self.fig = fig
+            else:
+                self.fig = _root_figure(ax)
         elif fig is not None:
             self.fig = fig
             self.ax = None
@@ -170,6 +203,14 @@ class Glyph:
         keys can be inspected **without constructing an instance** (and
         therefore without tripping the strict unknown-kwarg check in
         `_merge_kwargs`). The keys differ per glyph subclass.
+
+        This reports the class's *default* option set. For every concrete
+        glyph subclass that equals the instance's accepted keys (each
+        subclass passes the same dict to `__init__`). The base `Glyph`
+        reports the shared `STYLE_DEFAULTS`; an instance built with a
+        custom injected `default_options` is the one case where the two
+        can differ, so base `Glyph` is not part of the introspection
+        contract.
 
         Returns:
             set[str]: The accepted option keys for this glyph class.

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import inspect
 import math
 import warnings
 
@@ -20,7 +21,7 @@ from matplotlib import animation
 from matplotlib.animation import FuncAnimation
 from matplotlib.axes import Axes
 from matplotlib.colorbar import Colorbar
-from matplotlib.figure import Figure
+from matplotlib.figure import Figure, SubFigure
 from matplotlib.ticker import LogFormatter
 
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
@@ -34,25 +35,63 @@ SUPPORTED_VIDEO_FORMAT = ["gif", "mov", "avi", "mp4"]
 MAX_DISCRETE_LEVELS = 1000
 
 
+def _get_figure_supports_root(get_figure) -> bool:
+    """Return True if `get_figure` accepts a `root` keyword argument.
+
+    The `root` parameter was added to `Axes.get_figure` in matplotlib 3.10.
+    Detected by signature inspection (rather than a broad `try/except`) so an
+    unrelated `TypeError` from `get_figure` itself is never swallowed.
+    """
+    try:
+        return "root" in inspect.signature(get_figure).parameters
+    except (TypeError, ValueError):
+        return False
+
+
 def _root_figure(ax: Axes) -> Figure:
     """Return the top-level `Figure` that owns `ax`, across matplotlib versions.
 
-    Prefers `Axes.get_figure(root=True)` (matplotlib >= 3.10), which returns
-    the root `Figure` even when the axes lives on a `SubFigure` and avoids the
-    3.10 deprecation warning attached to the bare `get_figure()`. Falls back to
-    the plain `get_figure()` on older matplotlib where the `root` keyword does
-    not exist (the project's 3.8.4 floor).
+    On matplotlib >= 3.10 this uses `Axes.get_figure(root=True)`, which returns
+    the root `Figure` even when the axes lives on a `SubFigure` (and avoids the
+    3.10 deprecation warning attached to the bare `get_figure()`). On older
+    matplotlib (down to the project's 3.8.4 floor) the `root` keyword does not
+    exist, so it climbs out of any `SubFigure` to the owning `Figure` manually.
 
     Args:
-        ax: The axes whose owning figure is wanted.
+        ax: The axes whose top-level figure is wanted.
 
     Returns:
         Figure: The top-level figure for `ax`.
     """
-    try:
-        return ax.get_figure(root=True)
-    except TypeError:
-        return ax.get_figure()
+    get_figure = ax.get_figure
+    if _get_figure_supports_root(get_figure):
+        return get_figure(root=True)
+    fig = get_figure()
+    seen: set[int] = set()
+    while isinstance(fig, SubFigure) and id(fig) not in seen:
+        seen.add(id(fig))
+        fig = fig.figure
+    return fig
+
+
+def _immediate_figure(ax: Axes) -> Figure:
+    """Return the figure `ax` is directly attached to (its immediate parent).
+
+    Deprecation-safe counterpart to `_root_figure`: on matplotlib >= 3.10 it
+    passes `root=False` explicitly; on older matplotlib it calls the bare
+    `get_figure()`. For an axes on a `SubFigure` this is that `SubFigure`; for
+    an ordinary axes it is the same object as `_root_figure(ax)`.
+
+    Args:
+        ax: The axes whose immediate parent figure is wanted.
+
+    Returns:
+        Figure: The figure (or sub-figure) `ax` is directly attached to.
+    """
+    get_figure = ax.get_figure
+    if _get_figure_supports_root(get_figure):
+        return get_figure(root=False)
+    return get_figure()
 
 
 class Glyph:
@@ -165,7 +204,9 @@ class Glyph:
             if fig is not None:
                 # A mismatched (fig, ax) pair leaves self.fig and
                 # self.ax.figure disagreeing — almost always a caller mistake.
-                if fig is not _root_figure(ax):
+                # `fig` is fine if it is either the axes' immediate parent
+                # (e.g. a SubFigure) or its top-level root figure.
+                if fig is not _immediate_figure(ax) and fig is not _root_figure(ax):
                     warnings.warn(
                         "The given `fig` is not the figure that owns `ax`; "
                         "the axes' own figure is what will be drawn on. Pass "

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -43,8 +43,14 @@ class Glyph:
     Args:
         default_options: Default plot options dict. Subclasses provide
             their own defaults merged with `STYLE_DEFAULTS`.
-        fig: Pre-existing matplotlib figure. Default is None.
-        ax: Pre-existing matplotlib axes. Default is None.
+        fig: Pre-existing matplotlib figure to bind. Default is None.
+            An `ax` fully determines its figure, so `fig` is optional even
+            when `ax` is given; when both are passed the explicit `fig`
+            is kept as the figure handle.
+        ax: Pre-existing matplotlib axes to bind. Default is None. Passing
+            `ax` on its own is supported — the figure is derived from it
+            via `ax.get_figure()` (the axes is no longer dropped when
+            `fig` is omitted).
         **kwargs: Override any key in `default_options`.
 
     Examples:
@@ -76,6 +82,22 @@ class Glyph:
             True
 
             ```
+        - Provide only an axes; the figure is derived from it:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.glyph import Glyph
+            >>> from cleopatra.styles import DEFAULT_OPTIONS
+            >>> opts = DEFAULT_OPTIONS.copy()
+            >>> opts["vmin"] = None
+            >>> opts["vmax"] = None
+            >>> fig, ax = plt.subplots()
+            >>> g = Glyph(default_options=opts, ax=ax)
+            >>> g.ax is ax
+            True
+            >>> g.fig is ax.get_figure()
+            True
+
+            ```
 
     See Also:
         cleopatra.array_glyph.ArrayGlyph: Glyph subclass for
@@ -96,9 +118,17 @@ class Glyph:
         self._vmin: float | None = None
         self._vmax: float | None = None
         self.ticks_spacing: float | None = None
-        if fig is not None:
-            self.fig = fig
+        # Resolve the (fig, ax) binding. An `ax` fully determines its
+        # figure, so accept `ax` on its own and derive the figure from it
+        # rather than dropping the axes when `fig` is omitted. An explicit
+        # `fig` is honoured (and wins for the figure handle when both are
+        # given); passing neither leaves both unset until render time.
+        if ax is not None:
             self.ax = ax
+            self.fig = fig if fig is not None else ax.get_figure()
+        elif fig is not None:
+            self.fig = fig
+            self.ax = None
         else:
             self.fig = None
             self.ax = None

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -41,6 +41,12 @@ class Glyph:
     normalization, colorbar creation, tick control, point overlays,
     and animation saving. Subclasses implement the actual rendering.
 
+    The accepted option keys are exposed per subclass via the
+    `DEFAULT_OPTIONS` class attribute, and can be inspected or filtered
+    *before* constructing an instance with the `option_keys` and
+    `filter_kwargs` classmethods (useful for safely forwarding a bag of
+    user-supplied styling kwargs).
+
     Args:
         default_options: Default plot options dict. Subclasses provide
             their own defaults merged with `STYLE_DEFAULTS`.

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -74,11 +74,13 @@ class Glyph:
         fig: Pre-existing matplotlib figure to bind. Default is None.
             An `ax` fully determines its figure, so `fig` is optional even
             when `ax` is given; when both are passed the explicit `fig`
-            is kept as the figure handle.
+            is kept as the figure handle. Passing a `fig` that does not own
+            the given `ax` emits a `UserWarning` (the explicit `fig` is
+            still honoured, but the two handles then disagree).
         ax: Pre-existing matplotlib axes to bind. Default is None. Passing
-            `ax` on its own is supported — the figure is derived from it
-            via `ax.get_figure()` (the axes is no longer dropped when
-            `fig` is omitted).
+            `ax` on its own is supported — its parent figure is derived
+            automatically (the axes is no longer dropped when `fig` is
+            omitted).
         **kwargs: Override any key in `default_options`.
 
     Examples:

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -23,6 +23,7 @@ from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure
 from matplotlib.ticker import LogFormatter
 
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale, MidpointNormalize
 
 SUPPORTED_VIDEO_FORMAT = ["gif", "mov", "avi", "mp4"]
@@ -106,6 +107,13 @@ class Glyph:
             unstructured meshes.
     """
 
+    #: The option keys this glyph accepts, as a class attribute so they can
+    #: be introspected/filtered *before* an instance exists (see
+    #: `option_keys`/`filter_kwargs`). Each subclass overrides this with its
+    #: own option dict (built as `STYLE_DEFAULTS | <glyph-specific>`); the
+    #: base value is the shared style defaults.
+    DEFAULT_OPTIONS: dict = STYLE_DEFAULTS
+
     def __init__(
         self,
         default_options: dict,
@@ -147,6 +155,83 @@ class Glyph:
     def default_options(self) -> dict:
         """Default plot options."""
         return self._default_options
+
+    @classmethod
+    def option_keys(cls) -> set[str]:
+        """Return the keyword-argument keys this glyph accepts.
+
+        Resolves from the class-level `DEFAULT_OPTIONS`, so the accepted
+        keys can be inspected **without constructing an instance** (and
+        therefore without tripping the strict unknown-kwarg check in
+        `_merge_kwargs`). The keys differ per glyph subclass.
+
+        Returns:
+            set[str]: The accepted option keys for this glyph class.
+
+        Examples:
+            - Inspect the keys a glyph accepts before building one:
+                ```python
+                >>> from cleopatra.scatter_glyph import ScatterGlyph
+                >>> keys = ScatterGlyph.option_keys()
+                >>> "cmap" in keys
+                True
+                >>> "totally_unknown" in keys
+                False
+
+                ```
+            - Different glyphs expose different keys:
+                ```python
+                >>> from cleopatra.polygon_glyph import PolygonGlyph
+                >>> "edgecolor" in PolygonGlyph.option_keys()
+                True
+
+                ```
+
+        See Also:
+            filter_kwargs: Drop the keys a glyph does not accept from a dict.
+        """
+        return set(cls.DEFAULT_OPTIONS)
+
+    @classmethod
+    def filter_kwargs(cls, kwargs: dict) -> dict:
+        """Return only the subset of `kwargs` whose keys this glyph accepts.
+
+        A convenience for callers that forward a bag of user-supplied
+        styling kwargs into a glyph: pre-filtering with this method lets
+        the construction succeed instead of raising on an unknown key.
+        Order and values are preserved; rejected keys are simply dropped.
+
+        Args:
+            kwargs: A mapping of candidate option keys to values.
+
+        Returns:
+            dict: The entries of `kwargs` whose keys are in `option_keys()`.
+
+        Examples:
+            - Keep only the accepted keys, then construct safely:
+                ```python
+                >>> from cleopatra.polygon_glyph import PolygonGlyph
+                >>> raw = {"cmap": "viridis", "edgecolor": "black", "bogus": 1}
+                >>> safe = PolygonGlyph.filter_kwargs(raw)
+                >>> sorted(safe)
+                ['cmap', 'edgecolor']
+                >>> safe["cmap"]
+                'viridis'
+
+                ```
+            - An empty mapping yields an empty mapping:
+                ```python
+                >>> from cleopatra.scatter_glyph import ScatterGlyph
+                >>> ScatterGlyph.filter_kwargs({})
+                {}
+
+                ```
+
+        See Also:
+            option_keys: The set of keys this glyph accepts.
+        """
+        keys = cls.option_keys()
+        return {key: val for key, val in kwargs.items() if key in keys}
 
     @property
     def anim(self) -> FuncAnimation:

--- a/src/cleopatra/line_glyph.py
+++ b/src/cleopatra/line_glyph.py
@@ -81,6 +81,9 @@ class LineGlyph(Glyph):
             ```
     """
 
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = LINE_DEFAULT_OPTIONS
+
     def __init__(
         self,
         x: np.ndarray,

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -91,6 +91,9 @@ class MeshGlyph(Glyph):
             ```
     """
 
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = MESH_DEFAULT_OPTIONS
+
     def __init__(
         self,
         node_x: np.ndarray,

--- a/src/cleopatra/polygon_glyph.py
+++ b/src/cleopatra/polygon_glyph.py
@@ -103,6 +103,9 @@ class PolygonGlyph(Glyph):
             norm/colorbar/ticks pipeline used for the filled path.
     """
 
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = POLYGON_DEFAULT_OPTIONS
+
     def __init__(
         self,
         polygons: Sequence[np.ndarray],

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -103,6 +103,9 @@ class ScatterGlyph(Glyph):
             norm/colorbar/ticks pipeline used for the coloured path.
     """
 
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = SCATTER_DEFAULT_OPTIONS
+
     def __init__(
         self,
         x: np.ndarray,

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -141,6 +141,12 @@ class StatisticalGlyph:
         ![one-histogram](./../images/statistical_glyph/one-histogram.png)
     """
 
+    #: Option keys this glyph accepts, exposed as a class attribute so they
+    #: can be introspected/filtered before an instance exists (see
+    #: `option_keys`/`filter_kwargs`). The right-hand side is the
+    #: module-level ``DEFAULT_OPTIONS`` dict.
+    DEFAULT_OPTIONS = DEFAULT_OPTIONS
+
     def __init__(
         self,
         values: Union[List, np.ndarray],
@@ -321,6 +327,64 @@ class StatisticalGlyph:
             ```
         """
         return self._default_options
+
+    @classmethod
+    def option_keys(cls) -> set:
+        """Return the keyword-argument keys this glyph accepts.
+
+        Resolves from the class-level ``DEFAULT_OPTIONS`` so the accepted
+        keys can be inspected without constructing an instance. Mirrors
+        ``cleopatra.glyph.Glyph.option_keys`` (``StatisticalGlyph`` is a
+        standalone class, not a ``Glyph`` subclass).
+
+        Returns:
+            set: The accepted option keys for this glyph class.
+
+        Examples:
+            - Inspect the accepted keys before building one:
+                ```python
+                >>> from cleopatra.statistical_glyph import StatisticalGlyph
+                >>> keys = StatisticalGlyph.option_keys()
+                >>> "bins" in keys
+                True
+                >>> "totally_unknown" in keys
+                False
+
+                ```
+
+        See Also:
+            filter_kwargs: Drop the keys this glyph does not accept.
+        """
+        return set(cls.DEFAULT_OPTIONS)
+
+    @classmethod
+    def filter_kwargs(cls, kwargs: Dict) -> Dict:
+        """Return only the subset of ``kwargs`` whose keys this glyph accepts.
+
+        Args:
+            kwargs: A mapping of candidate option keys to values.
+
+        Returns:
+            Dict: The entries of ``kwargs`` whose keys are in ``option_keys()``.
+
+        Examples:
+            - Keep only the accepted keys:
+                ```python
+                >>> from cleopatra.statistical_glyph import StatisticalGlyph
+                >>> raw = {"bins": 20, "alpha": 0.5, "bogus": 1}
+                >>> safe = StatisticalGlyph.filter_kwargs(raw)
+                >>> sorted(safe)
+                ['alpha', 'bins']
+                >>> safe["bins"]
+                20
+
+                ```
+
+        See Also:
+            option_keys: The set of keys this glyph accepts.
+        """
+        keys = cls.option_keys()
+        return {key: val for key, val in kwargs.items() if key in keys}
 
     def histogram(self, **kwargs) -> Tuple[Figure, Axes, Dict]:
         """Create a histogram from the stored numerical values.

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -166,6 +166,11 @@ class StatisticalGlyph:
                 are created when ``histogram()`` is called. When supplied,
                 the histogram is composed into the given axes and its parent
                 figure is inferred (unless ``fig`` is also passed explicitly).
+                The box/stripe renderers (``boxplot``, ``multiboxplot``,
+                ``stripes``) also fall back to this axes when their own
+                ``ax`` argument is omitted. Note these renderers take ``ax``
+                per call but never ``fig`` — the figure is bound here, at
+                construction.
             **kwargs: Additional keyword arguments to customize the histogram appearance.
                 Supported arguments include:
                 - figsize: Figure size as (width, height) in inches, by default (5, 5).
@@ -513,27 +518,54 @@ class StatisticalGlyph:
         hist = {"n": n, "bins": bins, "patches": patches}
         return fig, ax, hist
 
-    def _resolve_fig_ax(
-        self, ax: Axes | None, fig: Figure | None
-    ) -> Tuple[Figure, Axes]:
+    @staticmethod
+    def _reject_fig_kwarg(kwargs: dict) -> None:
+        """Reject a per-call `fig=` with a clear migration message.
+
+        `fig` is a construction-time binding, not a renderer parameter.
+        Because the renderers forward `**kwargs` to matplotlib, an absorbed
+        `fig=` would otherwise surface as a confusing downstream error, so
+        catch it explicitly here.
+
+        Args:
+            kwargs: The renderer's forwarded keyword arguments.
+
+        Raises:
+            TypeError: If `fig` is present in `kwargs`.
+        """
+        if "fig" in kwargs:
+            raise TypeError(
+                "`fig` is not a parameter of boxplot/multiboxplot/stripes; "
+                "bind the figure at construction instead: "
+                "StatisticalGlyph(values, fig=...)."
+            )
+
+    def _resolve_fig_ax(self, ax: Axes | None) -> Tuple[Figure, Axes]:
         """Return a `(fig, ax)` pair, creating one when none is given.
 
-        Unlike `histogram`, the renderers added in T7.3c compose into a
-        caller-supplied axes when provided (and never call `plt.show()`),
-        so they can be laid out into a larger figure.
+        These renderers compose into a caller-supplied axes when provided
+        (and never call `plt.show()`), so they can be laid out into a
+        larger figure. The figure is always derived from the axes —
+        `fig` is a construction-time binding (`StatisticalGlyph(..., fig=)`),
+        not a per-call parameter.
+
+        Resolution priority: the method's `ax` argument, then the axes
+        bound at construction (`self._ax`), then a new axes on the
+        figure bound at construction (`self._fig`), otherwise a brand-new
+        figure/axes.
 
         Args:
             ax: An existing axes to draw on, or None.
-            fig: An existing figure, or None. Ignored when `ax` is given
-                (the axes' own figure is used).
 
         Returns:
             Tuple[Figure, Axes]: The figure/axes to render into.
         """
+        if ax is None:
+            ax = self._ax
         if ax is not None:
             return ax.figure, ax
-        if fig is not None:
-            return fig, fig.add_subplot(111)
+        if self._fig is not None:
+            return self._fig, self._fig.add_subplot(111)
         return plt.subplots(figsize=self.default_options["figsize"])
 
     def _columns(self) -> List[np.ndarray]:
@@ -559,7 +591,6 @@ class StatisticalGlyph:
     def boxplot(
         self,
         ax: Axes = None,
-        fig: Figure = None,
         labels: Sequence[str] | None = None,
         notch: bool = False,
         showfliers: bool = True,
@@ -573,9 +604,11 @@ class StatisticalGlyph:
         `ax`/`fig` and does not call `plt.show()`.
 
         Args:
-            ax: Axes to draw on. A new figure/axes is created when both
-                `ax` and `fig` are None.
-            fig: Figure to add an axes to when `ax` is None.
+            ax: Axes to draw on. Falls back to the axes/figure bound at
+                construction (`StatisticalGlyph(..., ax=/fig=)`), and a
+                brand-new figure/axes is created when none is available.
+                `fig` is a construction-time binding, not a parameter
+                here.
             labels: Tick labels, one per box. Defaults to 1-based
                 series indices.
             notch: Draw notched boxes (a rough CI around the median).
@@ -603,7 +636,8 @@ class StatisticalGlyph:
 
                 ```
         """
-        fig, ax = self._resolve_fig_ax(ax, fig)
+        self._reject_fig_kwarg(kwargs)
+        fig, ax = self._resolve_fig_ax(ax)
         columns = self._columns()
         tick_labels = (
             list(labels) if labels is not None
@@ -639,7 +673,6 @@ class StatisticalGlyph:
         positions: Sequence[float] | None = None,
         labels: Sequence[str] | None = None,
         ax: Axes = None,
-        fig: Figure = None,
         widths: float = 0.5,
         **kwargs,
     ) -> Tuple[Figure, Axes, Dict]:
@@ -655,9 +688,10 @@ class StatisticalGlyph:
                 Defaults to `1..n`.
             labels: Tick labels, one per box. Defaults to the string of
                 each position.
-            ax: Axes to draw on. A new figure/axes is created when both
-                `ax` and `fig` are None.
-            fig: Figure to add an axes to when `ax` is None.
+            ax: Axes to draw on. Falls back to the axes/figure bound at
+                construction, and a brand-new figure/axes is created
+                when none is available. `fig` is a construction-time
+                binding, not a parameter here.
             widths: Box width in data units. Default is 0.5.
             **kwargs: Forwarded to `Axes.boxplot`.
 
@@ -683,6 +717,7 @@ class StatisticalGlyph:
 
                 ```
         """
+        self._reject_fig_kwarg(kwargs)
         values = np.asarray(self.values)
         if values.ndim != 2:
             raise ValueError(
@@ -704,7 +739,7 @@ class StatisticalGlyph:
                 f"columns ({n})."
             )
 
-        fig, ax = self._resolve_fig_ax(ax, fig)
+        fig, ax = self._resolve_fig_ax(ax)
         bp = ax.boxplot(
             columns,
             positions=list(positions),
@@ -727,7 +762,6 @@ class StatisticalGlyph:
     def stripes(
         self,
         ax: Axes = None,
-        fig: Figure = None,
         cmap=None,
         vmin: float | None = None,
         vmax: float | None = None,
@@ -741,9 +775,10 @@ class StatisticalGlyph:
         into a supplied `ax`/`fig` and does not call `plt.show()`.
 
         Args:
-            ax: Axes to draw on. A new figure/axes is created when both
-                `ax` and `fig` are None.
-            fig: Figure to add an axes to when `ax` is None.
+            ax: Axes to draw on. Falls back to the axes/figure bound at
+                construction, and a brand-new figure/axes is created
+                when none is available. `fig` is a construction-time
+                binding, not a parameter here.
             cmap: Colormap name or object. Defaults to the `cmap`
                 option.
             vmin: Lower colour limit. Defaults to the data minimum.
@@ -770,12 +805,13 @@ class StatisticalGlyph:
 
                 ```
         """
+        self._reject_fig_kwarg(kwargs)
         values = np.asarray(self.values, dtype=float)
         if values.ndim != 1:
             raise ValueError(
                 f"stripes requires 1D values; got {values.ndim}D."
             )
-        fig, ax = self._resolve_fig_ax(ax, fig)
+        fig, ax = self._resolve_fig_ax(ax)
         cmap = cmap if cmap is not None else self.default_options["cmap"]
         cmap_obj = mpl.colormaps[cmap] if isinstance(cmap, str) else cmap
         lo = float(np.nanmin(values)) if vmin is None else vmin

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -68,14 +68,17 @@ from matplotlib.figure import Figure
 
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 
-DEFAULT_OPTIONS = {
+STATISTICAL_DEFAULT_OPTIONS = {
     "figsize": (5, 5),
     "bins": 15,
     "color": ["#0504aa"],
     "alpha": 0.7,
     "rwidth": 0.85,
 }
-DEFAULT_OPTIONS = STYLE_DEFAULTS | DEFAULT_OPTIONS
+STATISTICAL_DEFAULT_OPTIONS = STYLE_DEFAULTS | STATISTICAL_DEFAULT_OPTIONS
+#: Backwards-compatible alias for the statistical glyph's default options
+#: (named like the other glyphs' `*_DEFAULT_OPTIONS` constants).
+DEFAULT_OPTIONS = STATISTICAL_DEFAULT_OPTIONS
 
 
 class StatisticalGlyph:
@@ -148,9 +151,8 @@ class StatisticalGlyph:
 
     #: Option keys this glyph accepts, exposed as a class attribute so they
     #: can be introspected/filtered before an instance exists (see
-    #: `option_keys`/`filter_kwargs`). The right-hand side is the
-    #: module-level ``DEFAULT_OPTIONS`` dict.
-    DEFAULT_OPTIONS = DEFAULT_OPTIONS
+    #: `option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = STATISTICAL_DEFAULT_OPTIONS
 
     def __init__(
         self,
@@ -247,7 +249,7 @@ class StatisticalGlyph:
         self._values = values
         self._fig = fig
         self._ax = ax
-        options_dict = DEFAULT_OPTIONS.copy()
+        options_dict = STATISTICAL_DEFAULT_OPTIONS.copy()
         options_dict.update(kwargs)
         self._default_options = options_dict
 
@@ -334,7 +336,7 @@ class StatisticalGlyph:
         return self._default_options
 
     @classmethod
-    def option_keys(cls) -> set:
+    def option_keys(cls) -> set[str]:
         """Return the keyword-argument keys this glyph accepts.
 
         Resolves from the class-level ``DEFAULT_OPTIONS`` so the accepted
@@ -363,7 +365,7 @@ class StatisticalGlyph:
         return set(cls.DEFAULT_OPTIONS)
 
     @classmethod
-    def filter_kwargs(cls, kwargs: Dict) -> Dict:
+    def filter_kwargs(cls, kwargs: dict) -> dict:
         """Return only the subset of ``kwargs`` whose keys this glyph accepts.
 
         Args:

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -84,6 +84,11 @@ class StatisticalGlyph:
     This class provides methods for initializing the class with numerical values and optional keyword arguments,
     and for creating histograms from the given values.
 
+    The accepted option keys are exposed via the `DEFAULT_OPTIONS` class
+    attribute and can be inspected or filtered before constructing an
+    instance with the `option_keys` and `filter_kwargs` classmethods
+    (mirroring `cleopatra.glyph.Glyph`, though this is a standalone class).
+
     Attributes:
         values: The numerical values to be plotted as histograms.
         default_options: The default options for creating histograms, including:

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -90,6 +90,9 @@ class VectorGlyph(Glyph):
             norm/colorbar/ticks pipeline used to colour by magnitude.
     """
 
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = VECTOR_DEFAULT_OPTIONS
+
     def __init__(
         self,
         x: np.ndarray,

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2742,98 +2742,264 @@ class TestMappableAndColorbarToggle:
 
     Covers issues #128 (suppress the built-in colorbar for shared-axes
     composition) and #129 (expose the colour-mapped artist for a uniform
-    `(glyph, mappable)` contract).
+    `(glyph, mappable)` contract). Exercises both the `plot` and `animate`
+    render paths, the RGB branch, and the `_merge_kwargs` validation gate.
     """
 
     @staticmethod
     def _sample_arr() -> np.ndarray:
-        """Return a small 2-D array suitable for every kind."""
+        """Return a small 2-D array suitable for every kind.
+
+        Returns:
+            np.ndarray: A 5x5 float array of monotonically increasing values.
+        """
         return np.arange(25, dtype=float).reshape(5, 5)
+
+    @staticmethod
+    def _stack(n: int = 3, h: int = 5, w: int = 5) -> np.ndarray:
+        """Return a 3-D stack of frames for the `animate` path.
+
+        Args:
+            n: Number of frames.
+            h: Frame height.
+            w: Frame width.
+
+        Returns:
+            np.ndarray: An ``(n, h, w)`` float array.
+        """
+        return np.arange(n * h * w, dtype=float).reshape(n, h, w)
+
+    @staticmethod
+    def _rgb_arr() -> np.ndarray:
+        """Return a deterministic 3-band array for the RGB branch.
+
+        Returns:
+            np.ndarray: A ``(3, 8, 8)`` float32 array in the 0-254 range.
+        """
+        rng = np.random.default_rng(seed=1337)
+        return rng.integers(0, 255, size=(3, 8, 8)).astype(np.float32)
 
     # ---- #129: the mappable is exposed via `self.im` ---------------------
 
     def test_im_is_none_before_plot(self):
-        """`self.im` exists and is None before the first render."""
+        """`self.im` exists and is None before the first render.
+
+        Test scenario:
+            A freshly constructed glyph has the public `im` attribute
+            initialised to None, so callers can always reach it.
+        """
         glyph = ArrayGlyph(self._sample_arr())
-        assert glyph.im is None
+        assert glyph.im is None, f"im should start as None, got {glyph.im!r}"
 
-    def test_im_is_axesimage_for_imshow(self):
-        """`kind="imshow"` stores the actual `AxesImage` on `self.im`."""
-        from matplotlib.image import AxesImage
+    @pytest.mark.parametrize(
+        "kind, expected_type_path",
+        [
+            ("auto", "matplotlib.image.AxesImage"),
+            ("imshow", "matplotlib.image.AxesImage"),
+            ("pcolormesh", "matplotlib.collections.QuadMesh"),
+            ("contour", "matplotlib.contour.QuadContourSet"),
+            ("contourf", "matplotlib.contour.QuadContourSet"),
+        ],
+    )
+    def test_im_type_per_kind(self, kind, expected_type_path):
+        """`self.im` holds the artist matching the render kind.
 
+        Args:
+            kind: The `kind=` value passed to `plot`.
+            expected_type_path: Dotted import path of the expected artist type.
+
+        Test scenario:
+            Every non-RGB kind stores its colour-mapped artist on `self.im`
+            (AxesImage for imshow/auto, QuadMesh for pcolormesh,
+            QuadContourSet for contour/contourf).
+        """
+        import importlib
+
+        module_name, _, type_name = expected_type_path.rpartition(".")
+        expected_type = getattr(importlib.import_module(module_name), type_name)
+
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind=kind)
+        try:
+            assert isinstance(glyph.im, expected_type), (
+                f"kind={kind!r} should store {type_name} on im, "
+                f"got {type(glyph.im).__name__}"
+            )
+        finally:
+            plt.close(fig)
+
+    def test_im_is_real_artist_on_axes_imshow(self):
+        """For imshow, `self.im` is the live artist on the axes, not a copy.
+
+        Test scenario:
+            The stored mappable must be the same object matplotlib placed in
+            `ax.images`, so a host can drive a colorbar from it.
+        """
         glyph = ArrayGlyph(self._sample_arr())
         fig, ax = glyph.plot(kind="imshow")
         try:
-            assert isinstance(glyph.im, AxesImage)
-            # It is the real artist on the axes, not a detached object.
-            assert glyph.im in ax.get_images()
+            assert glyph.im in ax.get_images(), "im is not the artist on the axes"
         finally:
             plt.close(fig)
 
-    def test_im_is_quadmesh_for_pcolormesh(self):
-        """`kind="pcolormesh"` stores the `QuadMesh` on `self.im`."""
-        from matplotlib.collections import QuadMesh
+    def test_im_is_real_artist_on_axes_pcolormesh(self):
+        """For pcolormesh, `self.im` is the live `QuadMesh` in `ax.collections`.
 
+        Test scenario:
+            The stored mappable is the collection matplotlib registered on the
+            axes, confirming no detached object is handed back.
+        """
         glyph = ArrayGlyph(self._sample_arr())
         fig, ax = glyph.plot(kind="pcolormesh")
         try:
-            assert isinstance(glyph.im, QuadMesh)
-            assert glyph.im in ax.collections
-        finally:
-            plt.close(fig)
-
-    def test_im_is_contourset_for_contourf(self):
-        """`kind="contourf"` stores the `QuadContourSet` on `self.im`."""
-        from matplotlib.contour import QuadContourSet
-
-        glyph = ArrayGlyph(self._sample_arr())
-        fig, ax = glyph.plot(kind="contourf")
-        try:
-            assert isinstance(glyph.im, QuadContourSet)
+            assert glyph.im in ax.collections, "im is not the artist on the axes"
         finally:
             plt.close(fig)
 
     def test_im_set_for_rgb(self):
-        """The RGB branch also exposes its `AxesImage` and draws no colorbar."""
+        """The RGB branch also exposes its `AxesImage` and draws no colorbar.
+
+        Test scenario:
+            RGB compositing stores the image artist on `self.im` while leaving
+            `self.cbar` as None (RGB has no scalar mapping to a colorbar).
+        """
         from matplotlib.image import AxesImage
 
-        rgb_arr = np.random.randint(0, 255, size=(3, 8, 8)).astype(np.float32)
-        glyph = ArrayGlyph(rgb_arr, rgb=[0, 1, 2])
+        glyph = ArrayGlyph(self._rgb_arr(), rgb=[0, 1, 2])
         fig, ax = glyph.plot(kind="imshow")
         try:
-            assert isinstance(glyph.im, AxesImage)
-            assert glyph.cbar is None
+            assert isinstance(glyph.im, AxesImage), (
+                f"RGB im should be AxesImage, got {type(glyph.im).__name__}"
+            )
+            assert glyph.cbar is None, "RGB path must not create a colorbar"
         finally:
             plt.close(fig)
 
-    # ---- #128: the built-in colorbar can be suppressed -------------------
+    def test_im_supports_host_owned_colorbar(self):
+        """A host can build its own colorbar from `self.im` after opting out.
 
-    def test_colorbar_drawn_by_default(self):
-        """Default behaviour is unchanged: a colorbar is created."""
-        glyph = ArrayGlyph(self._sample_arr())
-        fig, ax = glyph.plot(kind="imshow")
-        try:
-            assert glyph.cbar is not None
-            # A colorbar adds its own Axes to the figure.
-            assert len(fig.axes) == 2
-        finally:
-            plt.close(fig)
+        Test scenario:
+            With `add_colorbar=False` the glyph draws no colorbar, but the
+            exposed mappable is sufficient for the host to call
+            `fig.colorbar(glyph.im, ...)` — the shared-axes composition goal.
+        """
+        from matplotlib.colorbar import Colorbar
 
-    def test_add_colorbar_false_draws_no_colorbar(self):
-        """`add_colorbar=False` leaves `self.cbar is None` and adds no axes."""
         glyph = ArrayGlyph(self._sample_arr())
         fig, ax = glyph.plot(kind="imshow", add_colorbar=False)
         try:
-            assert glyph.cbar is None
-            # Only the host axes remains — no colorbar axes was added.
-            assert len(fig.axes) == 1
-            # The mappable is still reachable for a host-owned colorbar.
-            assert glyph.im is not None
+            host_cbar = fig.colorbar(glyph.im, ax=ax)
+            assert isinstance(host_cbar, Colorbar), (
+                "host should be able to build a colorbar from glyph.im"
+            )
+        finally:
+            plt.close(fig)
+
+    def test_im_refreshed_on_replot(self):
+        """Re-rendering updates `self.im` to the new artist.
+
+        Test scenario:
+            Calling `plot` a second time (different kind) replaces the stored
+            mappable rather than leaving a stale handle from the first call.
+        """
+        from matplotlib.collections import QuadMesh
+        from matplotlib.image import AxesImage
+
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind="imshow")
+        try:
+            assert isinstance(glyph.im, AxesImage)
+            glyph.plot(kind="pcolormesh")
+            assert isinstance(glyph.im, QuadMesh), (
+                "im should reflect the most recent render kind"
+            )
+        finally:
+            plt.close(fig)
+
+    def test_animate_sets_im(self):
+        """`animate` stores the first-frame mappable on `self.im`.
+
+        Test scenario:
+            The animate path mirrors `plot`: after building the animation the
+            glyph exposes the colour-mapped artist via `self.im`.
+        """
+        from matplotlib.image import AxesImage
+
+        glyph = ArrayGlyph(self._stack())
+        anim = glyph.animate(list(range(3)))
+        try:
+            assert isinstance(glyph.im, AxesImage), (
+                f"animate should set im to AxesImage, got {type(glyph.im).__name__}"
+            )
+        finally:
+            plt.close(anim._fig)
+
+    # ---- #128: the built-in colorbar can be suppressed -------------------
+
+    def test_add_colorbar_accepted_without_validation_error(self):
+        """`add_colorbar` passes `_merge_kwargs` and is recorded in options.
+
+        Test scenario:
+            Because the toggle was added to DEFAULT_OPTIONS, passing it does
+            not trip the unknown-kwarg `ValueError`, and the value is stored
+            in `default_options` for the render to read.
+        """
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind="imshow", add_colorbar=False)
+        try:
+            assert glyph.default_options["add_colorbar"] is False, (
+                "add_colorbar should be merged into default_options"
+            )
+        finally:
+            plt.close(fig)
+
+    def test_colorbar_drawn_by_default(self):
+        """Default behaviour is unchanged: a colorbar is created.
+
+        Test scenario:
+            With no `add_colorbar` kwarg the glyph still draws its colorbar,
+            which adds a second Axes to the figure.
+        """
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind="imshow")
+        try:
+            assert glyph.cbar is not None, "default plot should create a colorbar"
+            assert len(fig.axes) == 2, (
+                f"colorbar should add a second axes, got {len(fig.axes)}"
+            )
+        finally:
+            plt.close(fig)
+
+    @pytest.mark.parametrize("kind", ["imshow", "pcolormesh", "contourf"])
+    def test_add_colorbar_false_draws_no_colorbar(self, kind):
+        """`add_colorbar=False` leaves `self.cbar is None` and adds no axes.
+
+        Args:
+            kind: The render kind under test.
+
+        Test scenario:
+            Across raster and filled-contour kinds, opting out draws no
+            colorbar (no extra axes) yet still exposes the mappable.
+        """
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind=kind, add_colorbar=False)
+        try:
+            assert glyph.cbar is None, f"kind={kind!r}: cbar should be None"
+            assert len(fig.axes) == 1, (
+                f"kind={kind!r}: no colorbar axes expected, got {len(fig.axes)}"
+            )
+            assert glyph.im is not None, f"kind={kind!r}: mappable should still be set"
         finally:
             plt.close(fig)
 
     def test_shared_axes_two_layers_no_colorbars(self):
-        """Overlaying two ArrayGlyph layers with add_colorbar=False stays clean."""
+        """Two ArrayGlyph layers with add_colorbar=False compose cleanly.
+
+        Test scenario:
+            A contourf field plus a contour overlay on one shared axes produce
+            no per-glyph colorbars (no extra axes), and each layer exposes its
+            own mappable for the host to aggregate.
+        """
         fig, ax = plt.subplots()
         try:
             g1 = ArrayGlyph(self._sample_arr(), ax=ax, fig=fig)
@@ -2841,12 +3007,49 @@ class TestMappableAndColorbarToggle:
             g2 = ArrayGlyph(self._sample_arr(), ax=ax, fig=fig)
             g2.plot(kind="contour", add_colorbar=False)
 
-            assert g1.cbar is None
-            assert g2.cbar is None
-            # No per-glyph colorbar axes were added to the shared figure.
-            assert len(fig.axes) == 1
-            # Each layer still hands back its own mappable for aggregation.
-            assert g1.im is not None
-            assert g2.im is not None
+            assert g1.cbar is None and g2.cbar is None, "no per-glyph colorbars"
+            assert len(fig.axes) == 1, (
+                f"shared axes should stay single, got {len(fig.axes)} axes"
+            )
+            assert g1.im is not None and g2.im is not None, (
+                "each layer must expose its mappable for aggregation"
+            )
         finally:
             plt.close(fig)
+
+    @pytest.mark.parametrize("add_colorbar", [True, False])
+    def test_rgb_never_draws_colorbar(self, add_colorbar):
+        """The RGB branch ignores `add_colorbar` and never draws a colorbar.
+
+        Args:
+            add_colorbar: Toggle value under test.
+
+        Test scenario:
+            RGB has no scalar mapping, so `self.cbar` stays None regardless of
+            the toggle, while `self.im` is always populated.
+        """
+        glyph = ArrayGlyph(self._rgb_arr(), rgb=[0, 1, 2])
+        fig, ax = glyph.plot(kind="imshow", add_colorbar=add_colorbar)
+        try:
+            assert glyph.cbar is None, "RGB path must never create a colorbar"
+            assert glyph.im is not None, "RGB path must still expose the mappable"
+        finally:
+            plt.close(fig)
+
+    def test_animate_add_colorbar_false(self):
+        """`animate(add_colorbar=False)` draws no colorbar but exposes the mappable.
+
+        Test scenario:
+            The toggle is honoured on the animate path too: `self.cbar` is None
+            and no colorbar axes is added, while `self.im` is still set.
+        """
+        glyph = ArrayGlyph(self._stack())
+        anim = glyph.animate(list(range(3)), add_colorbar=False)
+        try:
+            assert glyph.cbar is None, "animate add_colorbar=False should skip cbar"
+            assert glyph.im is not None, "animate should still expose the mappable"
+            assert len(anim._fig.axes) == 1, (
+                f"no colorbar axes expected, got {len(anim._fig.axes)}"
+            )
+        finally:
+            plt.close(anim._fig)

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -1283,10 +1283,8 @@ class TestCenterCmapDoesNotApplyToRgb:
         glyph = ArrayGlyph(rgb_arr, rgb=[0, 1, 2])
         fig, ax = glyph.plot()
         assert isinstance(fig, Figure)
-        # No colorbar is created on the RGB path; `cbar` is unset.
-        assert not hasattr(glyph, "cbar"), (
-            "RGB compositing should not create a colorbar"
-        )
+        # No colorbar is created on the RGB path; `cbar` stays None.
+        assert glyph.cbar is None, "RGB compositing should not create a colorbar"
 
 
 @pytest.mark.plot
@@ -2738,3 +2736,117 @@ class TestAnimateDataGetterEdgeCases:
             plt.close(glyph.fig)
 
 
+
+class TestMappableAndColorbarToggle:
+    """Tests for the exposed mappable (`self.im`) and the `add_colorbar` toggle.
+
+    Covers issues #128 (suppress the built-in colorbar for shared-axes
+    composition) and #129 (expose the colour-mapped artist for a uniform
+    `(glyph, mappable)` contract).
+    """
+
+    @staticmethod
+    def _sample_arr() -> np.ndarray:
+        """Return a small 2-D array suitable for every kind."""
+        return np.arange(25, dtype=float).reshape(5, 5)
+
+    # ---- #129: the mappable is exposed via `self.im` ---------------------
+
+    def test_im_is_none_before_plot(self):
+        """`self.im` exists and is None before the first render."""
+        glyph = ArrayGlyph(self._sample_arr())
+        assert glyph.im is None
+
+    def test_im_is_axesimage_for_imshow(self):
+        """`kind="imshow"` stores the actual `AxesImage` on `self.im`."""
+        from matplotlib.image import AxesImage
+
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind="imshow")
+        try:
+            assert isinstance(glyph.im, AxesImage)
+            # It is the real artist on the axes, not a detached object.
+            assert glyph.im in ax.get_images()
+        finally:
+            plt.close(fig)
+
+    def test_im_is_quadmesh_for_pcolormesh(self):
+        """`kind="pcolormesh"` stores the `QuadMesh` on `self.im`."""
+        from matplotlib.collections import QuadMesh
+
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind="pcolormesh")
+        try:
+            assert isinstance(glyph.im, QuadMesh)
+            assert glyph.im in ax.collections
+        finally:
+            plt.close(fig)
+
+    def test_im_is_contourset_for_contourf(self):
+        """`kind="contourf"` stores the `QuadContourSet` on `self.im`."""
+        from matplotlib.contour import QuadContourSet
+
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind="contourf")
+        try:
+            assert isinstance(glyph.im, QuadContourSet)
+        finally:
+            plt.close(fig)
+
+    def test_im_set_for_rgb(self):
+        """The RGB branch also exposes its `AxesImage` and draws no colorbar."""
+        from matplotlib.image import AxesImage
+
+        rgb_arr = np.random.randint(0, 255, size=(3, 8, 8)).astype(np.float32)
+        glyph = ArrayGlyph(rgb_arr, rgb=[0, 1, 2])
+        fig, ax = glyph.plot(kind="imshow")
+        try:
+            assert isinstance(glyph.im, AxesImage)
+            assert glyph.cbar is None
+        finally:
+            plt.close(fig)
+
+    # ---- #128: the built-in colorbar can be suppressed -------------------
+
+    def test_colorbar_drawn_by_default(self):
+        """Default behaviour is unchanged: a colorbar is created."""
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind="imshow")
+        try:
+            assert glyph.cbar is not None
+            # A colorbar adds its own Axes to the figure.
+            assert len(fig.axes) == 2
+        finally:
+            plt.close(fig)
+
+    def test_add_colorbar_false_draws_no_colorbar(self):
+        """`add_colorbar=False` leaves `self.cbar is None` and adds no axes."""
+        glyph = ArrayGlyph(self._sample_arr())
+        fig, ax = glyph.plot(kind="imshow", add_colorbar=False)
+        try:
+            assert glyph.cbar is None
+            # Only the host axes remains — no colorbar axes was added.
+            assert len(fig.axes) == 1
+            # The mappable is still reachable for a host-owned colorbar.
+            assert glyph.im is not None
+        finally:
+            plt.close(fig)
+
+    def test_shared_axes_two_layers_no_colorbars(self):
+        """Overlaying two ArrayGlyph layers with add_colorbar=False stays clean."""
+        fig, ax = plt.subplots()
+        try:
+            g1 = ArrayGlyph(self._sample_arr(), ax=ax, fig=fig)
+            g1.plot(kind="contourf", add_colorbar=False)
+            g2 = ArrayGlyph(self._sample_arr(), ax=ax, fig=fig)
+            g2.plot(kind="contour", add_colorbar=False)
+
+            assert g1.cbar is None
+            assert g2.cbar is None
+            # No per-glyph colorbar axes were added to the shared figure.
+            assert len(fig.axes) == 1
+            # Each layer still hands back its own mappable for aggregation.
+            assert g1.im is not None
+            assert g2.im is not None
+        finally:
+            plt.close(fig)

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3053,3 +3053,131 @@ class TestMappableAndColorbarToggle:
             )
         finally:
             plt.close(anim._fig)
+
+class TestPlotAxAndTitleParams:
+    """Tests for `ax=` and `title=` on `ArrayGlyph.plot` (issue #130).
+
+    Verifies parity with the other glyphs: `plot(ax=)` composes onto the
+    given axes (deriving its figure), `plot(title=)` sets the title, and the
+    axes-resolution priority is plot(ax=) > constructor ax > fresh figure.
+    """
+
+    @staticmethod
+    def _arr() -> np.ndarray:
+        """Return a small 2-D array."""
+        return np.arange(25, dtype=float).reshape(5, 5)
+
+    def test_plot_ax_renders_onto_supplied_axes(self):
+        """`plot(ax=ax)` draws on the given axes without making a new figure.
+
+        Test scenario:
+            A glyph constructed with no axes renders onto a caller's axes when
+            it is passed to `plot`, and binds that axes' figure.
+        """
+        fig, ax = plt.subplots()
+        try:
+            glyph = ArrayGlyph(self._arr())
+            out_fig, out_ax = glyph.plot(ax=ax, kind="imshow")
+            assert out_ax is ax, "plot(ax=) must render onto the supplied axes"
+            assert out_fig is ax.get_figure(), "figure must be derived from the axes"
+            assert glyph.ax is ax, "glyph.ax should be bound to the supplied axes"
+        finally:
+            plt.close(fig)
+
+    def test_plot_ax_overrides_constructor_axes(self):
+        """`plot(ax=)` wins over an axes bound at construction.
+
+        Test scenario:
+            Resolution priority: an explicit `plot(ax=)` takes precedence over
+            the constructor-supplied axes.
+        """
+        ctor_fig, ctor_ax = plt.subplots()
+        plot_fig, plot_ax = plt.subplots()
+        try:
+            glyph = ArrayGlyph(self._arr(), ax=ctor_ax, fig=ctor_fig)
+            out_fig, out_ax = glyph.plot(ax=plot_ax, kind="imshow")
+            assert out_ax is plot_ax, "plot(ax=) must override the constructor axes"
+            assert out_ax is not ctor_ax, "constructor axes must not win over plot(ax=)"
+        finally:
+            plt.close(ctor_fig)
+            plt.close(plot_fig)
+
+    def test_plot_uses_constructor_axes_when_no_plot_ax(self):
+        """Without `plot(ax=)`, the constructor axes is used (no fresh figure).
+
+        Test scenario:
+            Resolution priority middle tier: a glyph built with `ax=`/`fig=`
+            renders there when `plot` is called without an `ax`.
+        """
+        fig, ax = plt.subplots()
+        try:
+            glyph = ArrayGlyph(self._arr(), ax=ax, fig=fig)
+            out_fig, out_ax = glyph.plot(kind="imshow")
+            assert out_ax is ax, "constructor axes should be used when plot(ax=) omitted"
+            assert out_fig is fig, "constructor figure should be reused"
+        finally:
+            plt.close(fig)
+
+    def test_plot_creates_figure_when_no_axes_anywhere(self):
+        """With no axes from either source, `plot` creates its own figure/axes.
+
+        Test scenario:
+            Resolution priority fallback: neither constructor nor plot supplies
+            an axes, so a fresh figure/axes is created.
+        """
+        glyph = ArrayGlyph(self._arr())
+        out_fig, out_ax = glyph.plot(kind="imshow")
+        try:
+            assert isinstance(out_fig, Figure), "a fresh Figure should be created"
+            assert out_ax is not None, "a fresh axes should be created"
+        finally:
+            plt.close(out_fig)
+
+    def test_plot_title_sets_axes_title(self):
+        """`plot(title=...)` sets the axes title.
+
+        Test scenario:
+            The convenience `title` parameter is equivalent to the `title`
+            option and is applied to the rendered axes.
+        """
+        fig, ax = plt.subplots()
+        try:
+            glyph = ArrayGlyph(self._arr())
+            _, out_ax = glyph.plot(ax=ax, title="My Field", kind="imshow")
+            assert out_ax.get_title() == "My Field", (
+                f"title should be set, got {out_ax.get_title()!r}"
+            )
+        finally:
+            plt.close(fig)
+
+    def test_plot_title_overrides_constructor_title(self):
+        """`plot(title=)` overrides a title set at construction.
+
+        Test scenario:
+            When a title was given via constructor options, an explicit
+            `plot(title=)` takes precedence.
+        """
+        fig, ax = plt.subplots()
+        try:
+            glyph = ArrayGlyph(self._arr(), title="ctor title")
+            _, out_ax = glyph.plot(ax=ax, title="plot title", kind="imshow")
+            assert out_ax.get_title() == "plot title", (
+                f"plot title should win, got {out_ax.get_title()!r}"
+            )
+        finally:
+            plt.close(fig)
+
+    def test_construct_with_ax_only_keeps_axes(self):
+        """`ArrayGlyph(arr, ax=ax)` (no fig) now renders onto that axes.
+
+        Test scenario:
+            Regression for the old gate that dropped a constructor `ax` when
+            `fig` was omitted; the axes must now be honoured by `plot()`.
+        """
+        fig, ax = plt.subplots()
+        try:
+            glyph = ArrayGlyph(self._arr(), ax=ax)
+            _, out_ax = glyph.plot(kind="imshow")
+            assert out_ax is ax, "ax-only construction must be honoured by plot()"
+        finally:
+            plt.close(fig)

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -99,6 +99,37 @@ class TestInit:
         assert g.fig is fig, "explicit fig should be stored as-is"
         plt.close(fig)
 
+    def test_mismatched_fig_ax_warns(self):
+        """A `fig` that does not own `ax` warns the caller.
+
+        Test scenario:
+            Passing an `ax` together with an unrelated `fig` is almost always
+            a mistake (the two figure handles disagree), so the constructor
+            emits a warning while still honouring the explicit `fig`.
+        """
+        fig_a, ax_a = plt.subplots()
+        fig_b = plt.figure()
+        with pytest.warns(UserWarning, match="not the figure that owns"):
+            g = Glyph(default_options=_make_options(), fig=fig_b, ax=ax_a)
+        assert g.fig is fig_b, "explicit fig is still honoured despite the mismatch"
+        plt.close(fig_a)
+        plt.close(fig_b)
+
+    def test_matched_fig_ax_does_not_warn(self):
+        """Passing `ax` with its own parent `fig` does not warn.
+
+        Test scenario:
+            The consistent case (fig owns ax) must stay silent.
+        """
+        import warnings as _warnings
+
+        fig, ax = plt.subplots()
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            g = Glyph(default_options=_make_options(), fig=fig, ax=ax)
+        assert g.fig is fig, "matched fig should be stored without warning"
+        plt.close(fig)
+
     def test_kwargs_override_defaults(self):
         """Test that kwargs override default_options values."""
         g = Glyph(default_options=_make_options(), cmap="plasma")

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -1240,3 +1240,89 @@ class TestOptionKeysAndFilterKwargs:
         assert ScatterGlyph.filter_kwargs({"nope": 1, "nah": 2}) == {}, (
             "all-unknown input should yield an empty dict"
         )
+
+
+class TestRootFigure:
+    """Tests for the module-level `_root_figure` helper."""
+
+    def test_returns_owning_figure_for_normal_axes(self):
+        """`_root_figure(ax)` returns the Figure that owns a normal axes.
+
+        Test scenario:
+            For an axes created by `plt.subplots`, the helper resolves to that
+            same figure object.
+        """
+        from cleopatra.glyph import _root_figure
+
+        fig, ax = plt.subplots()
+        try:
+            assert _root_figure(ax) is fig, "should return the axes' owning figure"
+        finally:
+            plt.close(fig)
+
+    def test_uses_root_kwarg_when_supported(self):
+        """`_root_figure` passes `root=True` when the axes supports it.
+
+        Test scenario:
+            On matplotlib >= 3.10 `get_figure(root=True)` returns the top-level
+            Figure; the helper must use that path. Simulated with a fake axes
+            whose `get_figure` accepts `root`.
+        """
+        from cleopatra.glyph import _root_figure
+
+        root_fig = object()
+
+        class _ModernAx:
+            def get_figure(self, root=False):
+                return root_fig if root else "non-root"
+
+        assert _root_figure(_ModernAx()) is root_fig, "should request the root figure"
+
+    def test_falls_back_when_root_kwarg_unsupported(self):
+        """`_root_figure` falls back to bare `get_figure()` on older matplotlib.
+
+        Test scenario:
+            When `get_figure(root=True)` raises TypeError (no `root` kwarg, as
+            on the 3.8.4 floor), the helper retries without it.
+        """
+        from cleopatra.glyph import _root_figure
+
+        sentinel = object()
+
+        class _LegacyAx:
+            def get_figure(self):
+                return sentinel
+
+        assert _root_figure(_LegacyAx()) is sentinel, "should fall back to get_figure()"
+
+
+class TestDefaultOptionsAlias:
+    """The renamed option dicts keep a backwards-compatible `DEFAULT_OPTIONS` alias."""
+
+    def test_array_alias_is_same_object(self):
+        """`array_glyph.DEFAULT_OPTIONS` aliases `ARRAY_DEFAULT_OPTIONS`.
+
+        Test scenario:
+            The public `DEFAULT_OPTIONS` name still resolves to the renamed
+            constant (same object), and the class attribute / `option_keys`
+            agree with it.
+        """
+        import cleopatra.array_glyph as ag
+
+        assert ag.DEFAULT_OPTIONS is ag.ARRAY_DEFAULT_OPTIONS, "alias must be the same object"
+        assert ag.ArrayGlyph.DEFAULT_OPTIONS is ag.ARRAY_DEFAULT_OPTIONS, "class attr mismatch"
+        assert ag.ArrayGlyph.option_keys() == set(ag.ARRAY_DEFAULT_OPTIONS), "keys mismatch"
+
+    def test_statistical_alias_is_same_object(self):
+        """`statistical_glyph.DEFAULT_OPTIONS` aliases `STATISTICAL_DEFAULT_OPTIONS`.
+
+        Test scenario:
+            The public `DEFAULT_OPTIONS` name still resolves to the renamed
+            constant (same object), and the class attribute / `option_keys`
+            agree with it.
+        """
+        import cleopatra.statistical_glyph as sg
+
+        assert sg.DEFAULT_OPTIONS is sg.STATISTICAL_DEFAULT_OPTIONS, "alias must be the same object"
+        assert sg.StatisticalGlyph.DEFAULT_OPTIONS is sg.STATISTICAL_DEFAULT_OPTIONS, "class attr mismatch"
+        assert sg.StatisticalGlyph.option_keys() == set(sg.STATISTICAL_DEFAULT_OPTIONS), "keys mismatch"

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -1033,3 +1033,112 @@ class TestArrayGlyphUnchangedByHelper:
             array_ticks,
             err_msg="Helper ticks should match ArrayGlyph's ticks for the same data",
         )
+
+
+class TestOptionKeysAndFilterKwargs:
+    """Tests for `Glyph.option_keys` / `Glyph.filter_kwargs` (issue #131).
+
+    Pre-construction introspection of a glyph's accepted option keys, and a
+    filter helper that drops unknown keys so a forwarded kwargs bag can be
+    used without tripping the strict `_merge_kwargs` validation.
+    """
+
+    def test_option_keys_without_instance(self):
+        """`option_keys()` works on the class, with no instance built.
+
+        Test scenario:
+            The base Glyph exposes the shared style-default keys via a
+            classmethod, so no construction (and no `_merge_kwargs`) is needed.
+        """
+        keys = Glyph.option_keys()
+        assert keys == set(STYLE_DEFAULTS), "base keys should equal STYLE_DEFAULTS"
+        assert "cmap" in keys, "a known style key should be present"
+
+    @pytest.mark.parametrize(
+        "import_path, class_name, const_name",
+        [
+            ("cleopatra.array_glyph", "ArrayGlyph", "DEFAULT_OPTIONS"),
+            ("cleopatra.scatter_glyph", "ScatterGlyph", "SCATTER_DEFAULT_OPTIONS"),
+            ("cleopatra.polygon_glyph", "PolygonGlyph", "POLYGON_DEFAULT_OPTIONS"),
+            ("cleopatra.vector_glyph", "VectorGlyph", "VECTOR_DEFAULT_OPTIONS"),
+            ("cleopatra.line_glyph", "LineGlyph", "LINE_DEFAULT_OPTIONS"),
+            ("cleopatra.mesh_glyph", "MeshGlyph", "MESH_DEFAULT_OPTIONS"),
+        ],
+    )
+    def test_subclass_keys_match_their_option_dict(
+        self, import_path, class_name, const_name
+    ):
+        """Each glyph's `option_keys()` equals its own option-dict keys.
+
+        Args:
+            import_path: Dotted module path of the glyph.
+            class_name: The glyph class to introspect.
+            const_name: Name of that glyph's module-level option dict.
+
+        Test scenario:
+            The class attribute is the single source of truth, so the keys
+            reported per glyph match its `*_DEFAULT_OPTIONS` constant exactly.
+        """
+        import importlib
+
+        module = importlib.import_module(import_path)
+        glyph_cls = getattr(module, class_name)
+        const = getattr(module, const_name)
+        assert glyph_cls.option_keys() == set(const), (
+            f"{glyph_cls.__name__}.option_keys() must match {const_name}"
+        )
+
+    def test_keys_differ_per_glyph(self):
+        """Different glyphs expose different option keys.
+
+        Test scenario:
+            A polygon-specific key (`edgecolor`) is accepted by PolygonGlyph
+            but not by ScatterGlyph, proving the keys are resolved per class.
+        """
+        from cleopatra.polygon_glyph import PolygonGlyph
+        from cleopatra.scatter_glyph import ScatterGlyph
+
+        assert "edgecolor" in PolygonGlyph.option_keys(), "polygon accepts edgecolor"
+        assert "edgecolor" not in ScatterGlyph.option_keys(), "scatter does not"
+
+    def test_filter_kwargs_keeps_accepted_drops_unknown(self):
+        """`filter_kwargs` returns only accepted keys, preserving values.
+
+        Test scenario:
+            A mixed bag of known and unknown keys is filtered to just the
+            known ones, with their values intact.
+        """
+        from cleopatra.polygon_glyph import PolygonGlyph
+
+        raw = {"cmap": "viridis", "edgecolor": "black", "bogus": 1}
+        safe = PolygonGlyph.filter_kwargs(raw)
+        assert sorted(safe) == ["cmap", "edgecolor"], f"unexpected keys: {sorted(safe)}"
+        assert safe["cmap"] == "viridis", "values must be preserved"
+
+    def test_filter_kwargs_empty_returns_empty(self):
+        """Filtering an empty mapping yields an empty mapping.
+
+        Test scenario:
+            Boundary case — no keys in, no keys out.
+        """
+        from cleopatra.scatter_glyph import ScatterGlyph
+
+        assert ScatterGlyph.filter_kwargs({}) == {}, "empty in -> empty out"
+
+    def test_filter_then_construct_does_not_raise(self):
+        """Pre-filtering resolves the catch-22: construction then succeeds.
+
+        Test scenario:
+            Forwarding a bag with an unknown key would raise on construction;
+            filtering first lets the same bag build the glyph cleanly while
+            keeping the accepted styling.
+        """
+        import numpy as np
+        from cleopatra.array_glyph import ArrayGlyph
+
+        raw = {"cmap": "viridis", "totally_unknown": 1}
+        with pytest.raises(ValueError, match="totally_unknown"):
+            ArrayGlyph(np.arange(9.0).reshape(3, 3), **raw)
+        safe = ArrayGlyph.filter_kwargs(raw)
+        glyph = ArrayGlyph(np.arange(9.0).reshape(3, 3), **safe)
+        assert glyph.default_options["cmap"] == "viridis", "accepted key must survive"

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -1326,3 +1326,148 @@ class TestDefaultOptionsAlias:
         assert sg.DEFAULT_OPTIONS is sg.STATISTICAL_DEFAULT_OPTIONS, "alias must be the same object"
         assert sg.StatisticalGlyph.DEFAULT_OPTIONS is sg.STATISTICAL_DEFAULT_OPTIONS, "class attr mismatch"
         assert sg.StatisticalGlyph.option_keys() == set(sg.STATISTICAL_DEFAULT_OPTIONS), "keys mismatch"
+
+
+class TestSubFigureFigureResolution:
+    """`_root_figure` / the mismatch warning behave correctly with SubFigures.
+
+    Regression coverage for the review's N1: an axes living on a SubFigure must
+    resolve to the top-level Figure, and passing either the root figure or the
+    immediate SubFigure as `fig` must not trip the mismatch warning.
+    """
+
+    def test_root_figure_resolves_to_top_level_for_subfigure_axes(self):
+        """`_root_figure(ax)` returns the root Figure, not the SubFigure.
+
+        Test scenario:
+            An axes created on a SubFigure resolves up to the owning top-level
+            Figure (so a host-owned colorbar/figure handle is the real one).
+        """
+        from cleopatra.glyph import _root_figure
+
+        fig = plt.figure()
+        sub = fig.subfigures(1, 1)
+        ax = sub.subplots()
+        try:
+            assert _root_figure(ax) is fig, "should climb to the top-level figure"
+        finally:
+            plt.close(fig)
+
+    def test_root_figure_passed_for_subfigure_axes_does_not_warn(self):
+        """Passing the root Figure with a SubFigure axes does not warn.
+
+        Test scenario:
+            The N1 case — `fig` is the top-level figure that transitively owns
+            an axes on a SubFigure; this is a valid pairing and must be silent.
+        """
+        import warnings as _warnings
+
+        fig = plt.figure()
+        sub = fig.subfigures(1, 1)
+        ax = sub.subplots()
+        try:
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("error")
+                g = Glyph(default_options=_make_options(), fig=fig, ax=ax)
+            assert g.fig is fig, "the explicit root fig should be stored"
+        finally:
+            plt.close(fig)
+
+    def test_immediate_subfigure_passed_does_not_warn(self):
+        """Passing the immediate SubFigure with its own axes does not warn.
+
+        Test scenario:
+            `fig` is the SubFigure the axes is directly attached to — also a
+            valid pairing, so no warning.
+        """
+        import warnings as _warnings
+
+        fig = plt.figure()
+        sub = fig.subfigures(1, 1)
+        ax = sub.subplots()
+        try:
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("error")
+                g = Glyph(default_options=_make_options(), fig=sub, ax=ax)
+            assert g.fig is sub, "the explicit sub-figure should be stored"
+        finally:
+            plt.close(fig)
+
+    def test_unrelated_figure_with_subfigure_axes_still_warns(self):
+        """An unrelated `fig` with a SubFigure axes still warns.
+
+        Test scenario:
+            The warning must still fire for a genuinely unrelated figure, even
+            when the axes lives on a SubFigure.
+        """
+        fig = plt.figure()
+        sub = fig.subfigures(1, 1)
+        ax = sub.subplots()
+        other = plt.figure()
+        try:
+            with pytest.warns(UserWarning, match="not the figure that owns"):
+                Glyph(default_options=_make_options(), fig=other, ax=ax)
+        finally:
+            plt.close(fig)
+            plt.close(other)
+
+
+class TestFigureResolutionInternals:
+    """Branch coverage for the matplotlib-version fallback paths of the helpers.
+
+    On matplotlib >= 3.10 the `root=` path is always taken for real axes, so
+    the legacy (< 3.10) branches are exercised here with small fakes.
+    """
+
+    def test_supports_root_false_when_signature_uninspectable(self):
+        """`_get_figure_supports_root` returns False if the signature can't be read.
+
+        Test scenario:
+            A non-callable (whose signature inspection raises) must yield False
+            rather than propagating the error.
+        """
+        from cleopatra.glyph import _get_figure_supports_root
+
+        assert _get_figure_supports_root(object()) is False, "uninspectable -> False"
+
+    def test_root_figure_climbs_subfigure_on_legacy_path(self):
+        """The legacy path climbs a `SubFigure` to the top-level `Figure`.
+
+        Test scenario:
+            A fake axes whose `get_figure` has no `root` kwarg returns a real
+            SubFigure; `_root_figure` must climb to the owning Figure.
+        """
+        import warnings as _warnings
+
+        from cleopatra.glyph import _root_figure
+
+        fig = plt.figure()
+        sub = fig.subfigures(1, 1)
+
+        class _LegacyAxOnSub:
+            def get_figure(self):
+                return sub
+
+        try:
+            with _warnings.catch_warnings():
+                _warnings.simplefilter("ignore")
+                assert _root_figure(_LegacyAxOnSub()) is fig, "should climb to the root figure"
+        finally:
+            plt.close(fig)
+
+    def test_immediate_figure_legacy_path(self):
+        """`_immediate_figure` uses the bare `get_figure()` on the legacy path.
+
+        Test scenario:
+            A fake axes whose `get_figure` has no `root` kwarg returns its
+            figure directly.
+        """
+        from cleopatra.glyph import _immediate_figure
+
+        sentinel = object()
+
+        class _LegacyAx:
+            def get_figure(self):
+                return sentinel
+
+        assert _immediate_figure(_LegacyAx()) is sentinel, "should return get_figure()"

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -1142,3 +1142,70 @@ class TestOptionKeysAndFilterKwargs:
         safe = ArrayGlyph.filter_kwargs(raw)
         glyph = ArrayGlyph(np.arange(9.0).reshape(3, 3), **safe)
         assert glyph.default_options["cmap"] == "viridis", "accepted key must survive"
+
+    def test_option_keys_returns_independent_set(self):
+        """`option_keys()` returns a fresh set each call; mutation can't leak.
+
+        Test scenario:
+            Mutating the returned set must not corrupt the class option keys
+            seen by a subsequent call (the helper builds a new set from the
+            class dict rather than aliasing it).
+        """
+        first = Glyph.option_keys()
+        first.add("totally_unknown")
+        second = Glyph.option_keys()
+        assert "totally_unknown" not in second, "returned set must be independent"
+
+    def test_option_keys_matches_instance_accepted_keys(self):
+        """Class-level `option_keys()` equals a built instance's option keys.
+
+        Test scenario:
+            The class attribute is the real source of truth: the keys reported
+            without an instance match the keys an actual instance ends up with.
+        """
+        import numpy as np
+        from cleopatra.array_glyph import ArrayGlyph
+
+        glyph = ArrayGlyph(np.arange(9.0).reshape(3, 3))
+        assert ArrayGlyph.option_keys() == set(glyph.default_options), (
+            "class option_keys must match the instance's accepted keys"
+        )
+
+    def test_filter_kwargs_does_not_mutate_input(self):
+        """`filter_kwargs` leaves the caller's dict untouched and returns a copy.
+
+        Test scenario:
+            Filtering is pure — the input mapping keeps all its original keys,
+            and the returned dict is a distinct object.
+        """
+        from cleopatra.scatter_glyph import ScatterGlyph
+
+        raw = {"cmap": "viridis", "bogus": 1}
+        safe = ScatterGlyph.filter_kwargs(raw)
+        assert raw == {"cmap": "viridis", "bogus": 1}, "input must not be mutated"
+        assert safe is not raw, "a new dict should be returned"
+
+    def test_filter_kwargs_preserves_insertion_order(self):
+        """`filter_kwargs` preserves the order of the accepted keys.
+
+        Test scenario:
+            Two accepted keys given in a specific order come back in that same
+            order (rejected keys are dropped without reordering the rest).
+        """
+        from cleopatra.array_glyph import ArrayGlyph
+
+        raw = {"vmax": 5, "bogus": 1, "vmin": 0}
+        safe = ArrayGlyph.filter_kwargs(raw)
+        assert list(safe) == ["vmax", "vmin"], f"order not preserved: {list(safe)}"
+
+    def test_filter_kwargs_all_unknown_returns_empty(self):
+        """A mapping of only unknown keys filters down to nothing.
+
+        Test scenario:
+            Boundary case — when no key is accepted, the result is empty.
+        """
+        from cleopatra.scatter_glyph import ScatterGlyph
+
+        assert ScatterGlyph.filter_kwargs({"nope": 1, "nah": 2}) == {}, (
+            "all-unknown input should yield an empty dict"
+        )

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -58,6 +58,46 @@ class TestInit:
         g = Glyph(default_options=_make_options(), fig=fig, ax=ax)
         assert g.fig is fig, "Should store the provided figure"
         assert g.ax is ax, "Should store the provided axes"
+        plt.close(fig)
+
+    def test_ax_without_fig_keeps_axes_and_derives_fig(self):
+        """Passing `ax` alone keeps the axes and derives the figure from it.
+
+        Test scenario:
+            Previously an `ax` given without a `fig` was dropped (both set
+            to None). Now the axes is retained and `self.fig` is derived via
+            `ax.get_figure()`, so a caller can bind a target with `ax=` only.
+        """
+        fig, ax = plt.subplots()
+        g = Glyph(default_options=_make_options(), ax=ax)
+        assert g.ax is ax, "ax passed alone must be kept"
+        assert g.fig is ax.get_figure(), "fig must be derived from the axes"
+        plt.close(fig)
+
+    def test_fig_without_ax_keeps_fig_and_leaves_ax_none(self):
+        """Passing `fig` alone keeps the figure and leaves `ax` None.
+
+        Test scenario:
+            A figure with no specific axes binds the figure handle; the axes
+            stays None until render time.
+        """
+        fig = plt.figure()
+        g = Glyph(default_options=_make_options(), fig=fig)
+        assert g.fig is fig, "fig passed alone must be kept"
+        assert g.ax is None, "ax should remain None when only fig is given"
+        plt.close(fig)
+
+    def test_explicit_fig_wins_over_axes_parent(self):
+        """When both `fig` and `ax` are given, the explicit `fig` is stored.
+
+        Test scenario:
+            The explicit figure handle takes precedence for `self.fig` rather
+            than being recomputed from the axes.
+        """
+        fig, ax = plt.subplots()
+        g = Glyph(default_options=_make_options(), fig=fig, ax=ax)
+        assert g.fig is fig, "explicit fig should be stored as-is"
+        plt.close(fig)
 
     def test_kwargs_override_defaults(self):
         """Test that kwargs override default_options values."""

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -592,3 +592,51 @@ class TestOptionKeysAndFilterKwargs:
         safe = StatisticalGlyph.filter_kwargs(raw)
         fig, ax, hist = stat.histogram(**safe)
         assert len(hist["n"]) == 1, "histogram should produce one series"
+
+    def test_option_keys_returns_independent_set(self):
+        """`option_keys()` returns a fresh set each call; mutation can't leak.
+
+        Test scenario:
+            Mutating the returned set must not corrupt the keys seen by a
+            later call.
+        """
+        first = StatisticalGlyph.option_keys()
+        first.add("totally_unknown")
+        assert "totally_unknown" not in StatisticalGlyph.option_keys(), (
+            "returned set must be independent"
+        )
+
+    def test_option_keys_matches_instance_accepted_keys(self):
+        """Class-level `option_keys()` matches a built instance's option keys.
+
+        Test scenario:
+            The class attribute is the source of truth: with no extra kwargs,
+            an instance's `default_options` keys equal `option_keys()`.
+        """
+        stat = StatisticalGlyph(np.arange(10, dtype=float))
+        assert StatisticalGlyph.option_keys() == set(stat.default_options), (
+            "class option_keys must match the instance's accepted keys"
+        )
+
+    def test_filter_kwargs_does_not_mutate_input(self):
+        """`filter_kwargs` leaves the caller's dict untouched and returns a copy.
+
+        Test scenario:
+            Filtering is pure — the input keeps its keys and a new dict is
+            returned.
+        """
+        raw = {"bins": 20, "bogus": 1}
+        safe = StatisticalGlyph.filter_kwargs(raw)
+        assert raw == {"bins": 20, "bogus": 1}, "input must not be mutated"
+        assert safe is not raw, "a new dict should be returned"
+
+    def test_filter_kwargs_preserves_insertion_order(self):
+        """`filter_kwargs` preserves the order of the accepted keys.
+
+        Test scenario:
+            Accepted keys come back in their original order, with the rejected
+            key dropped in between.
+        """
+        raw = {"bins": 20, "bogus": 1, "alpha": 0.5}
+        safe = StatisticalGlyph.filter_kwargs(raw)
+        assert list(safe) == ["bins", "alpha"], f"order not preserved: {list(safe)}"

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -544,3 +544,51 @@ class TestFigParameterRemovedFromRenderers:
         stat = StatisticalGlyph(np.array([0.1, 0.5, 0.9]), ax=ax)
         _, out_ax, _ = stat.stripes(cmap="coolwarm")
         assert out_ax is ax, "stripes should reuse the constructor axes"
+
+
+class TestOptionKeysAndFilterKwargs:
+    """Tests for `StatisticalGlyph.option_keys` / `filter_kwargs` (issue #131).
+
+    StatisticalGlyph is a standalone class (not a Glyph subclass) but exposes
+    the same pre-construction introspection helpers for parity.
+    """
+
+    def test_option_keys_match_default_options(self):
+        """`option_keys()` equals the module-level option dict keys.
+
+        Test scenario:
+            The class attribute is the single source of truth; the accepted
+            keys match `DEFAULT_OPTIONS` and exclude unknown names.
+        """
+        from cleopatra.statistical_glyph import DEFAULT_OPTIONS
+
+        keys = StatisticalGlyph.option_keys()
+        assert keys == set(DEFAULT_OPTIONS), "keys must match DEFAULT_OPTIONS"
+        assert "bins" in keys, "a known histogram key should be present"
+        assert "totally_unknown" not in keys, "unknown keys must be absent"
+
+    def test_filter_kwargs_keeps_accepted_drops_unknown(self):
+        """`filter_kwargs` keeps accepted keys (with values) and drops the rest.
+
+        Test scenario:
+            A mixed bag is filtered to just the accepted keys; values intact.
+        """
+        raw = {"bins": 20, "alpha": 0.5, "bogus": 1}
+        safe = StatisticalGlyph.filter_kwargs(raw)
+        assert sorted(safe) == ["alpha", "bins"], f"unexpected keys: {sorted(safe)}"
+        assert safe["bins"] == 20, "values must be preserved"
+
+    def test_filter_then_histogram_does_not_raise(self):
+        """Pre-filtering lets a forwarded bag flow into histogram() cleanly.
+
+        Test scenario:
+            histogram() validates kwargs strictly; filtering an unknown key
+            out first avoids the ValueError while keeping accepted styling.
+        """
+        raw = {"bins": 10, "totally_unknown": 1}
+        stat = StatisticalGlyph(np.arange(20, dtype=float))
+        with pytest.raises(ValueError, match="totally_unknown"):
+            stat.histogram(**raw)
+        safe = StatisticalGlyph.filter_kwargs(raw)
+        fig, ax, hist = stat.histogram(**safe)
+        assert len(hist["n"]) == 1, "histogram should produce one series"

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -467,3 +467,80 @@ class TestStripes:
         assert typing.get_args(hints["return"]) == (Figure, Axes, BarContainer), (
             f"Unexpected resolved return hint: {hints['return']}"
         )
+
+
+class TestFigParameterRemovedFromRenderers:
+    """`fig` is no longer a per-call parameter on the box/stripe renderers.
+
+    The figure is a construction-time binding; `boxplot`/`multiboxplot`/
+    `stripes` resolve it from the method `ax`, then the constructor
+    `ax`/`fig`, then a fresh figure. Passing `fig=` to these methods is a
+    (now removed) keyword and must be rejected.
+    """
+
+    @pytest.mark.parametrize("method", ["boxplot", "multiboxplot", "stripes"])
+    def test_fig_kwarg_rejected(self, method):
+        """Passing `fig=` to a renderer raises TypeError (param removed).
+
+        Args:
+            method: Renderer method name under test.
+
+        Test scenario:
+            The breaking change removed `fig` from these signatures, so
+            `fig=` is now an unexpected keyword argument.
+        """
+        fig, ax = plt.subplots()
+        stat = StatisticalGlyph(np.arange(12, dtype=float).reshape(4, 3))
+        with pytest.raises(TypeError, match="fig"):
+            getattr(stat, method)(fig=fig)
+
+    def test_boxplot_falls_back_to_constructor_axes(self):
+        """`boxplot()` with no `ax` uses the axes bound at construction.
+
+        Test scenario:
+            The renderer resolves `ax` from `self._ax` when the method `ax`
+            argument is omitted, composing onto the constructor's axes.
+        """
+        fig, ax = plt.subplots()
+        stat = StatisticalGlyph(np.arange(9, dtype=float), ax=ax)
+        out_fig, out_ax, _ = stat.boxplot()
+        assert out_ax is ax, "boxplot should reuse the constructor axes"
+        assert out_fig is ax.get_figure(), "figure must come from that axes"
+
+    def test_boxplot_falls_back_to_constructor_figure(self):
+        """`boxplot()` with only a constructor `fig` adds an axes to it.
+
+        Test scenario:
+            With no axes anywhere but a constructor figure, the renderer adds
+            a subplot to that figure rather than creating a new one.
+        """
+        fig = plt.figure()
+        stat = StatisticalGlyph(np.arange(9, dtype=float), fig=fig)
+        out_fig, out_ax, _ = stat.boxplot()
+        assert out_fig is fig, "boxplot should add an axes to the constructor figure"
+        assert out_ax in fig.axes, "the new axes must belong to that figure"
+
+    def test_method_ax_wins_over_constructor_ax(self):
+        """A method `ax=` overrides the axes bound at construction.
+
+        Test scenario:
+            Resolution priority: the explicit `boxplot(ax=)` takes precedence
+            over `self._ax`.
+        """
+        ctor_fig, ctor_ax = plt.subplots()
+        call_fig, call_ax = plt.subplots()
+        stat = StatisticalGlyph(np.arange(9, dtype=float), ax=ctor_ax)
+        _, out_ax, _ = stat.boxplot(ax=call_ax)
+        assert out_ax is call_ax, "method ax should win over constructor ax"
+
+    def test_stripes_falls_back_to_constructor_axes(self):
+        """`stripes()` resolves the axes from the constructor when omitted.
+
+        Test scenario:
+            Same constructor-axes fallback as boxplot, for the 1-D stripes
+            renderer.
+        """
+        fig, ax = plt.subplots()
+        stat = StatisticalGlyph(np.array([0.1, 0.5, 0.9]), ax=ax)
+        _, out_ax, _ = stat.stripes(cmap="coolwarm")
+        assert out_ax is ax, "stripes should reuse the constructor axes"

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -545,6 +545,31 @@ class TestFigParameterRemovedFromRenderers:
         _, out_ax, _ = stat.stripes(cmap="coolwarm")
         assert out_ax is ax, "stripes should reuse the constructor axes"
 
+    def test_multiboxplot_falls_back_to_constructor_axes(self):
+        """`multiboxplot()` resolves the axes from the constructor when omitted.
+
+        Test scenario:
+            Same constructor-axes fallback as boxplot/stripes, for the
+            grouped `multiboxplot` renderer (requires 2D values).
+        """
+        fig, ax = plt.subplots()
+        stat = StatisticalGlyph(np.arange(12, dtype=float).reshape(4, 3), ax=ax)
+        _, out_ax, _ = stat.multiboxplot(positions=[1, 2, 3])
+        assert out_ax is ax, "multiboxplot should reuse the constructor axes"
+
+    def test_multiboxplot_falls_back_to_constructor_figure(self):
+        """`multiboxplot()` with only a constructor `fig` adds an axes to it.
+
+        Test scenario:
+            With no axes anywhere but a constructor figure, the renderer adds
+            a subplot to that figure rather than creating a new one.
+        """
+        fig = plt.figure()
+        stat = StatisticalGlyph(np.arange(12, dtype=float).reshape(4, 3), fig=fig)
+        out_fig, out_ax, _ = stat.multiboxplot(positions=[1, 2, 3])
+        assert out_fig is fig, "multiboxplot should add an axes to the constructor figure"
+        assert out_ax in fig.axes, "the new axes must belong to that figure"
+
 
 class TestOptionKeysAndFilterKwargs:
     """Tests for `StatisticalGlyph.option_keys` / `filter_kwargs` (issue #131).


### PR DESCRIPTION
# Issues

- Fixes #128
- Fixes #129
- Fixes #130
- Fixes #131

The full `ArrayGlyph`/glyph parity set — all aimed at making the glyphs usable as layers in shared-axes composition (the downstream Digital-Earth `Scene`/`Map`).

> ⚠️ **Breaking change** (StatisticalGlyph) — see the StatisticalGlyph section. The mappable/colorbar (#128/#129) and introspection (#131) work is non-breaking; the glyph-API standardization (#130) adds one breaking change to `StatisticalGlyph`.

## #129 — expose the mappable

`ArrayGlyph` now stores the colour-mapped artist on **`self.im`** for every kind:

| kind | `self.im` type |
|------|----------------|
| `imshow` / RGB | `AxesImage` |
| `pcolormesh` | `QuadMesh` |
| `contour` / `contourf` | `QuadContourSet` |

`plot()` still returns `(fig, ax)` (non-breaking); the handle is reachable via `glyph.im`.

## #128 — suppress the built-in colorbar

`add_colorbar` (default `True`) added to `DEFAULT_OPTIONS` and guarded in `plot` and `animate`. With `add_colorbar=False`, `self.cbar` stays `None` and no colorbar axes is added.

## #130 — `ax`/`title` on `ArrayGlyph.plot` + ax/fig standardization

Standardize the glyph API so the **axes is the per-call render target** and the **figure is a construction-time binding**:

- `ArrayGlyph.plot` now accepts `ax=` and `title=` (parity with Scatter/Vector/Polygon/Line). Axes resolution priority: `plot(ax=)` > constructor `ax` > fresh figure. `fig` is intentionally *not* a plot param (derived from `ax.get_figure()`).
- `Glyph.__init__` no longer drops a constructor `ax` when `fig` is omitted — it derives `self.fig = ax.get_figure()`.
- Scatter/Polygon/Vector/Line/Mesh already followed this convention — unchanged.

## #131 — pre-construction option introspection

New, additive helpers so a consumer that forwards a bag of styling kwargs can pre-filter it instead of hitting the strict-kwarg `ValueError` on construction:

```python
ScatterGlyph.option_keys()                 # -> set of accepted keys, no instance needed
safe = PolygonGlyph.filter_kwargs(raw)     # -> only the keys PolygonGlyph accepts
PolygonGlyph(polys, values=v, **safe)      # no raise
```

- `Glyph` gains a `DEFAULT_OPTIONS` class attribute + `option_keys()` / `filter_kwargs()` classmethods.
- Each glyph sets `DEFAULT_OPTIONS = <its *_DEFAULT_OPTIONS dict>` (single source of truth, correct per glyph).
- `StatisticalGlyph` gets matching helpers for parity. Strict `_merge_kwargs` is unchanged.

## ⚠️ Breaking change — StatisticalGlyph

`StatisticalGlyph.boxplot` / `multiboxplot` / `stripes` **no longer accept a `fig` parameter**. The figure is now bound at construction:

```python
# before
StatisticalGlyph(values).boxplot(ax=ax, fig=fig)
# after
StatisticalGlyph(values, fig=fig).boxplot(ax=ax)
```

These renderers resolve the axes as: method `ax` > constructor `ax` > constructor `fig` > new figure. A stray `fig=` (absorbed via `**kwargs`) now raises a clear `TypeError`.

## Tests & docs

- New/expanded test classes across `test_array_glyph.py`, `test_glyph.py`, `test_statistical_glyph.py`.
- Coverage: `glyph.py` 100%, `statistical_glyph.py` 100%, `array_glyph.py` 97% (line+branch).
- Docstrings updated across all touched modules; module doctests pass.
- Full suite: **669 passed, 3 skipped**.
