### PR TITLE
fix(glyph): flat-data guard, MeshGlyph mappable, colorbar toggles, per-band RGB stretch

### DIFF
--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -535,8 +535,10 @@ class ArrayGlyph(Glyph):
             self.default_options["cmap"] = DIVERGING_DEFAULT_CMAP
 
         self._arr = array
-        # get the tick spacing that has 10 ticks only
-        self.ticks_spacing = (self._vmax - self._vmin) / 10
+        # get the tick spacing that has 10 ticks only; fall back to 1.0 for a
+        # degenerate range (constant-value array, vmax == vmin) so the tick
+        # math never divides by zero (mirrors the shared scalar-mapping path).
+        self.ticks_spacing = (self._vmax - self._vmin) / 10 or 1.0
         shape = array.shape
         # Cells in the data domain (not masked, not NaN). Use the same
         # predicate plot/animate use to place per-cell labels so the counts
@@ -1470,31 +1472,97 @@ class ArrayGlyph(Glyph):
         arr = arr if arr.dtype == "uint8" else self.scale_to_rgb()
         return Image.fromarray(arr).convert("RGB")
 
-    def scale_to_rgb(self, arr: np.ndarray = None) -> np.ndarray:
-        """Create an RGB image.
+    def scale_to_rgb(
+        self,
+        arr: np.ndarray = None,
+        per_band: bool = False,
+        percentile: tuple[float, float] = (2.0, 98.0),
+    ) -> np.ndarray:
+        """Scale an array to the 0-255 ``uint8`` range for RGB rendering.
+
+        Two modes are available:
+
+        - **Global (default, `per_band=False`):** scale the whole array by a
+          single maximum (`arr * 255 / arr.max()`). Suitable for a single
+          band or when all bands share a range.
+        - **Per-band percentile stretch (`per_band=True`):** stretch each band
+          (the last axis of a ``(rows, cols, bands)`` array) independently
+          between its `percentile` low/high cut, clip to that range, and map
+          to 0-255. This is the contrast stretch typically wanted for true
+          RGB composites where bands have different dynamic ranges.
 
         Args:
-            arr: array. if None, the array in the object will be used.
+            arr: Array to scale. If None, the glyph's own array is used.
+                For `per_band=True` it must be 3-D ``(rows, cols, bands)``.
+            per_band: When True, stretch each band independently using
+                `percentile`. When False (default), use the legacy single
+                global-max scaling. Defaults to False.
+            percentile: ``(low, high)`` percentile cuts for the per-band
+                stretch, by default ``(2.0, 98.0)``. Ignored when
+                `per_band` is False.
+
+        Returns:
+            np.ndarray: A ``uint8`` array of the same shape as the input,
+                with values in 0-255. The input array is not modified.
+
+        Raises:
+            ValueError: If `per_band=True` and `arr` is not a 3-D
+                ``(rows, cols, bands)`` array.
 
         Examples:
-        ```python
-        >>> import numpy as np
-        >>> arr = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
-        >>> array = ArrayGlyph(arr)
-        >>> rgb_array = array.scale_to_rgb()
-        >>> print(rgb_array)
-        [[28 56 85]
-         [113 141 170]
-         [198 226 255]]
-        >>> print(rgb_array.dtype)
-        uint8
+            - Global scaling of a single band (default):
+                ```python
+                >>> import numpy as np
+                >>> arr = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+                >>> array = ArrayGlyph(arr)
+                >>> rgb_array = array.scale_to_rgb()
+                >>> print(rgb_array)
+                [[28 56 85]
+                 [113 141 170]
+                 [198 226 255]]
+                >>> print(rgb_array.dtype)
+                uint8
 
-        ```
+                ```
+            - Per-band percentile stretch of a 3-band composite (each band
+              spans the full 0-255 range independently):
+                ```python
+                >>> import numpy as np
+                >>> rng = np.random.default_rng(0)
+                >>> stack = rng.uniform(10, 200, size=(8, 8, 3))
+                >>> array = ArrayGlyph(np.zeros((4, 4)))   # any 2-D placeholder
+                >>> out = array.scale_to_rgb(stack, per_band=True)
+                >>> out.shape, out.dtype
+                ((8, 8, 3), dtype('uint8'))
+                >>> int(out[..., 0].min()), int(out[..., 0].max())
+                (0, 255)
+
+                ```
         """
         if arr is None:
             arr = self.arr
-        # This is done to scale the values between 0 and 255
-        return (arr * 255 / arr.max()).astype("uint8")
+
+        if per_band:
+            arr = np.asarray(arr, dtype="float64")
+            if arr.ndim != 3:
+                raise ValueError(
+                    "per_band=True requires a 3-D (rows, cols, bands) array; "
+                    f"got {arr.ndim}-D shape {arr.shape}."
+                )
+            lo_p, hi_p = percentile
+            out = np.empty(arr.shape, dtype="float64")
+            for band in range(arr.shape[-1]):
+                values = arr[..., band]
+                lo, hi = np.nanpercentile(values, [lo_p, hi_p])
+                if hi <= lo:
+                    hi = lo + 1.0
+                out[..., band] = np.clip((values - lo) / (hi - lo), 0.0, 1.0)
+            return (out * 255).astype("uint8")
+
+        # Legacy global-max scaling. Guard against an all-zero array so a
+        # max of 0 does not divide by zero (returns all-zeros instead).
+        denominator = arr.max() or 1
+        return (arr * 255 / denominator).astype("uint8")
 
     @staticmethod
     def _plot_text(
@@ -2090,9 +2158,10 @@ class ArrayGlyph(Glyph):
                 self._vmin = vmin_final
                 self._vmax = vmax_final
                 # Keep ticks_spacing in sync with the new colour range
-                # unless the caller pinned it explicitly.
+                # unless the caller pinned it explicitly (fall back to 1.0
+                # for a degenerate range so the tick math stays safe).
                 if "ticks_spacing" not in kwargs:
-                    self.ticks_spacing = (vmax_final - vmin_final) / 10
+                    self.ticks_spacing = (vmax_final - vmin_final) / 10 or 1.0
                     self.default_options["ticks_spacing"] = self.ticks_spacing
 
             # Auto-switch the colormap to a diverging default when the
@@ -2116,8 +2185,15 @@ class ArrayGlyph(Glyph):
 
             # Create colorbar, unless the caller opted out (e.g. shared-axes
             # composition where the host owns a single aggregated colorbar).
+            # A constant-value field rendered as line `contour` has no level
+            # crossings, so matplotlib cannot build a line colorbar from that
+            # degenerate contour set — skip it (nothing to show) rather than
+            # crash. (`contourf`/`imshow`/`pcolormesh` are unaffected.)
             self.cbar = None
-            if self.default_options["add_colorbar"]:
+            degenerate_contour = (
+                effective_kind == "contour" and self._vmax == self._vmin
+            )
+            if self.default_options["add_colorbar"] and not degenerate_contour:
                 self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
         ax.set_title(

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1489,7 +1489,9 @@ class ArrayGlyph(Glyph):
           (the last axis of a ``(rows, cols, bands)`` array) independently
           between its `percentile` low/high cut, clip to that range, and map
           to 0-255. This is the contrast stretch typically wanted for true
-          RGB composites where bands have different dynamic ranges.
+          RGB composites where bands have different dynamic ranges. A band
+          with no usable range (all-NaN, or flat where the two cuts coincide)
+          has nothing to stretch and is returned as a flat zero band.
 
         Args:
             arr: Array to scale. If None, the glyph's own array is used.
@@ -1687,6 +1689,10 @@ class ArrayGlyph(Glyph):
                         aggregated color bar; then `self.cbar` stays
                         None and no axes space is taken by a color bar.
                         The mappable is still reachable via `self.im`.
+                        Note: for a constant-value field rendered as line
+                        `contour` there are no contour lines to map, so the
+                        color bar is skipped (with a warning) even when
+                        `add_colorbar` is True, and `self.cbar` stays None.
                     cbar_orientation : str, optional
                         Orientation of the color bar, by default 'vertical'.
                         Can be 'horizontal' or 'vertical'.

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1553,9 +1553,17 @@ class ArrayGlyph(Glyph):
             out = np.empty(arr.shape, dtype="float64")
             for band in range(arr.shape[-1]):
                 values = arr[..., band]
-                lo, hi = np.nanpercentile(values, [lo_p, hi_p])
-                if hi <= lo:
-                    hi = lo + 1.0
+                with warnings.catch_warnings():
+                    # An all-NaN band makes `nanpercentile` warn and return
+                    # NaN cuts; handle that below instead of propagating it.
+                    warnings.simplefilter("ignore", RuntimeWarning)
+                    lo, hi = np.nanpercentile(values, [lo_p, hi_p])
+                # A band with no usable range (all-NaN, or flat where the cuts
+                # coincide) has nothing to stretch — emit a flat zero band
+                # rather than dividing by zero / propagating NaN into uint8.
+                if not (np.isfinite(lo) and np.isfinite(hi)) or hi <= lo:
+                    out[..., band] = 0.0
+                    continue
                 out[..., band] = np.clip((values - lo) / (hi - lo), 0.0, 1.0)
             return (out * 255).astype("uint8")
 
@@ -2193,8 +2201,15 @@ class ArrayGlyph(Glyph):
             degenerate_contour = (
                 effective_kind == "contour" and self._vmax == self._vmin
             )
-            if self.default_options["add_colorbar"] and not degenerate_contour:
-                self.cbar = self.create_color_bar(ax, im, cbar_kw)
+            if self.default_options["add_colorbar"]:
+                if degenerate_contour:
+                    warnings.warn(
+                        "Constant-value field has no contour lines; skipping "
+                        "the colorbar for kind='contour'.",
+                        stacklevel=2,
+                    )
+                else:
+                    self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
         ax.set_title(
             self.default_options["title"], fontsize=self.default_options["title_size"]

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1567,6 +1567,9 @@ class ArrayGlyph(Glyph):
                     out[..., band] = 0.0
                     continue
                 out[..., band] = np.clip((values - lo) / (hi - lo), 0.0, 1.0)
+            # Map any residual NaN (e.g. NaN pixels within an otherwise-valid
+            # band) to 0 so the uint8 cast is deterministic and warning-free.
+            out = np.nan_to_num(out, nan=0.0)
             return (out * 255).astype("uint8")
 
         # Legacy global-max scaling. Guard against an all-zero array so a

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -394,6 +394,12 @@ class Glyph:
         ticks_spacing = self.default_options["ticks_spacing"]
         vmax = self.default_options["vmax"]
         vmin = self.default_options["vmin"]
+        # A degenerate colour range (e.g. a constant-value array where
+        # vmax == vmin, so ticks_spacing is 0) has no meaningful tick
+        # spacing; return a single tick at the value rather than dividing
+        # by zero in `np.arange` / `math.remainder` below.
+        if not ticks_spacing or vmax <= vmin:
+            return np.array([vmin])
         ticks = np.arange(vmin, vmax + ticks_spacing, ticks_spacing)
         # If vmax is not evenly divisible by spacing, append one more tick.
         remainder = np.round(math.remainder(vmax, ticks_spacing), 3)

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -146,6 +146,9 @@ class MeshGlyph(Glyph):
         self._cached_tri_array: np.ndarray | None = None
         self._cached_nodes_per_face: np.ndarray | None = None
         self._cbar = None
+        #: Colour-mapped artist from the most recent `plot` call (the
+        #: `tripcolor`/`tricontour(f)` mappable); `None` before first render.
+        self.im = None
 
     @property
     def node_x(self) -> np.ndarray:
@@ -653,6 +656,11 @@ class MeshGlyph(Glyph):
             filled=filled,
             **render_kwargs,
         )
+        # Expose the colour-mapped artist (the `PolyCollection` from
+        # `tripcolor`, or the `TriContourSet` from `tricontour(f)`) so a
+        # caller can attach a colorbar/register the layer without scraping
+        # `ax.collections` (mirrors `ArrayGlyph.im` / the other glyphs).
+        self.im = tpc
 
         # Remove previous colorbar before adding a new one.
         if self._cbar is not None:

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -867,6 +867,11 @@ class MeshGlyph(Glyph):
                 `plt.close(fig)` after saving to avoid memory leaks
                 in batch processing.
 
+        Notes:
+            An outline carries no scalar mapping, so this resets `self.im`
+            to None (clearing any colour-mapped artist left by a prior
+            `plot()` call).
+
         Examples:
             - Render a triangular mesh wireframe:
                 ```python

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -896,6 +896,10 @@ class MeshGlyph(Glyph):
         self.ax.autoscale()
         self.ax.set_aspect("equal")
 
+        # An outline carries no scalar mapping, so clear any colour-mapped
+        # artist left on `self.im` by a previous `plot()` call.
+        self.im = None
+
         return self.fig, self.ax
 
     def _build_edge_segments(self) -> np.ndarray:

--- a/src/cleopatra/polygon_glyph.py
+++ b/src/cleopatra/polygon_glyph.py
@@ -137,6 +137,7 @@ class PolygonGlyph(Glyph):
         outline_only: bool = False,
         ax: Axes = None,
         title: str | None = None,
+        add_colorbar: bool | None = None,
     ) -> tuple[Figure, Axes, PolyCollection]:
         """Draw the polygons, filling by value when present.
 
@@ -153,6 +154,10 @@ class PolygonGlyph(Glyph):
                 construction, otherwise a new figure/axes is created.
             title: Plot title. Overrides `default_options["title"]`
                 when given.
+            add_colorbar: Override the `add_colorbar` option for this call
+                — True draws the colorbar, False suppresses it (for
+                shared-axes composition). Defaults to None, which keeps the
+                value set at construction.
 
         Returns:
             tuple[Figure, Axes, PolyCollection]: The figure, the axes,
@@ -183,6 +188,8 @@ class PolygonGlyph(Glyph):
 
         if title is not None:
             opts["title"] = title
+        if add_colorbar is not None:
+            opts["add_colorbar"] = add_colorbar
 
         if outline_only or self.values is None:
             pc = PolyCollection(

--- a/src/cleopatra/polygon_glyph.py
+++ b/src/cleopatra/polygon_glyph.py
@@ -188,8 +188,11 @@ class PolygonGlyph(Glyph):
 
         if title is not None:
             opts["title"] = title
-        if add_colorbar is not None:
-            opts["add_colorbar"] = add_colorbar
+        # Resolve the colorbar choice for this call only (a plot-time
+        # override does not persist into the glyph's options).
+        draw_colorbar = (
+            opts["add_colorbar"] if add_colorbar is None else add_colorbar
+        )
 
         if outline_only or self.values is None:
             pc = PolyCollection(
@@ -214,7 +217,7 @@ class PolygonGlyph(Glyph):
                 pc.set_clim(ticks[0], ticks[-1])
             ax.add_collection(pc)
             ax.autoscale_view()
-            if opts["add_colorbar"]:
+            if draw_colorbar:
                 self.cbar = self.create_color_bar(ax, pc, cbar_kw)
 
         if opts["title"]:

--- a/src/cleopatra/polygon_glyph.py
+++ b/src/cleopatra/polygon_glyph.py
@@ -51,6 +51,7 @@ POLYGON_DEFAULT_OPTIONS = {
     "vmax": None,
     "levels": None,
     "ticks_spacing": None,
+    "add_colorbar": True,
 }
 POLYGON_DEFAULT_OPTIONS = STYLE_DEFAULTS | POLYGON_DEFAULT_OPTIONS
 
@@ -76,7 +77,9 @@ class PolygonGlyph(Glyph):
         **kwargs: Override any key in `POLYGON_DEFAULT_OPTIONS`
             (e.g. `edgecolor`, `linewidth`, `cmap`, `vmin`, `vmax`,
             `levels`, `color_scale`, `ticks_spacing`, `cbar_label`,
-            `figsize`, `title`).
+            `figsize`, `title`). Set `add_colorbar=False` to suppress the
+            per-glyph colorbar (default True) for shared-axes composition
+            where the host owns a single aggregated colorbar.
 
     Raises:
         ValueError: If `values` is given but its length does not match
@@ -204,7 +207,8 @@ class PolygonGlyph(Glyph):
                 pc.set_clim(ticks[0], ticks[-1])
             ax.add_collection(pc)
             ax.autoscale_view()
-            self.cbar = self.create_color_bar(ax, pc, cbar_kw)
+            if opts["add_colorbar"]:
+                self.cbar = self.create_color_bar(ax, pc, cbar_kw)
 
         if opts["title"]:
             ax.set_title(opts["title"], fontsize=opts["title_size"])

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -143,6 +143,7 @@ class ScatterGlyph(Glyph):
         self,
         ax: Axes = None,
         title: str | None = None,
+        add_colorbar: bool | None = None,
     ) -> tuple[Figure, Axes, PathCollection]:
         """Draw the point cloud, colour-mapping by value when present.
 
@@ -157,6 +158,10 @@ class ScatterGlyph(Glyph):
                 construction, otherwise a new figure/axes is created.
             title: Plot title. Overrides `default_options["title"]`
                 when given.
+            add_colorbar: Override the `add_colorbar` option for this call
+                — True draws the colorbar, False suppresses it (for
+                shared-axes composition). Defaults to None, which keeps the
+                value set at construction.
 
         Returns:
             tuple[Figure, Axes, PathCollection]: The figure, the axes,
@@ -199,6 +204,8 @@ class ScatterGlyph(Glyph):
 
         if title is not None:
             opts["title"] = title
+        if add_colorbar is not None:
+            opts["add_colorbar"] = add_colorbar
 
         if self.values is None:
             paths = ax.scatter(

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -52,6 +52,7 @@ SCATTER_DEFAULT_OPTIONS = {
     "vmax": None,
     "levels": None,
     "ticks_spacing": None,
+    "add_colorbar": True,
 }
 SCATTER_DEFAULT_OPTIONS = STYLE_DEFAULTS | SCATTER_DEFAULT_OPTIONS
 
@@ -76,7 +77,9 @@ class ScatterGlyph(Glyph):
         **kwargs: Override any key in `SCATTER_DEFAULT_OPTIONS`
             (e.g. `marker`, `point_size`, `cmap`, `vmin`, `vmax`,
             `levels`, `color_scale`, `ticks_spacing`, `cbar_label`,
-            `figsize`, `title`).
+            `figsize`, `title`). Set `add_colorbar=False` to suppress the
+            per-glyph colorbar (default True) for shared-axes composition
+            where the host owns a single aggregated colorbar.
 
     Raises:
         ValueError: If `x` and `y` (or `values`, when given) have
@@ -217,7 +220,8 @@ class ScatterGlyph(Glyph):
                 vmin=None if norm else ticks[0],
                 vmax=None if norm else ticks[-1],
             )
-            self.cbar = self.create_color_bar(ax, paths, cbar_kw)
+            if opts["add_colorbar"]:
+                self.cbar = self.create_color_bar(ax, paths, cbar_kw)
 
         if opts["title"]:
             ax.set_title(opts["title"], fontsize=opts["title_size"])

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -204,8 +204,11 @@ class ScatterGlyph(Glyph):
 
         if title is not None:
             opts["title"] = title
-        if add_colorbar is not None:
-            opts["add_colorbar"] = add_colorbar
+        # Resolve the colorbar choice for this call only (a plot-time
+        # override does not persist into the glyph's options).
+        draw_colorbar = (
+            opts["add_colorbar"] if add_colorbar is None else add_colorbar
+        )
 
         if self.values is None:
             paths = ax.scatter(
@@ -227,7 +230,7 @@ class ScatterGlyph(Glyph):
                 vmin=None if norm else ticks[0],
                 vmax=None if norm else ticks[-1],
             )
-            if opts["add_colorbar"]:
+            if draw_colorbar:
                 self.cbar = self.create_color_bar(ax, paths, cbar_kw)
 
         if opts["title"]:

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -128,6 +128,7 @@ class VectorGlyph(Glyph):
         kind: str = "quiver",
         ax: Axes = None,
         title: str | None = None,
+        add_colorbar: bool | None = None,
     ):
         """Render the vector field, coloured by magnitude.
 
@@ -142,6 +143,10 @@ class VectorGlyph(Glyph):
                 construction, otherwise a new figure/axes is created.
             title: Plot title. Overrides `default_options["title"]`
                 when given.
+            add_colorbar: Override the `add_colorbar` option for this call
+                — True draws the colorbar, False suppresses it (for
+                shared-axes composition). Defaults to None, which keeps the
+                value set at construction.
 
         Returns:
             tuple[Figure, Axes, Any]: The figure, the axes, and the
@@ -198,6 +203,8 @@ class VectorGlyph(Glyph):
 
         if title is not None:
             opts["title"] = title
+        if add_colorbar is not None:
+            opts["add_colorbar"] = add_colorbar
 
         mag = self.magnitude
         norm, cbar_kw, ticks = self._prepare_scalar_mapping(mag)

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -203,8 +203,11 @@ class VectorGlyph(Glyph):
 
         if title is not None:
             opts["title"] = title
-        if add_colorbar is not None:
-            opts["add_colorbar"] = add_colorbar
+        # Resolve the colorbar choice for this call only (a plot-time
+        # override does not persist into the glyph's options).
+        draw_colorbar = (
+            opts["add_colorbar"] if add_colorbar is None else add_colorbar
+        )
 
         mag = self.magnitude
         norm, cbar_kw, ticks = self._prepare_scalar_mapping(mag)
@@ -235,7 +238,7 @@ class VectorGlyph(Glyph):
             if norm is None:
                 im.set_clim(ticks[0], ticks[-1])
 
-        if opts["add_colorbar"]:
+        if draw_colorbar:
             self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
         if opts["title"]:

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -48,6 +48,7 @@ VECTOR_DEFAULT_OPTIONS = {
     "vmax": None,
     "levels": None,
     "ticks_spacing": None,
+    "add_colorbar": True,
 }
 VECTOR_DEFAULT_OPTIONS = STYLE_DEFAULTS | VECTOR_DEFAULT_OPTIONS
 
@@ -69,7 +70,9 @@ class VectorGlyph(Glyph):
         **kwargs: Override any key in `VECTOR_DEFAULT_OPTIONS`
             (e.g. `density`, `scale`, `cmap`, `vmin`, `vmax`, `levels`,
             `color_scale`, `ticks_spacing`, `cbar_label`, `figsize`,
-            `title`).
+            `title`). Set `add_colorbar=False` to suppress the per-glyph
+            colorbar (default True) for shared-axes composition where the
+            host owns a single aggregated colorbar.
 
     Examples:
         - Build a field and inspect the stored magnitude:
@@ -225,7 +228,8 @@ class VectorGlyph(Glyph):
             if norm is None:
                 im.set_clim(ticks[0], ticks[-1])
 
-        self.cbar = self.create_color_bar(ax, im, cbar_kw)
+        if opts["add_colorbar"]:
+            self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
         if opts["title"]:
             ax.set_title(opts["title"], fontsize=opts["title_size"])

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3181,3 +3181,105 @@ class TestPlotAxAndTitleParams:
             assert out_ax is ax, "ax-only construction must be honoured by plot()"
         finally:
             plt.close(fig)
+
+
+class TestConstantValueArray:
+    """Constant-value (flat) arrays must render without dividing by zero (#61/#4)."""
+
+    @pytest.mark.parametrize("kind", ["imshow", "pcolormesh", "contourf", "contour"])
+    def test_flat_array_plots_without_error(self, kind):
+        """A constant field renders for every kind (no ZeroDivisionError).
+
+        Args:
+            kind: The render kind under test.
+
+        Test scenario:
+            `vmax == vmin` made `ticks_spacing` zero and the tick math raised;
+            the guard now lets a flat array plot for every kind. Line `contour`
+            additionally skips its (degenerate, empty) colorbar.
+        """
+        glyph = ArrayGlyph(np.full((10, 10), 5.0))
+        fig, ax = glyph.plot(kind=kind)
+        try:
+            assert isinstance(fig, Figure), f"kind={kind!r} should render a figure"
+            if kind == "contour":
+                assert glyph.cbar is None, "degenerate contour should skip the colorbar"
+        finally:
+            plt.close(fig)
+
+    def test_all_zero_array_plots(self):
+        """An all-zero array (vmax==vmin==0) also renders without error.
+
+        Test scenario:
+            Boundary of the degenerate case where the value itself is zero.
+        """
+        glyph = ArrayGlyph(np.zeros((5, 5)))
+        fig, ax = glyph.plot(kind="imshow")
+        try:
+            assert isinstance(fig, Figure), "all-zero array should render"
+        finally:
+            plt.close(fig)
+
+
+class TestScaleToRgbPerBand:
+    """Per-band percentile stretch option on `scale_to_rgb` (#1 enhancement)."""
+
+    def test_global_default_unchanged(self):
+        """The default global-max path is unchanged and does not mutate input.
+
+        Test scenario:
+            Backward-compatibility: `per_band=False` keeps the legacy scaling
+            and leaves the source array untouched.
+        """
+        arr = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]])
+        glyph = ArrayGlyph(arr.copy())
+        before = glyph.arr.copy()
+        out = glyph.scale_to_rgb()
+        assert out.dtype == np.uint8, f"expected uint8, got {out.dtype}"
+        assert out[0].tolist() == [28, 56, 85], f"global scaling changed: {out[0]}"
+        assert np.array_equal(glyph.arr, before), "scale_to_rgb must not mutate self.arr"
+
+    def test_per_band_stretches_each_band_to_full_range(self):
+        """`per_band=True` maps each band independently across 0-255.
+
+        Test scenario:
+            A 3-band stack with differing per-band ranges comes back uint8 with
+            each band spanning the full 0-255 range after the percentile cut.
+        """
+        rng = np.random.default_rng(0)
+        stack = rng.uniform(10.0, 200.0, size=(8, 8, 3))
+        out = ArrayGlyph(np.zeros((4, 4))).scale_to_rgb(stack, per_band=True)
+        assert out.shape == (8, 8, 3) and out.dtype == np.uint8, "shape/dtype wrong"
+        for band in range(3):
+            assert int(out[..., band].min()) == 0, f"band {band} min should be 0"
+            assert int(out[..., band].max()) == 255, f"band {band} max should be 255"
+
+    def test_per_band_does_not_mutate_input(self):
+        """The per-band path leaves the source array unmodified.
+
+        Test scenario:
+            Purity — the caller's stack is unchanged after stretching.
+        """
+        stack = np.random.default_rng(1).uniform(0, 100, size=(5, 5, 3))
+        before = stack.copy()
+        ArrayGlyph(np.zeros((4, 4))).scale_to_rgb(stack, per_band=True)
+        assert np.array_equal(stack, before), "input stack must not be mutated"
+
+    def test_per_band_requires_3d(self):
+        """`per_band=True` on a non-3-D array raises a clear ValueError.
+
+        Test scenario:
+            A 2-D array has no band axis, so per-band stretching is rejected.
+        """
+        with pytest.raises(ValueError, match="3-D"):
+            ArrayGlyph(np.zeros((4, 4))).scale_to_rgb(np.zeros((4, 4)), per_band=True)
+
+    def test_all_zero_global_no_zero_division(self):
+        """Global scaling of an all-zero array returns zeros, not a crash.
+
+        Test scenario:
+            `arr.max() == 0` previously divided by zero; the guard returns an
+            all-zero uint8 array instead.
+        """
+        out = ArrayGlyph(np.zeros((3, 3))).scale_to_rgb()
+        assert out.dtype == np.uint8 and int(out.max()) == 0, "expected all-zero uint8"

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3235,6 +3235,24 @@ class TestConstantValueArray:
         finally:
             plt.close(fig)
 
+    def test_constant_contourf_does_not_warn(self):
+        """A constant-field filled `contourf` draws normally without warning.
+
+        Test scenario:
+            The degenerate-contour warning is specific to line `contour`;
+            `contourf` fills a region and keeps its colorbar.
+        """
+        import warnings as _warnings
+
+        glyph = ArrayGlyph(np.full((10, 10), 5.0))
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error", UserWarning)
+            fig, ax = glyph.plot(kind="contourf")
+        try:
+            assert glyph.cbar is not None, "contourf should still draw a colorbar"
+        finally:
+            plt.close(fig)
+
 
 class TestScaleToRgbPerBand:
     """Per-band percentile stretch option on `scale_to_rgb` (#1 enhancement)."""
@@ -3318,3 +3336,18 @@ class TestScaleToRgbPerBand:
         assert out.dtype == np.uint8, "expected uint8 output"
         assert int(out[..., 0].max()) == 0, "all-NaN band should be zero-filled"
         assert int(out[..., 1].max()) == 0, "flat band has no range -> zero"
+
+    def test_per_band_partial_nan_band_stretches_finite_values(self):
+        """A band with some NaNs stretches its finite values across 0-255.
+
+        Test scenario:
+            NaN pixels do not break the stretch; the finite part still spans
+            the full output range (NaN pixels are not asserted on, only that
+            the band has real contrast and the call does not raise).
+        """
+        rng = np.random.default_rng(3)
+        stack = rng.uniform(10.0, 200.0, size=(6, 6, 3))
+        stack[0, 0, 0] = np.nan  # a single NaN pixel in band 0
+        out = ArrayGlyph(np.zeros((4, 4))).scale_to_rgb(stack, per_band=True)
+        assert out.dtype == np.uint8, "expected uint8 output"
+        assert int(out[..., 0].max()) == 255, "finite values should still stretch to 255"

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3220,6 +3220,21 @@ class TestConstantValueArray:
         finally:
             plt.close(fig)
 
+    def test_constant_contour_warns_and_skips_colorbar(self):
+        """A constant-field line `contour` warns and draws no colorbar.
+
+        Test scenario:
+            The degenerate contour set cannot back a line colorbar; the glyph
+            warns and leaves `self.cbar` None instead of crashing.
+        """
+        glyph = ArrayGlyph(np.full((10, 10), 5.0))
+        with pytest.warns(UserWarning, match="no contour lines"):
+            fig, ax = glyph.plot(kind="contour")
+        try:
+            assert glyph.cbar is None, "degenerate contour should skip the colorbar"
+        finally:
+            plt.close(fig)
+
 
 class TestScaleToRgbPerBand:
     """Per-band percentile stretch option on `scale_to_rgb` (#1 enhancement)."""
@@ -3283,3 +3298,23 @@ class TestScaleToRgbPerBand:
         """
         out = ArrayGlyph(np.zeros((3, 3))).scale_to_rgb()
         assert out.dtype == np.uint8 and int(out.max()) == 0, "expected all-zero uint8"
+
+    def test_per_band_all_nan_band_is_zero_filled_without_warning(self):
+        """An all-NaN (or flat) band yields a zero band and emits no warning.
+
+        Test scenario:
+            `nanpercentile` on an all-NaN band returns NaN cuts; the guard
+            detects the non-finite range, emits a flat zero band, and the
+            `RuntimeWarning` is suppressed (treated as an error here to prove
+            it does not surface).
+        """
+        import warnings as _warnings
+
+        stack = np.full((4, 4, 3), np.nan)
+        stack[..., 1] = 5.0  # band 1 is a flat (no-range) band
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            out = ArrayGlyph(np.zeros((4, 4))).scale_to_rgb(stack, per_band=True)
+        assert out.dtype == np.uint8, "expected uint8 output"
+        assert int(out[..., 0].max()) == 0, "all-NaN band should be zero-filled"
+        assert int(out[..., 1].max()) == 0, "flat band has no range -> zero"

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3345,9 +3345,14 @@ class TestScaleToRgbPerBand:
             the full output range (NaN pixels are not asserted on, only that
             the band has real contrast and the call does not raise).
         """
+        import warnings as _warnings
+
         rng = np.random.default_rng(3)
         stack = rng.uniform(10.0, 200.0, size=(6, 6, 3))
         stack[0, 0, 0] = np.nan  # a single NaN pixel in band 0
-        out = ArrayGlyph(np.zeros((4, 4))).scale_to_rgb(stack, per_band=True)
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")  # no stray cast warning may surface
+            out = ArrayGlyph(np.zeros((4, 4))).scale_to_rgb(stack, per_band=True)
         assert out.dtype == np.uint8, "expected uint8 output"
         assert int(out[..., 0].max()) == 255, "finite values should still stretch to 255"
+        assert int(out[0, 0, 0]) == 0, "the NaN pixel should map to 0"

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -1471,3 +1471,33 @@ class TestFigureResolutionInternals:
                 return sentinel
 
         assert _immediate_figure(_LegacyAx()) is sentinel, "should return get_figure()"
+
+
+class TestGetTicksDegenerateRange:
+    """`get_ticks` must not divide by zero on a degenerate colour range (#4)."""
+
+    def test_zero_spacing_returns_single_tick(self):
+        """`ticks_spacing == 0` yields a single tick at `vmin`.
+
+        Test scenario:
+            A constant-value field gives `vmax == vmin` and a zero spacing;
+            `get_ticks` returns `[vmin]` rather than calling `np.arange` with
+            a zero step.
+        """
+        opts = _make_options()
+        opts.update({"vmin": 5.0, "vmax": 5.0, "ticks_spacing": 0.0})
+        g = Glyph(default_options=opts)
+        ticks = g.get_ticks()
+        assert ticks.tolist() == [5.0], f"expected a single tick, got {ticks.tolist()}"
+
+    def test_normal_range_unaffected(self):
+        """A normal range still produces evenly spaced ticks.
+
+        Test scenario:
+            Regression guard — the degenerate check does not alter the
+            ordinary path.
+        """
+        opts = _make_options()
+        opts.update({"vmin": 0.0, "vmax": 10.0, "ticks_spacing": 2.0})
+        g = Glyph(default_options=opts)
+        assert g.get_ticks().tolist() == [0.0, 2.0, 4.0, 6.0, 8.0, 10.0], "ticks changed"

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1113,3 +1113,19 @@ class TestMeshGlyphMappable:
             assert glyph.im in ax.collections, "im must be the artist on the axes"
         finally:
             plt.close(fig)
+
+    def test_plot_outline_clears_im(self):
+        """`plot_outline` resets `self.im` (an outline has no scalar mapping).
+
+        Test scenario:
+            After a coloured `plot()` sets `self.im`, an outline-only render
+            must clear it rather than leave a stale mappable.
+        """
+        glyph, x = self._mesh()
+        z = np.random.default_rng(2).random(x.size)
+        fig, ax = glyph.plot(z, location="node", colorbar=False)
+        plt.close(fig)
+        assert glyph.im is not None, "im should be set after a coloured plot"
+        fig, ax = glyph.plot_outline()
+        plt.close(fig)
+        assert glyph.im is None, "plot_outline should clear im"

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1079,3 +1079,37 @@ class TestAnimate:
         path = str(tmp_path / "test.gif")
         mg.save_animation(path, fps=2)
         assert (tmp_path / "test.gif").exists(), "GIF file should be created"
+
+
+class TestMeshGlyphMappable:
+    """`MeshGlyph` exposes the colour-mapped artist as `self.im` (#2)."""
+
+    @staticmethod
+    def _mesh():
+        from matplotlib.tri import Triangulation
+
+        rng = np.random.default_rng(0)
+        x = rng.random(20)
+        y = rng.random(20)
+        return MeshGlyph(x, y, Triangulation(x, y).triangles), x
+
+    def test_im_none_before_plot(self):
+        """`self.im` is None before the first render."""
+        glyph, _ = self._mesh()
+        assert glyph.im is None, "im should start as None"
+
+    def test_plot_sets_im_to_live_artist(self):
+        """After `plot`, `self.im` is the artist registered on the axes.
+
+        Test scenario:
+            The tricontour/tripcolor mappable is stored on `self.im` so a
+            caller need not scrape `ax.collections[-1]`.
+        """
+        glyph, x = self._mesh()
+        z = np.random.default_rng(1).random(x.size)
+        fig, ax = glyph.plot(z, location="node", colorbar=False)
+        try:
+            assert glyph.im is not None, "im should be set after plot"
+            assert glyph.im in ax.collections, "im must be the artist on the axes"
+        finally:
+            plt.close(fig)

--- a/tests/test_polygon_glyph.py
+++ b/tests/test_polygon_glyph.py
@@ -204,3 +204,35 @@ def test_polygon_default_options_extend_style_defaults():
     """
     assert "figsize" in POLYGON_DEFAULT_OPTIONS, "Should inherit base style keys"
     assert "edgecolor" in POLYGON_DEFAULT_OPTIONS, "Should add polygon keys"
+
+
+class TestAddColorbarToggle:
+    """`add_colorbar=False` suppresses PolygonGlyph's colorbar (#3)."""
+
+    @staticmethod
+    def _polys():
+        return [np.array([[0, 0], [1, 0], [1, 1]]), np.array([[1, 1], [2, 1], [2, 2]])]
+
+    def test_default_draws_colorbar(self):
+        """A value-filled polygon layer draws its colorbar by default."""
+        glyph = PolygonGlyph(self._polys(), values=np.array([1.0, 2.0]))
+        fig, ax, _ = glyph.plot()
+        try:
+            assert glyph.cbar is not None, "default should draw a colorbar"
+            assert len(fig.axes) == 2, f"expected 2 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
+    def test_add_colorbar_false_suppresses(self):
+        """`add_colorbar=False` leaves cbar None and adds no axes."""
+        glyph = PolygonGlyph(self._polys(), values=np.array([1.0, 2.0]), add_colorbar=False)
+        fig, ax, _ = glyph.plot()
+        try:
+            assert glyph.cbar is None, "add_colorbar=False should skip the colorbar"
+            assert len(fig.axes) == 1, f"expected 1 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
+    def test_add_colorbar_in_option_keys(self):
+        """`add_colorbar` is an accepted option key."""
+        assert "add_colorbar" in PolygonGlyph.option_keys(), "add_colorbar missing"

--- a/tests/test_polygon_glyph.py
+++ b/tests/test_polygon_glyph.py
@@ -233,6 +233,21 @@ class TestAddColorbarToggle:
         finally:
             plt.close(fig)
 
+    def test_plot_time_override_suppresses(self):
+        """Passing `add_colorbar=False` to `plot` suppresses the colorbar.
+
+        Test scenario:
+            Plot-time override: even with the default construction option,
+            `plot(add_colorbar=False)` draws no colorbar.
+        """
+        glyph = PolygonGlyph(self._polys(), values=np.array([1.0, 2.0]))
+        fig, ax, _ = glyph.plot(add_colorbar=False)
+        try:
+            assert glyph.cbar is None, "plot(add_colorbar=False) should skip the colorbar"
+            assert len(fig.axes) == 1, f"expected 1 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
     def test_add_colorbar_in_option_keys(self):
         """`add_colorbar` is an accepted option key."""
         assert "add_colorbar" in PolygonGlyph.option_keys(), "add_colorbar missing"

--- a/tests/test_scatter_glyph.py
+++ b/tests/test_scatter_glyph.py
@@ -242,3 +242,37 @@ def test_scatter_default_options_extend_style_defaults():
     """
     assert "figsize" in SCATTER_DEFAULT_OPTIONS, "Should inherit base style keys"
     assert "point_size" in SCATTER_DEFAULT_OPTIONS, "Should add scatter keys"
+
+
+class TestAddColorbarToggle:
+    """`add_colorbar=False` suppresses ScatterGlyph's colorbar (#3)."""
+
+    @staticmethod
+    def _xyv():
+        return np.array([0.0, 1.0, 2.0]), np.array([0.0, 1.0, 2.0]), np.array([1.0, 2.0, 3.0])
+
+    def test_default_draws_colorbar(self):
+        """By default a coloured scatter draws its colorbar (extra axes)."""
+        x, y, v = self._xyv()
+        glyph = ScatterGlyph(x, y, values=v)
+        fig, ax, _ = glyph.plot()
+        try:
+            assert glyph.cbar is not None, "default should draw a colorbar"
+            assert len(fig.axes) == 2, f"expected 2 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
+    def test_add_colorbar_false_suppresses(self):
+        """`add_colorbar=False` leaves cbar None and adds no axes."""
+        x, y, v = self._xyv()
+        glyph = ScatterGlyph(x, y, values=v, add_colorbar=False)
+        fig, ax, _ = glyph.plot()
+        try:
+            assert glyph.cbar is None, "add_colorbar=False should skip the colorbar"
+            assert len(fig.axes) == 1, f"expected 1 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
+    def test_add_colorbar_in_option_keys(self):
+        """`add_colorbar` is an accepted option key (no validation error)."""
+        assert "add_colorbar" in ScatterGlyph.option_keys(), "add_colorbar missing"

--- a/tests/test_scatter_glyph.py
+++ b/tests/test_scatter_glyph.py
@@ -273,6 +273,22 @@ class TestAddColorbarToggle:
         finally:
             plt.close(fig)
 
+    def test_plot_time_override_suppresses(self):
+        """Passing `add_colorbar=False` to `plot` suppresses the colorbar.
+
+        Test scenario:
+            Plot-time override mirrors ArrayGlyph: even with the default
+            construction option, `plot(add_colorbar=False)` draws no colorbar.
+        """
+        x, y, v = self._xyv()
+        glyph = ScatterGlyph(x, y, values=v)
+        fig, ax, _ = glyph.plot(add_colorbar=False)
+        try:
+            assert glyph.cbar is None, "plot(add_colorbar=False) should skip the colorbar"
+            assert len(fig.axes) == 1, f"expected 1 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
     def test_add_colorbar_in_option_keys(self):
         """`add_colorbar` is an accepted option key (no validation error)."""
         assert "add_colorbar" in ScatterGlyph.option_keys(), "add_colorbar missing"

--- a/tests/test_scatter_glyph.py
+++ b/tests/test_scatter_glyph.py
@@ -289,6 +289,37 @@ class TestAddColorbarToggle:
         finally:
             plt.close(fig)
 
+    def test_plot_time_override_enables(self):
+        """`plot(add_colorbar=True)` draws even when constructed with False.
+
+        Test scenario:
+            The plot-time override works in both directions — a glyph built
+            with `add_colorbar=False` can still draw a colorbar per-call.
+        """
+        x, y, v = self._xyv()
+        glyph = ScatterGlyph(x, y, values=v, add_colorbar=False)
+        fig, ax, _ = glyph.plot(add_colorbar=True)
+        try:
+            assert glyph.cbar is not None, "plot(add_colorbar=True) should draw"
+            assert len(fig.axes) == 2, f"expected 2 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
+    def test_plot_time_none_keeps_construction_value(self):
+        """`add_colorbar=None` (default) keeps the construction-time setting.
+
+        Test scenario:
+            Omitting the override leaves the constructor's `add_colorbar=False`
+            in force.
+        """
+        x, y, v = self._xyv()
+        glyph = ScatterGlyph(x, y, values=v, add_colorbar=False)
+        fig, ax, _ = glyph.plot()
+        try:
+            assert glyph.cbar is None, "construction-time False should persist"
+        finally:
+            plt.close(fig)
+
     def test_add_colorbar_in_option_keys(self):
         """`add_colorbar` is an accepted option key (no validation error)."""
         assert "add_colorbar" in ScatterGlyph.option_keys(), "add_colorbar missing"

--- a/tests/test_scatter_glyph.py
+++ b/tests/test_scatter_glyph.py
@@ -320,6 +320,27 @@ class TestAddColorbarToggle:
         finally:
             plt.close(fig)
 
+    def test_plot_time_override_does_not_persist(self):
+        """A plot-time `add_colorbar` override does not mutate the glyph options.
+
+        Test scenario:
+            `plot(add_colorbar=False)` suppresses the colorbar for that call
+            only; the glyph's `default_options["add_colorbar"]` stays True so a
+            later `plot()` draws again.
+        """
+        x, y, v = self._xyv()
+        glyph = ScatterGlyph(x, y, values=v)
+        fig, ax, _ = glyph.plot(add_colorbar=False)
+        plt.close(fig)
+        assert glyph.default_options["add_colorbar"] is True, (
+            "override must not persist into default_options"
+        )
+        fig, ax, _ = glyph.plot()
+        try:
+            assert glyph.cbar is not None, "a later plot() should draw again"
+        finally:
+            plt.close(fig)
+
     def test_add_colorbar_in_option_keys(self):
         """`add_colorbar` is an accepted option key (no validation error)."""
         assert "add_colorbar" in ScatterGlyph.option_keys(), "add_colorbar missing"

--- a/tests/test_vector_glyph.py
+++ b/tests/test_vector_glyph.py
@@ -301,6 +301,22 @@ class TestAddColorbarToggle:
         finally:
             plt.close(fig)
 
+    def test_plot_time_override_suppresses(self):
+        """Passing `add_colorbar=False` to `plot` suppresses the colorbar.
+
+        Test scenario:
+            Plot-time override: even with the default construction option,
+            `plot(add_colorbar=False)` draws no colorbar.
+        """
+        gx, gy, u, v = self._field()
+        glyph = VectorGlyph(gx, gy, u, v)
+        fig, ax, _ = glyph.plot(add_colorbar=False)
+        try:
+            assert glyph.cbar is None, "plot(add_colorbar=False) should skip the colorbar"
+            assert len(fig.axes) == 1, f"expected 1 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
     def test_add_colorbar_in_option_keys(self):
         """`add_colorbar` is an accepted option key."""
         assert "add_colorbar" in VectorGlyph.option_keys(), "add_colorbar missing"

--- a/tests/test_vector_glyph.py
+++ b/tests/test_vector_glyph.py
@@ -269,3 +269,38 @@ def test_vector_default_options_extend_style_defaults():
     """
     assert "figsize" in VECTOR_DEFAULT_OPTIONS, "Should inherit base style keys"
     assert "density" in VECTOR_DEFAULT_OPTIONS, "Should add vector keys"
+
+
+class TestAddColorbarToggle:
+    """`add_colorbar=False` suppresses VectorGlyph's colorbar (#3)."""
+
+    @staticmethod
+    def _field():
+        gx, gy = np.meshgrid(np.arange(5), np.arange(5))
+        return gx, gy, np.ones_like(gx, float), np.ones_like(gx, float)
+
+    def test_default_draws_colorbar(self):
+        """A vector field draws its magnitude colorbar by default."""
+        gx, gy, u, v = self._field()
+        glyph = VectorGlyph(gx, gy, u, v)
+        fig, ax, _ = glyph.plot()
+        try:
+            assert glyph.cbar is not None, "default should draw a colorbar"
+            assert len(fig.axes) == 2, f"expected 2 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
+    def test_add_colorbar_false_suppresses(self):
+        """`add_colorbar=False` leaves cbar None and adds no axes."""
+        gx, gy, u, v = self._field()
+        glyph = VectorGlyph(gx, gy, u, v, add_colorbar=False)
+        fig, ax, _ = glyph.plot()
+        try:
+            assert glyph.cbar is None, "add_colorbar=False should skip the colorbar"
+            assert len(fig.axes) == 1, f"expected 1 axes, got {len(fig.axes)}"
+        finally:
+            plt.close(fig)
+
+    def test_add_colorbar_in_option_keys(self):
+        """`add_colorbar` is an accepted option key."""
+        assert "add_colorbar" in VectorGlyph.option_keys(), "add_colorbar missing"


### PR DESCRIPTION
Closes #61
Closes #137
Closes #138
Closes #139

Resolves the genuine cleopatra issues surfaced while building the Digital-Earth earthkit-plots port (the composition gaps not already covered by #128–#131). Two of the reported five were **not** cleopatra bugs and are intentionally excluded (see "Out of scope").

## #61 — Constant-value arrays crash the tick math (bug)

A flat field gives `vmax == vmin`, so `ticks_spacing` was `0` and
`np.arange(vmin, vmax, 0)` raised `ZeroDivisionError`. Now:

- `Glyph.get_ticks` returns a single tick at the value for a degenerate range
  (the crash site, fixes it for every glyph).
- `ArrayGlyph` falls back to a unit `ticks_spacing` (mirrors the shared
  scalar-mapping path, which already did this).
- A constant-field line `contour` skips its (empty, uncolorbar-able) colorbar.

Every render kind (`imshow`/`pcolormesh`/`contourf`/`contour`) now works on flat data.

## #137 — Expose the MeshGlyph mappable

`MeshGlyph.plot` kept no handle to the tripcolor/tricontour(f) artist, forcing
`ax.collections[-1]` scraping. It now stores it on **`MeshGlyph.im`** (None
before first render), mirroring `ArrayGlyph.im`.

## #138 — `add_colorbar` toggle on the other glyphs

`ScatterGlyph`/`PolygonGlyph`/`VectorGlyph` gain `add_colorbar` (default `True`,
behaviour unchanged); `add_colorbar=False` leaves `self.cbar` None and adds no
axes, so a shared-axes host can own a single aggregated colorbar. (`MeshGlyph`
already had an equivalent `colorbar=` parameter; `LineGlyph` draws no colorbar.)

## #139 — Per-band percentile stretch in `scale_to_rgb` (enhancement)

The only legitimate part of the original reported RGB issue (the rest was an
input-layout misuse — cleopatra's `rgb=` is band-first — and an incorrect
"mutates state" claim). `scale_to_rgb` gains a `per_band` percentile-stretch
mode (default `(2, 98)`) that normalises each band of a `(rows, cols, bands)`
stack to 0-255; the default global path is unchanged and now guards an all-zero
array. The method never mutates its input.

## Out of scope (verified not cleopatra bugs)

- **"scale_to_rgb is broken / transposes / mutates"** — the transpose was
  feeding band-last data to the band-first `rgb=` API; `scale_to_rgb` does not
  mutate `self.arr`. Only the per-band stretch (#139) was a real gap.
- **"filter_kwargs silently drops keys"** — that is the deliberate purpose of
  `filter_kwargs` (#131); cleopatra already raises loudly via `_merge_kwargs`.
  The fix belongs in the caller.

## Tests & docs

- New test classes: `TestConstantValueArray` + `TestScaleToRgbPerBand` (array),
  `TestGetTicksDegenerateRange` (glyph), `TestMeshGlyphMappable` (mesh), and
  `TestAddColorbarToggle` (scatter/polygon/vector).
- Docstrings updated (`scale_to_rgb`, the `add_colorbar` option, `MeshGlyph.im`); module doctests pass.
- Full suite: **734 passed, 3 skipped** (+23). No breaking changes.