### PR TITLE
feat(projection): add apply_projection_frame for static projected map frames

### DIFF
--- a/docs/reference/projection.md
+++ b/docs/reference/projection.md
@@ -1,0 +1,63 @@
+# Projection Module — Static Projected ("Globe") Map Frames
+
+The `cleopatra.projection` module adds a single, stateless helper:
+`apply_projection_frame` turns a plain matplotlib `Axes` into a static projected
+("globe") frame. It sets the projected limits and equal aspect, draws the projection
+**boundary** (the globe's circle, Robinson's rounded rectangle, ...), optionally **clips**
+the existing data layers to that boundary, and draws the **graticule** polylines.
+
+The module is **pure matplotlib with no PROJ/CRS dependency**. It only *receives*
+already-computed geometry — boundary vertices, graticule polylines, and projected limits —
+as plain arrays. Whatever produces the projection (reprojecting data and deriving the
+boundary/graticule) lives upstream; cleopatra only renders the result. This keeps the
+engine split clean: the upstream owns CRS/PROJ, cleopatra owns matplotlib.
+
+## Usage
+
+```python
+import matplotlib
+matplotlib.use("Agg")  # any backend; Agg shown for headless rendering
+import numpy as np
+import matplotlib.pyplot as plt
+
+from cleopatra.projection import apply_projection_frame
+
+# Geometry comes in as plain arrays (here a unit-circle globe outline and a
+# meridian); upstream produces the real projected boundary/graticule.
+theta = np.linspace(0, 2 * np.pi, 200)
+boundary = np.column_stack([np.cos(theta), np.sin(theta)])
+meridian = np.column_stack([np.zeros(50), np.linspace(-1, 1, 50)])
+
+fig, ax = plt.subplots()
+# plot your (already reprojected) data first so it can be clipped ...
+ax.imshow(np.random.rand(8, 8), extent=(-1, 1, -1, 1))
+
+# ... then frame the axes as a globe and clip the data to the boundary
+patch = apply_projection_frame(
+    ax,
+    boundary_xy=boundary,
+    xlim=(-1, 1),
+    ylim=(-1, 1),
+    graticule_lines=[meridian],
+)
+
+fig.savefig("globe.png")
+```
+
+!!! note
+    `apply_projection_frame` performs **no reprojection** — pass already-densified,
+    already-projected geometry as `(N, 2)` arrays. It is a **one-shot** helper: each call
+    appends a fresh boundary patch and graticule lines, so apply it once per axes (create a
+    new axes to re-frame). With `clip_artists=True` (default) every existing
+    `ax.images`/`ax.collections`/`ax.lines` artist — and the graticule — is clipped to the
+    boundary; pass `clip_artists=False` to leave the data layers unclipped. Style the
+    boundary and graticule via `boundary_kw` / `graticule_kw`, which override
+    `DEFAULT_BOUNDARY_KW` / `DEFAULT_GRATICULE_KW`.
+
+## Module Documentation
+
+::: cleopatra.projection
+    options:
+      show_root_heading: true
+      show_source: true
+      heading_level: 3

--- a/docs/reference/projection.md
+++ b/docs/reference/projection.md
@@ -30,7 +30,7 @@ meridian = np.column_stack([np.zeros(50), np.linspace(-1, 1, 50)])
 
 fig, ax = plt.subplots()
 # plot your (already reprojected) data first so it can be clipped ...
-ax.imshow(np.random.rand(8, 8), extent=(-1, 1, -1, 1))
+ax.imshow(np.zeros((8, 8)), extent=(-1, 1, -1, 1))
 
 # ... then frame the axes as a globe and clip the data to the boundary
 patch = apply_projection_frame(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ nav:
     - ArrayGlyph: reference/array-glyph.md
     - MeshGlyph: reference/mesh-glyph.md
     - Tiles (basemaps): reference/tiles.md
+    - Projection (globe frames): reference/projection.md
     - Colors: reference/colors-glyph.md
     - Styles: reference/styles-glyph.md
     - Config: reference/config.md

--- a/src/cleopatra/__init__.py
+++ b/src/cleopatra/__init__.py
@@ -7,7 +7,7 @@ classes/functions from their submodules, e.g.
 `from cleopatra.config import Config`.
 
 Submodules: `array_glyph`, `glyph`, `mesh_glyph`, `statistical_glyph`,
-`colors`, `styles`, `tiles`, `config`.
+`colors`, `styles`, `tiles`, `projection`, `config`.
 
 Importing cleopatra does not change the active matplotlib backend. If you
 want the old convenience behaviour (`%matplotlib inline` in a notebook,

--- a/src/cleopatra/projection.py
+++ b/src/cleopatra/projection.py
@@ -35,7 +35,8 @@ Examples:
 
 from __future__ import annotations
 
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 from matplotlib.patches import PathPatch
@@ -62,6 +63,31 @@ def _as_xy(array: Any, name: str) -> np.ndarray:
 
     Raises:
         ValueError: If the input is not 2-D with two columns.
+
+    Examples:
+        - Coerce a nested list of integer pairs to a float array:
+            ```python
+            >>> from cleopatra.projection import _as_xy
+            >>> _as_xy([[1, 0], [0, 1], [-1, 0]], "boundary_xy").tolist()
+            [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0]]
+
+            ```
+        - A single vertex is a valid ``(1, 2)`` array:
+            ```python
+            >>> from cleopatra.projection import _as_xy
+            >>> _as_xy([[0.5, 0.5]], "graticule_lines[0]").shape
+            (1, 2)
+
+            ```
+        - A 1-D input raises ``ValueError`` naming the argument:
+            ```python
+            >>> from cleopatra.projection import _as_xy
+            >>> _as_xy([1, 2, 3], "boundary_xy")
+            Traceback (most recent call last):
+                ...
+            ValueError: boundary_xy must be an (N, 2) array of x/y coordinates, got shape (3,).
+
+            ```
     """
     xy = np.asarray(array, dtype=float)
     if xy.ndim != 2 or xy.shape[1] != 2:
@@ -91,6 +117,11 @@ def apply_projection_frame(
     and turns the axis decorations off. The boundary geometry, graticule
     polylines, and limits are supplied as plain arrays -- this function
     performs no reprojection and has no PROJ/CRS dependency.
+
+    This is a one-shot helper: each call appends a fresh boundary patch and
+    a fresh set of graticule lines, so calling it twice on the same axes
+    stacks duplicate artists. Apply it once per axes (create a new axes to
+    re-frame).
 
     Args:
         ax: Matplotlib `matplotlib.axes.Axes` to frame. Any data
@@ -122,27 +153,62 @@ def apply_projection_frame(
             ``(N, 2)`` array, or if `xlim`/`ylim` are not 2-tuples.
 
     Examples:
-        Frame an axes as a globe with a graticule and clip an image to
-        the boundary:
+        - Frame a plain axes as a globe and read back the result: the
+            returned patch is registered on the axes and the aspect is equal:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import numpy as np
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.projection import apply_projection_frame
+            >>> theta = np.linspace(0, 2 * np.pi, 200)
+            >>> boundary = np.column_stack([np.cos(theta), np.sin(theta)])
+            >>> fig, ax = plt.subplots()
+            >>> patch = apply_projection_frame(
+            ...     ax, boundary_xy=boundary, xlim=(-1, 1), ylim=(-1, 1)
+            ... )
+            >>> ax.get_aspect()
+            1.0
+            >>> patch in ax.patches
+            True
 
-        >>> import matplotlib
-        >>> matplotlib.use("Agg")
-        >>> import numpy as np
-        >>> import matplotlib.pyplot as plt
-        >>> theta = np.linspace(0, 2 * np.pi, 200)
-        >>> boundary = np.column_stack([np.cos(theta), np.sin(theta)])
-        >>> meridian = np.column_stack([np.zeros(50), np.linspace(-1, 1, 50)])
-        >>> fig, ax = plt.subplots()
-        >>> im = ax.imshow(np.random.rand(8, 8), extent=(-1, 1, -1, 1))
-        >>> patch = apply_projection_frame(
-        ...     ax,
-        ...     boundary_xy=boundary,
-        ...     xlim=(-1, 1),
-        ...     ylim=(-1, 1),
-        ...     graticule_lines=[meridian],
-        ... )
-        >>> im.get_clip_path() is not None
-        True
+            ```
+        - Clip a data image and draw one graticule line (plain lists are
+            accepted): the image gains a clip path and one line is added:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import numpy as np
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.projection import apply_projection_frame
+            >>> boundary = [[1, 0], [0, 1], [-1, 0], [0, -1]]
+            >>> meridian = [[0, -1], [0, 1]]
+            >>> fig, ax = plt.subplots()
+            >>> im = ax.imshow(np.zeros((4, 4)), extent=(-1, 1, -1, 1))
+            >>> patch = apply_projection_frame(
+            ...     ax,
+            ...     boundary_xy=boundary,
+            ...     xlim=(-1, 1),
+            ...     ylim=(-1, 1),
+            ...     graticule_lines=[meridian],
+            ... )
+            >>> im.get_clip_path() is not None
+            True
+            >>> len(ax.lines)
+            1
+
+            ```
+        - Passing a non-Axes object raises ``TypeError``:
+            ```python
+            >>> from cleopatra.projection import apply_projection_frame
+            >>> apply_projection_frame(
+            ...     object(), boundary_xy=[[0, 0], [1, 1]], xlim=(-1, 1), ylim=(-1, 1)
+            ... )
+            Traceback (most recent call last):
+                ...
+            TypeError: ax must be a matplotlib.axes.Axes instance, got object
+
+            ```
     """
     if not hasattr(ax, "set_xlim") or not hasattr(ax, "add_patch"):
         raise TypeError(
@@ -162,6 +228,10 @@ def apply_projection_frame(
     ax.set_xlim(xlim[0], xlim[1])
     ax.set_ylim(ylim[0], ylim[1])
 
+    # The boundary is treated as a closed ring for clipping/fill regardless
+    # of whether its final vertex repeats the first: matplotlib's
+    # point-in-path test implicitly connects the last vertex back to the
+    # first, so an open ring still clips correctly.
     patch = PathPatch(
         Path(boundary),
         facecolor="none",

--- a/src/cleopatra/projection.py
+++ b/src/cleopatra/projection.py
@@ -1,0 +1,184 @@
+"""Static projected ('globe') map frame for matplotlib axes.
+
+Provides `apply_projection_frame` -- a single stateless helper that turns
+a plain `matplotlib.axes.Axes` into a static projected map frame: it sets
+the projected limits and equal aspect, draws the projection *boundary*
+(the globe's circle, Robinson's rounded rectangle, ...), optionally
+*clips* the existing data layers to that boundary, and draws the
+*graticule* polylines.
+
+The module is **pure matplotlib with no PROJ/CRS dependency**. It only
+*receives* already-computed geometry -- boundary vertices, graticule
+polylines, and projected limits -- as plain arrays. Whatever produces the
+projection (reprojecting data and deriving the boundary/graticule) lives
+upstream; cleopatra only renders the result. This keeps the engine split
+clean: the upstream owns CRS/PROJ, cleopatra owns matplotlib.
+
+Examples:
+    Frame a plain axes as an orthographic globe and clip an image to the
+    boundary circle:
+
+    >>> import matplotlib
+    >>> matplotlib.use("Agg")
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> theta = np.linspace(0, 2 * np.pi, 200)
+    >>> boundary = np.column_stack([np.cos(theta), np.sin(theta)])
+    >>> fig, ax = plt.subplots()
+    >>> _ = ax.imshow(np.random.rand(8, 8), extent=(-1, 1, -1, 1))
+    >>> patch = apply_projection_frame(
+    ...     ax, boundary_xy=boundary, xlim=(-1, 1), ylim=(-1, 1)
+    ... )
+    >>> ax.get_aspect()
+    1.0
+"""
+
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import numpy as np
+from matplotlib.patches import PathPatch
+from matplotlib.path import Path
+
+#: Default style for the projection boundary patch. Merged with (and
+#: overridden by) the caller's ``boundary_kw``.
+DEFAULT_BOUNDARY_KW: dict[str, Any] = {"edgecolor": "black", "linewidth": 0.8}
+
+#: Default style for the graticule polylines. Merged with (and overridden
+#: by) the caller's ``graticule_kw``.
+DEFAULT_GRATICULE_KW: dict[str, Any] = {"color": "gray", "linewidth": 0.4}
+
+
+def _as_xy(array: Any, name: str) -> np.ndarray:
+    """Coerce input to a float ``(N, 2)`` array of x/y vertices.
+
+    Args:
+        array: Anything array-like holding vertex coordinates.
+        name: Argument name, used in error messages.
+
+    Returns:
+        numpy.ndarray: A ``(N, 2)`` float array.
+
+    Raises:
+        ValueError: If the input is not 2-D with two columns.
+    """
+    xy = np.asarray(array, dtype=float)
+    if xy.ndim != 2 or xy.shape[1] != 2:
+        raise ValueError(
+            f"{name} must be an (N, 2) array of x/y coordinates, "
+            f"got shape {xy.shape}."
+        )
+    return xy
+
+
+def apply_projection_frame(
+    ax: Any,
+    *,
+    boundary_xy: Any,
+    xlim: Sequence[float],
+    ylim: Sequence[float],
+    graticule_lines: Sequence[Any] | None = None,
+    clip_artists: bool = True,
+    boundary_kw: dict[str, Any] | None = None,
+    graticule_kw: dict[str, Any] | None = None,
+) -> PathPatch:
+    """Turn a plain axes into a static projected ('globe') frame.
+
+    Sets equal aspect and the projected x/y limits, draws the projection
+    boundary as a `matplotlib.patches.PathPatch`, draws the graticule
+    polylines, optionally clips the existing data layers to the boundary,
+    and turns the axis decorations off. The boundary geometry, graticule
+    polylines, and limits are supplied as plain arrays -- this function
+    performs no reprojection and has no PROJ/CRS dependency.
+
+    Args:
+        ax: Matplotlib `matplotlib.axes.Axes` to frame. Any data
+            layers to be clipped should already be plotted.
+        boundary_xy: ``(N, 2)`` projection-boundary vertices in projected
+            coordinates (e.g. the globe's circle). Array-like.
+        xlim: Projected-coordinate x-limits ``(xmin, xmax)`` -- the CRS
+            domain in the x direction.
+        ylim: Projected-coordinate y-limits ``(ymin, ymax)``.
+        graticule_lines: Optional list of ``(M, 2)`` polylines (already
+            densified and projected), each drawn as a graticule line.
+            `None` (default) draws no graticule.
+        clip_artists: If `True` (default), clip the existing data layers
+            (`ax.images`, `ax.collections`, `ax.lines`) and the drawn
+            graticule to the boundary path.
+        boundary_kw: Style overrides for the boundary patch, merged over
+            `DEFAULT_BOUNDARY_KW`. ``facecolor`` defaults to
+            ``"none"`` so the patch never hides the data.
+        graticule_kw: Style overrides for the graticule lines, merged
+            over `DEFAULT_GRATICULE_KW`.
+
+    Returns:
+        matplotlib.patches.PathPatch: The boundary patch added to the
+        axes (also used as the clip path).
+
+    Raises:
+        TypeError: If `ax` is not a matplotlib Axes.
+        ValueError: If `boundary_xy` or a graticule line is not an
+            ``(N, 2)`` array, or if `xlim`/`ylim` are not 2-tuples.
+
+    Examples:
+        Frame an axes as a globe with a graticule and clip an image to
+        the boundary:
+
+        >>> import matplotlib
+        >>> matplotlib.use("Agg")
+        >>> import numpy as np
+        >>> import matplotlib.pyplot as plt
+        >>> theta = np.linspace(0, 2 * np.pi, 200)
+        >>> boundary = np.column_stack([np.cos(theta), np.sin(theta)])
+        >>> meridian = np.column_stack([np.zeros(50), np.linspace(-1, 1, 50)])
+        >>> fig, ax = plt.subplots()
+        >>> im = ax.imshow(np.random.rand(8, 8), extent=(-1, 1, -1, 1))
+        >>> patch = apply_projection_frame(
+        ...     ax,
+        ...     boundary_xy=boundary,
+        ...     xlim=(-1, 1),
+        ...     ylim=(-1, 1),
+        ...     graticule_lines=[meridian],
+        ... )
+        >>> im.get_clip_path() is not None
+        True
+    """
+    if not hasattr(ax, "set_xlim") or not hasattr(ax, "add_patch"):
+        raise TypeError(
+            "ax must be a matplotlib.axes.Axes instance, "
+            f"got {type(ax).__name__}"
+        )
+
+    if len(xlim) != 2 or len(ylim) != 2:
+        raise ValueError(
+            f"xlim and ylim must each be a (min, max) pair, "
+            f"got xlim={xlim!r}, ylim={ylim!r}."
+        )
+
+    boundary = _as_xy(boundary_xy, "boundary_xy")
+
+    ax.set_aspect("equal")
+    ax.set_xlim(xlim[0], xlim[1])
+    ax.set_ylim(ylim[0], ylim[1])
+
+    patch = PathPatch(
+        Path(boundary),
+        facecolor="none",
+        **{**DEFAULT_BOUNDARY_KW, **(boundary_kw or {})},
+    )
+    ax.add_patch(patch)
+
+    graticule_style = {**DEFAULT_GRATICULE_KW, **(graticule_kw or {})}
+    graticule_artists = []
+    for i, line in enumerate(graticule_lines or []):
+        xy = _as_xy(line, f"graticule_lines[{i}]")
+        (artist,) = ax.plot(xy[:, 0], xy[:, 1], **graticule_style)
+        graticule_artists.append(artist)
+
+    if clip_artists:
+        for art in (*ax.images, *ax.collections, *ax.lines):
+            art.set_clip_path(patch)
+
+    ax.set_axis_off()
+    return patch

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -24,6 +24,7 @@ _SUBMODULES = [
     "line_glyph",
     "mesh_glyph",
     "polygon_glyph",
+    "projection",
     "scatter_glyph",
     "statistical_glyph",
     "styles",

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,0 +1,178 @@
+"""Tests for cleopatra.projection.
+
+Covers `apply_projection_frame`, the stateless helper that turns a plain
+axes into a static projected ('globe') frame. Pure matplotlib -- no PROJ
+dependency -- so the geometry is built inline as numpy arrays.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.plot
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.patches import PathPatch  # noqa: E402
+
+from cleopatra.projection import apply_projection_frame  # noqa: E402
+
+
+@pytest.fixture
+def globe_boundary() -> np.ndarray:
+    """Unit-circle boundary, the canonical orthographic-globe outline."""
+    theta = np.linspace(0, 2 * np.pi, 200)
+    return np.column_stack([np.cos(theta), np.sin(theta)])
+
+
+@pytest.fixture
+def axes():
+    fig, ax = plt.subplots()
+    yield ax
+    plt.close(fig)
+
+
+def test_returns_boundary_patch_added_to_axes(axes, globe_boundary):
+    patch = apply_projection_frame(
+        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+    )
+    assert isinstance(patch, PathPatch)
+    assert patch in axes.patches
+
+
+def test_equal_aspect_and_limits(axes, globe_boundary):
+    apply_projection_frame(
+        axes, boundary_xy=globe_boundary, xlim=(-2, 2), ylim=(-3, 3)
+    )
+    assert axes.get_aspect() == 1
+    assert axes.get_xlim() == (-2, 2)
+    assert axes.get_ylim() == (-3, 3)
+
+
+def test_axis_turned_off(axes, globe_boundary):
+    apply_projection_frame(
+        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+    )
+    assert axes.axison is False
+
+
+def test_data_image_clipped_to_boundary(axes, globe_boundary):
+    image = axes.imshow(np.random.rand(8, 8), extent=(-1, 1, -1, 1))
+    patch = apply_projection_frame(
+        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+    )
+    clip_path = image.get_clip_path()
+    assert clip_path is not None
+    # The clip path is the boundary patch we returned (matplotlib wraps it
+    # in a TransformedPatchPath); the vertex count proves it is the
+    # boundary circle, not the default axes bbox.
+    verts = clip_path.get_fully_transformed_path().vertices
+    assert len(verts) == len(patch.get_path().vertices)
+
+
+def test_collection_clipped_to_boundary(axes, globe_boundary):
+    collection = axes.scatter([0.2, -0.3], [0.1, -0.4])
+    apply_projection_frame(
+        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+    )
+    assert collection.get_clip_path() is not None
+
+
+def test_clip_artists_false_leaves_data_unclipped(axes, globe_boundary):
+    image = axes.imshow(np.random.rand(4, 4), extent=(-1, 1, -1, 1))
+    default_clip = image.get_clip_path()
+    apply_projection_frame(
+        axes,
+        boundary_xy=globe_boundary,
+        xlim=(-1, 1),
+        ylim=(-1, 1),
+        clip_artists=False,
+    )
+    # Unchanged from the matplotlib default (the axes bbox / None).
+    assert image.get_clip_path() is default_clip
+
+
+def test_graticule_lines_drawn(axes, globe_boundary):
+    meridian = np.column_stack([np.zeros(50), np.linspace(-1, 1, 50)])
+    equator = np.column_stack([np.linspace(-1, 1, 50), np.zeros(50)])
+    apply_projection_frame(
+        axes,
+        boundary_xy=globe_boundary,
+        xlim=(-1, 1),
+        ylim=(-1, 1),
+        graticule_lines=[meridian, equator],
+    )
+    assert len(axes.lines) == 2
+
+
+def test_graticule_default_none_draws_nothing(axes, globe_boundary):
+    apply_projection_frame(
+        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+    )
+    assert len(axes.lines) == 0
+
+
+def test_style_overrides_applied(axes, globe_boundary):
+    meridian = np.column_stack([np.zeros(10), np.linspace(-1, 1, 10)])
+    patch = apply_projection_frame(
+        axes,
+        boundary_xy=globe_boundary,
+        xlim=(-1, 1),
+        ylim=(-1, 1),
+        graticule_lines=[meridian],
+        boundary_kw={"edgecolor": "red", "linewidth": 2.0},
+        graticule_kw={"color": "blue"},
+    )
+    assert patch.get_edgecolor()[:3] == pytest.approx((1.0, 0.0, 0.0))
+    assert patch.get_linewidth() == 2.0
+    assert axes.lines[0].get_color() == "blue"
+
+
+def test_accepts_list_input(axes):
+    # Plain Python lists, not numpy arrays, must be coerced.
+    boundary = [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
+    patch = apply_projection_frame(
+        axes,
+        boundary_xy=boundary,
+        xlim=(-1, 1),
+        ylim=(-1, 1),
+        graticule_lines=[[[0.0, -1.0], [0.0, 1.0]]],
+    )
+    assert isinstance(patch, PathPatch)
+    assert len(axes.lines) == 1
+
+
+def test_bad_axes_raises_type_error(globe_boundary):
+    with pytest.raises(TypeError, match="matplotlib.axes.Axes"):
+        apply_projection_frame(
+            object(), boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+        )
+
+
+def test_bad_boundary_shape_raises_value_error(axes):
+    with pytest.raises(ValueError, match=r"boundary_xy must be an \(N, 2\)"):
+        apply_projection_frame(
+            axes, boundary_xy=np.arange(10), xlim=(-1, 1), ylim=(-1, 1)
+        )
+
+
+def test_bad_limits_raise_value_error(axes, globe_boundary):
+    with pytest.raises(ValueError, match="min, max"):
+        apply_projection_frame(
+            axes, boundary_xy=globe_boundary, xlim=(-1, 0, 1), ylim=(-1, 1)
+        )
+
+
+def test_bad_graticule_shape_raises_value_error(axes, globe_boundary):
+    with pytest.raises(ValueError, match=r"graticule_lines\[0\]"):
+        apply_projection_frame(
+            axes,
+            boundary_xy=globe_boundary,
+            xlim=(-1, 1),
+            ylim=(-1, 1),
+            graticule_lines=[np.arange(6)],
+        )

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -11,6 +11,8 @@ so runs are deterministic.
 
 from __future__ import annotations
 
+import doctest
+
 import numpy as np
 import pytest
 
@@ -23,6 +25,7 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.patches import PathPatch  # noqa: E402
 
+from cleopatra import projection as projection_module  # noqa: E402
 from cleopatra.projection import (  # noqa: E402
     DEFAULT_BOUNDARY_KW,
     DEFAULT_GRATICULE_KW,
@@ -551,3 +554,24 @@ class TestApplyProjectionFrame:
                 ylim=(-1, 1),
                 graticule_lines=[meridian, np.arange(6)],
             )
+
+
+class TestModuleDoctests:
+    """Run the module's docstring examples inside the default test suite."""
+
+    def test_doctests_pass(self):
+        """Execute every ``cleopatra.projection`` doctest in-band.
+
+        Test scenario:
+            The default ``pytest`` run (``testpaths = ["tests"]``) does not
+            collect ``--doctest-modules`` from ``src``, so the module and
+            function docstring examples would otherwise go unverified in CI.
+            Running ``doctest.testmod`` here catches example drift as part of
+            the normal suite.
+        """
+        results = doctest.testmod(projection_module, verbose=False)
+        assert results.failed == 0, (
+            f"{results.failed} doctest(s) failed in cleopatra.projection "
+            f"(attempted {results.attempted})"
+        )
+        assert results.attempted > 0, "Expected doctest examples to be collected"

--- a/tests/test_projection.py
+++ b/tests/test_projection.py
@@ -1,8 +1,12 @@
-"""Tests for cleopatra.projection.
+"""Tests for ``cleopatra.projection``.
 
-Covers `apply_projection_frame`, the stateless helper that turns a plain
-axes into a static projected ('globe') frame. Pure matplotlib -- no PROJ
-dependency -- so the geometry is built inline as numpy arrays.
+Covers the public helper ``apply_projection_frame`` and the private
+``_as_xy`` coercion utility. The module is pure matplotlib with no PROJ
+dependency, so all geometry is built inline as deterministic numpy arrays
+(no reprojection, no network, no filesystem).
+
+Tests are grouped one class per function. Randomised image data is seeded
+so runs are deterministic.
 """
 
 from __future__ import annotations
@@ -19,160 +23,531 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.patches import PathPatch  # noqa: E402
 
-from cleopatra.projection import apply_projection_frame  # noqa: E402
+from cleopatra.projection import (  # noqa: E402
+    DEFAULT_BOUNDARY_KW,
+    DEFAULT_GRATICULE_KW,
+    _as_xy,
+    apply_projection_frame,
+)
+
+
+@pytest.fixture
+def rng() -> np.random.Generator:
+    """Seeded numpy generator for deterministic image data.
+
+    Returns:
+        numpy.random.Generator: A generator seeded with a fixed value so
+        every test run produces identical pixel data.
+    """
+    return np.random.default_rng(1337)
 
 
 @pytest.fixture
 def globe_boundary() -> np.ndarray:
-    """Unit-circle boundary, the canonical orthographic-globe outline."""
+    """Closed unit-circle boundary -- the canonical globe outline.
+
+    Returns:
+        numpy.ndarray: A ``(200, 2)`` array of x/y vertices tracing the
+        unit circle, with the final vertex repeating the first.
+    """
     theta = np.linspace(0, 2 * np.pi, 200)
     return np.column_stack([np.cos(theta), np.sin(theta)])
 
 
 @pytest.fixture
+def meridian() -> np.ndarray:
+    """A single vertical graticule polyline (the prime meridian).
+
+    Returns:
+        numpy.ndarray: A ``(50, 2)`` polyline from the south to the north
+        pole along ``x == 0``.
+    """
+    return np.column_stack([np.zeros(50), np.linspace(-1, 1, 50)])
+
+
+@pytest.fixture
 def axes():
+    """Create a fresh figure/axes pair and close it after the test.
+
+    Yields:
+        matplotlib.axes.Axes: A clean axes with no data plotted.
+    """
     fig, ax = plt.subplots()
     yield ax
     plt.close(fig)
 
 
-def test_returns_boundary_patch_added_to_axes(axes, globe_boundary):
-    patch = apply_projection_frame(
-        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+class TestAsXy:
+    """Tests for the private ``_as_xy`` coercion helper."""
+
+    def test_coerces_nested_list_to_float_array(self):
+        """Coerce a nested Python list into a float ``(N, 2)`` array.
+
+        Test scenario:
+            A list of integer x/y pairs is converted to a numpy array with
+            float dtype and ``(N, 2)`` shape.
+        """
+        result = _as_xy([[1, 0], [0, 1], [-1, 0]], "boundary_xy")
+        assert isinstance(result, np.ndarray), f"Expected ndarray, got {type(result)}"
+        assert result.shape == (3, 2), f"Expected shape (3, 2), got {result.shape}"
+        assert result.dtype == np.float64, f"Expected float64, got {result.dtype}"
+
+    def test_passes_through_float_ndarray(self):
+        """Return an equivalent array for an already-valid float ndarray.
+
+        Test scenario:
+            A ``(N, 2)`` float array is returned unchanged in value/shape.
+        """
+        source = np.array([[0.0, 0.0], [1.0, 1.0]])
+        result = _as_xy(source, "boundary_xy")
+        assert result.shape == (2, 2), f"Expected shape (2, 2), got {result.shape}"
+        assert np.array_equal(result, source), f"Values changed: {result}"
+
+    def test_accepts_single_vertex(self):
+        """Accept the minimal ``(1, 2)`` array without raising.
+
+        Test scenario:
+            A single x/y pair is a valid 2-D, two-column array.
+        """
+        result = _as_xy([[0.5, 0.5]], "graticule_lines[0]")
+        assert result.shape == (1, 2), f"Expected shape (1, 2), got {result.shape}"
+
+    @pytest.mark.parametrize(
+        "bad_input, shape_desc",
+        [
+            (np.arange(10), "(10,)"),
+            (np.zeros((4, 3)), "(4, 3)"),
+            (np.zeros((2, 2, 2)), "(2, 2, 2)"),
+            (5.0, "()"),
+        ],
     )
-    assert isinstance(patch, PathPatch)
-    assert patch in axes.patches
+    def test_rejects_non_n_by_2(self, bad_input, shape_desc):
+        """Raise ``ValueError`` for inputs that are not ``(N, 2)``.
 
+        Args:
+            bad_input: Array-like with an invalid shape.
+            shape_desc: Human-readable shape, for the assertion message.
 
-def test_equal_aspect_and_limits(axes, globe_boundary):
-    apply_projection_frame(
-        axes, boundary_xy=globe_boundary, xlim=(-2, 2), ylim=(-3, 3)
-    )
-    assert axes.get_aspect() == 1
-    assert axes.get_xlim() == (-2, 2)
-    assert axes.get_ylim() == (-3, 3)
+        Test scenario:
+            1-D, three-column, 3-D, and scalar inputs each fail the
+            ``ndim == 2 and shape[1] == 2`` contract.
+        """
+        with pytest.raises(ValueError, match=r"must be an \(N, 2\) array") as exc:
+            _as_xy(bad_input, "boundary_xy")
+        assert "boundary_xy" in str(exc.value), (
+            f"Error should name the argument for shape {shape_desc}, got: {exc.value}"
+        )
 
+    def test_error_message_includes_argument_name(self):
+        """Include the caller-supplied name in the error message.
 
-def test_axis_turned_off(axes, globe_boundary):
-    apply_projection_frame(
-        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
-    )
-    assert axes.axison is False
-
-
-def test_data_image_clipped_to_boundary(axes, globe_boundary):
-    image = axes.imshow(np.random.rand(8, 8), extent=(-1, 1, -1, 1))
-    patch = apply_projection_frame(
-        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
-    )
-    clip_path = image.get_clip_path()
-    assert clip_path is not None
-    # The clip path is the boundary patch we returned (matplotlib wraps it
-    # in a TransformedPatchPath); the vertex count proves it is the
-    # boundary circle, not the default axes bbox.
-    verts = clip_path.get_fully_transformed_path().vertices
-    assert len(verts) == len(patch.get_path().vertices)
-
-
-def test_collection_clipped_to_boundary(axes, globe_boundary):
-    collection = axes.scatter([0.2, -0.3], [0.1, -0.4])
-    apply_projection_frame(
-        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
-    )
-    assert collection.get_clip_path() is not None
-
-
-def test_clip_artists_false_leaves_data_unclipped(axes, globe_boundary):
-    image = axes.imshow(np.random.rand(4, 4), extent=(-1, 1, -1, 1))
-    default_clip = image.get_clip_path()
-    apply_projection_frame(
-        axes,
-        boundary_xy=globe_boundary,
-        xlim=(-1, 1),
-        ylim=(-1, 1),
-        clip_artists=False,
-    )
-    # Unchanged from the matplotlib default (the axes bbox / None).
-    assert image.get_clip_path() is default_clip
-
-
-def test_graticule_lines_drawn(axes, globe_boundary):
-    meridian = np.column_stack([np.zeros(50), np.linspace(-1, 1, 50)])
-    equator = np.column_stack([np.linspace(-1, 1, 50), np.zeros(50)])
-    apply_projection_frame(
-        axes,
-        boundary_xy=globe_boundary,
-        xlim=(-1, 1),
-        ylim=(-1, 1),
-        graticule_lines=[meridian, equator],
-    )
-    assert len(axes.lines) == 2
-
-
-def test_graticule_default_none_draws_nothing(axes, globe_boundary):
-    apply_projection_frame(
-        axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
-    )
-    assert len(axes.lines) == 0
-
-
-def test_style_overrides_applied(axes, globe_boundary):
-    meridian = np.column_stack([np.zeros(10), np.linspace(-1, 1, 10)])
-    patch = apply_projection_frame(
-        axes,
-        boundary_xy=globe_boundary,
-        xlim=(-1, 1),
-        ylim=(-1, 1),
-        graticule_lines=[meridian],
-        boundary_kw={"edgecolor": "red", "linewidth": 2.0},
-        graticule_kw={"color": "blue"},
-    )
-    assert patch.get_edgecolor()[:3] == pytest.approx((1.0, 0.0, 0.0))
-    assert patch.get_linewidth() == 2.0
-    assert axes.lines[0].get_color() == "blue"
-
-
-def test_accepts_list_input(axes):
-    # Plain Python lists, not numpy arrays, must be coerced.
-    boundary = [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
-    patch = apply_projection_frame(
-        axes,
-        boundary_xy=boundary,
-        xlim=(-1, 1),
-        ylim=(-1, 1),
-        graticule_lines=[[[0.0, -1.0], [0.0, 1.0]]],
-    )
-    assert isinstance(patch, PathPatch)
-    assert len(axes.lines) == 1
-
-
-def test_bad_axes_raises_type_error(globe_boundary):
-    with pytest.raises(TypeError, match="matplotlib.axes.Axes"):
-        apply_projection_frame(
-            object(), boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+        Test scenario:
+            ``_as_xy`` is told the argument name so the raised message
+            points at the offending parameter (e.g. ``graticule_lines[2]``).
+        """
+        with pytest.raises(ValueError, match=r"graticule_lines\[2\]") as exc:
+            _as_xy(np.arange(3), "graticule_lines[2]")
+        assert "graticule_lines[2]" in str(exc.value), (
+            f"Argument name missing from message: {exc.value}"
         )
 
 
-def test_bad_boundary_shape_raises_value_error(axes):
-    with pytest.raises(ValueError, match=r"boundary_xy must be an \(N, 2\)"):
-        apply_projection_frame(
-            axes, boundary_xy=np.arange(10), xlim=(-1, 1), ylim=(-1, 1)
+class TestApplyProjectionFrame:
+    """Tests for the public ``apply_projection_frame`` helper."""
+
+    def test_returns_boundary_patch_added_to_axes(self, axes, globe_boundary):
+        """Return the boundary patch and add it to the axes.
+
+        Test scenario:
+            The return value is a ``PathPatch`` that is also registered in
+            ``ax.patches``.
+        """
+        patch = apply_projection_frame(
+            axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+        )
+        assert isinstance(patch, PathPatch), f"Expected PathPatch, got {type(patch)}"
+        assert patch in axes.patches, "Boundary patch was not added to ax.patches"
+
+    def test_boundary_facecolor_is_transparent(self, axes, globe_boundary):
+        """Default the boundary face to fully transparent.
+
+        Test scenario:
+            ``facecolor="none"`` means the patch never hides the data; the
+            resolved RGBA alpha is 0.
+        """
+        patch = apply_projection_frame(
+            axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+        )
+        facecolor = patch.get_facecolor()
+        assert facecolor[3] == 0.0, f"Expected transparent face, got RGBA {facecolor}"
+
+    def test_default_boundary_and_graticule_style(self, axes, globe_boundary, meridian):
+        """Apply the module default styles when no overrides are passed.
+
+        Test scenario:
+            The boundary uses ``DEFAULT_BOUNDARY_KW`` (black, 0.8 lw) and the
+            graticule uses ``DEFAULT_GRATICULE_KW`` (gray, 0.4 lw).
+        """
+        patch = apply_projection_frame(
+            axes,
+            boundary_xy=globe_boundary,
+            xlim=(-1, 1),
+            ylim=(-1, 1),
+            graticule_lines=[meridian],
+        )
+        assert patch.get_edgecolor()[:3] == pytest.approx((0.0, 0.0, 0.0)), (
+            f"Expected black boundary, got {patch.get_edgecolor()}"
+        )
+        assert patch.get_linewidth() == DEFAULT_BOUNDARY_KW["linewidth"], (
+            f"Expected lw {DEFAULT_BOUNDARY_KW['linewidth']}, got {patch.get_linewidth()}"
+        )
+        line = axes.lines[0]
+        assert line.get_linewidth() == DEFAULT_GRATICULE_KW["linewidth"], (
+            f"Expected graticule lw {DEFAULT_GRATICULE_KW['linewidth']}, "
+            f"got {line.get_linewidth()}"
         )
 
+    def test_equal_aspect_and_limits(self, axes, globe_boundary):
+        """Set equal aspect and the requested projected limits.
 
-def test_bad_limits_raise_value_error(axes, globe_boundary):
-    with pytest.raises(ValueError, match="min, max"):
+        Test scenario:
+            ``get_aspect() == 1`` and the x/y limits match the inputs.
+        """
         apply_projection_frame(
-            axes, boundary_xy=globe_boundary, xlim=(-1, 0, 1), ylim=(-1, 1)
+            axes, boundary_xy=globe_boundary, xlim=(-2, 2), ylim=(-3, 3)
+        )
+        assert axes.get_aspect() == 1, f"Expected aspect 1, got {axes.get_aspect()}"
+        assert axes.get_xlim() == (-2, 2), f"Unexpected xlim: {axes.get_xlim()}"
+        assert axes.get_ylim() == (-3, 3), f"Unexpected ylim: {axes.get_ylim()}"
+
+    def test_limits_accept_numpy_array(self, axes, globe_boundary):
+        """Accept numpy arrays of length 2 as ``xlim``/``ylim``.
+
+        Test scenario:
+            A ``(2,)`` numpy array passes the ``len(...) == 2`` check and is
+            applied like a tuple.
+        """
+        apply_projection_frame(
+            axes,
+            boundary_xy=globe_boundary,
+            xlim=np.array([-1.0, 1.0]),
+            ylim=np.array([-1.0, 1.0]),
+        )
+        assert axes.get_xlim() == (-1.0, 1.0), f"Unexpected xlim: {axes.get_xlim()}"
+
+    def test_axis_turned_off(self, axes, globe_boundary):
+        """Turn the axis decorations off.
+
+        Test scenario:
+            ``ax.axison`` is ``False`` after framing.
+        """
+        apply_projection_frame(
+            axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+        )
+        assert axes.axison is False, "Axis decorations should be turned off"
+
+    def test_image_clipped_to_boundary(self, axes, globe_boundary, rng):
+        """Clip a pre-existing image to the boundary path.
+
+        Test scenario:
+            An ``imshow`` image drawn before the call gets a clip path whose
+            transformed vertex count matches the boundary patch -- i.e. it is
+            clipped to the globe, not the default axes bbox.
+        """
+        image = axes.imshow(rng.random((8, 8)), extent=(-1, 1, -1, 1))
+        patch = apply_projection_frame(
+            axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+        )
+        clip_path = image.get_clip_path()
+        assert clip_path is not None, "Image should have a clip path set"
+        verts = clip_path.get_fully_transformed_path().vertices
+        expected = len(patch.get_path().vertices)
+        assert len(verts) == expected, (
+            f"Clip path should follow the boundary ({expected} verts), got {len(verts)}"
         )
 
+    def test_collection_clipped_to_boundary(self, axes, globe_boundary):
+        """Clip a pre-existing collection (scatter) to the boundary.
 
-def test_bad_graticule_shape_raises_value_error(axes, globe_boundary):
-    with pytest.raises(ValueError, match=r"graticule_lines\[0\]"):
+        Test scenario:
+            A ``scatter`` collection drawn before the call has a non-None
+            clip path afterwards.
+        """
+        collection = axes.scatter([0.2, -0.3], [0.1, -0.4])
+        apply_projection_frame(
+            axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+        )
+        assert collection.get_clip_path() is not None, "Collection was not clipped"
+
+    def test_line_clipped_to_boundary(self, axes, globe_boundary):
+        """Clip a pre-existing data line to the boundary.
+
+        Test scenario:
+            A ``plot`` line drawn before the call has a non-None clip path
+            afterwards (``ax.lines`` are clipped too).
+        """
+        (data_line,) = axes.plot([-0.5, 0.5], [0.0, 0.0])
+        apply_projection_frame(
+            axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+        )
+        assert data_line.get_clip_path() is not None, "Data line was not clipped"
+
+    def test_graticule_clipped_when_clip_enabled(self, axes, globe_boundary, meridian):
+        """Clip the drawn graticule lines to the boundary as well.
+
+        Test scenario:
+            With ``clip_artists=True`` the freshly drawn graticule line is
+            itself clipped to the globe.
+        """
         apply_projection_frame(
             axes,
             boundary_xy=globe_boundary,
             xlim=(-1, 1),
             ylim=(-1, 1),
-            graticule_lines=[np.arange(6)],
+            graticule_lines=[meridian],
         )
+        assert axes.lines[0].get_clip_path() is not None, "Graticule was not clipped"
+
+    def test_clip_artists_false_leaves_data_unclipped(self, axes, globe_boundary, rng):
+        """Leave data layers unclipped when ``clip_artists=False``.
+
+        Test scenario:
+            The image's clip path is the same object it had before the call
+            (the matplotlib default), i.e. untouched.
+        """
+        image = axes.imshow(rng.random((4, 4)), extent=(-1, 1, -1, 1))
+        default_clip = image.get_clip_path()
+        apply_projection_frame(
+            axes,
+            boundary_xy=globe_boundary,
+            xlim=(-1, 1),
+            ylim=(-1, 1),
+            clip_artists=False,
+        )
+        assert image.get_clip_path() is default_clip, (
+            "Image clip path should be untouched when clip_artists=False"
+        )
+
+    def test_graticule_lines_drawn(self, axes, globe_boundary):
+        """Draw one Line2D per supplied graticule polyline.
+
+        Test scenario:
+            Two polylines produce exactly two entries in ``ax.lines``.
+        """
+        equator = np.column_stack([np.linspace(-1, 1, 50), np.zeros(50)])
+        meridian = np.column_stack([np.zeros(50), np.linspace(-1, 1, 50)])
+        apply_projection_frame(
+            axes,
+            boundary_xy=globe_boundary,
+            xlim=(-1, 1),
+            ylim=(-1, 1),
+            graticule_lines=[meridian, equator],
+        )
+        assert len(axes.lines) == 2, f"Expected 2 graticule lines, got {len(axes.lines)}"
+
+    def test_graticule_default_none_draws_nothing(self, axes, globe_boundary):
+        """Draw no graticule when ``graticule_lines`` is omitted.
+
+        Test scenario:
+            The default ``None`` leaves ``ax.lines`` empty.
+        """
+        apply_projection_frame(
+            axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+        )
+        assert len(axes.lines) == 0, f"Expected no lines, got {len(axes.lines)}"
+
+    def test_empty_graticule_list_draws_nothing(self, axes, globe_boundary):
+        """Treat an empty graticule list the same as ``None``.
+
+        Test scenario:
+            ``graticule_lines=[]`` iterates zero times and draws nothing.
+        """
+        apply_projection_frame(
+            axes,
+            boundary_xy=globe_boundary,
+            xlim=(-1, 1),
+            ylim=(-1, 1),
+            graticule_lines=[],
+        )
+        assert len(axes.lines) == 0, f"Expected no lines, got {len(axes.lines)}"
+
+    def test_style_overrides_applied(self, axes, globe_boundary, meridian):
+        """Apply caller style overrides over the module defaults.
+
+        Test scenario:
+            ``boundary_kw`` and ``graticule_kw`` override edge color, line
+            width, and graticule color.
+        """
+        patch = apply_projection_frame(
+            axes,
+            boundary_xy=globe_boundary,
+            xlim=(-1, 1),
+            ylim=(-1, 1),
+            graticule_lines=[meridian],
+            boundary_kw={"edgecolor": "red", "linewidth": 2.0},
+            graticule_kw={"color": "blue"},
+        )
+        assert patch.get_edgecolor()[:3] == pytest.approx((1.0, 0.0, 0.0)), (
+            f"Expected red boundary, got {patch.get_edgecolor()}"
+        )
+        assert patch.get_linewidth() == 2.0, (
+            f"Expected lw 2.0, got {patch.get_linewidth()}"
+        )
+        assert axes.lines[0].get_color() == "blue", (
+            f"Expected blue graticule, got {axes.lines[0].get_color()}"
+        )
+
+    def test_does_not_mutate_caller_style_dicts(self, axes, globe_boundary, meridian):
+        """Leave the caller-supplied style dicts unmodified.
+
+        Test scenario:
+            Merging defaults must not mutate the passed ``boundary_kw`` /
+            ``graticule_kw`` dicts (purity of inputs).
+        """
+        boundary_kw = {"edgecolor": "red"}
+        graticule_kw = {"color": "blue"}
+        apply_projection_frame(
+            axes,
+            boundary_xy=globe_boundary,
+            xlim=(-1, 1),
+            ylim=(-1, 1),
+            graticule_lines=[meridian],
+            boundary_kw=boundary_kw,
+            graticule_kw=graticule_kw,
+        )
+        assert boundary_kw == {"edgecolor": "red"}, (
+            f"boundary_kw was mutated: {boundary_kw}"
+        )
+        assert graticule_kw == {"color": "blue"}, (
+            f"graticule_kw was mutated: {graticule_kw}"
+        )
+
+    def test_accepts_plain_list_geometry(self, axes):
+        """Coerce plain-list boundary and graticule geometry.
+
+        Test scenario:
+            Nested Python lists (not numpy arrays) are accepted for both the
+            boundary and the graticule polylines.
+        """
+        boundary = [[1.0, 0.0], [0.0, 1.0], [-1.0, 0.0], [0.0, -1.0]]
+        patch = apply_projection_frame(
+            axes,
+            boundary_xy=boundary,
+            xlim=(-1, 1),
+            ylim=(-1, 1),
+            graticule_lines=[[[0.0, -1.0], [0.0, 1.0]]],
+        )
+        assert isinstance(patch, PathPatch), f"Expected PathPatch, got {type(patch)}"
+        assert len(axes.lines) == 1, f"Expected 1 graticule line, got {len(axes.lines)}"
+
+    def test_open_boundary_still_clips(self, axes, rng):
+        """Clip correctly even when the boundary ring is not closed.
+
+        Test scenario:
+            A boundary whose last vertex does not repeat the first (an open
+            ring) still produces a clip path -- matplotlib closes the polygon
+            implicitly for containment.
+        """
+        open_square = [[1.0, 1.0], [-1.0, 1.0], [-1.0, -1.0], [1.0, -1.0]]
+        image = axes.imshow(rng.random((4, 4)), extent=(-1, 1, -1, 1))
+        apply_projection_frame(
+            axes, boundary_xy=open_square, xlim=(-1, 1), ylim=(-1, 1)
+        )
+        assert image.get_clip_path() is not None, "Open boundary should still clip"
+
+    def test_bad_axes_raises_type_error(self, globe_boundary):
+        """Raise ``TypeError`` when ``ax`` is not an Axes-like object.
+
+        Test scenario:
+            A bare ``object()`` lacks ``set_xlim``; the helper rejects it.
+        """
+        with pytest.raises(TypeError, match="matplotlib.axes.Axes") as exc:
+            apply_projection_frame(
+                object(), boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+            )
+        assert "object" in str(exc.value), (
+            f"Error should report the bad type name, got: {exc.value}"
+        )
+
+    def test_axes_missing_add_patch_raises_type_error(self, globe_boundary):
+        """Raise ``TypeError`` when ``ax`` has ``set_xlim`` but not ``add_patch``.
+
+        Test scenario:
+            Exercises the second operand of the duck-type check: an object
+            with ``set_xlim`` but no ``add_patch`` is still rejected.
+        """
+
+        class _HalfAxes:
+            def set_xlim(self, *args, **kwargs):  # pragma: no cover - never called
+                pass
+
+        with pytest.raises(TypeError, match="matplotlib.axes.Axes"):
+            apply_projection_frame(
+                _HalfAxes(), boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(-1, 1)
+            )
+
+    def test_bad_boundary_shape_raises_value_error(self, axes):
+        """Raise ``ValueError`` for a non ``(N, 2)`` boundary.
+
+        Test scenario:
+            A 1-D boundary array fails the shape contract.
+        """
+        with pytest.raises(ValueError, match=r"boundary_xy must be an \(N, 2\)"):
+            apply_projection_frame(
+                axes, boundary_xy=np.arange(10), xlim=(-1, 1), ylim=(-1, 1)
+            )
+
+    def test_bad_xlim_raises_value_error(self, axes, globe_boundary):
+        """Raise ``ValueError`` when ``xlim`` is not a 2-tuple.
+
+        Test scenario:
+            A 3-element ``xlim`` trips the first operand of the limit check.
+        """
+        with pytest.raises(ValueError, match="min, max"):
+            apply_projection_frame(
+                axes, boundary_xy=globe_boundary, xlim=(-1, 0, 1), ylim=(-1, 1)
+            )
+
+    def test_bad_ylim_raises_value_error(self, axes, globe_boundary):
+        """Raise ``ValueError`` when ``ylim`` is not a 2-tuple.
+
+        Test scenario:
+            A valid ``xlim`` with a 1-element ``ylim`` trips the second
+            operand of the limit check.
+        """
+        with pytest.raises(ValueError, match="min, max"):
+            apply_projection_frame(
+                axes, boundary_xy=globe_boundary, xlim=(-1, 1), ylim=(1,)
+            )
+
+    def test_bad_graticule_shape_raises_value_error(self, axes, globe_boundary):
+        """Raise ``ValueError`` for a malformed graticule polyline.
+
+        Test scenario:
+            A 1-D graticule entry fails ``_as_xy`` and the error names the
+            offending index.
+        """
+        with pytest.raises(ValueError, match=r"graticule_lines\[0\]"):
+            apply_projection_frame(
+                axes,
+                boundary_xy=globe_boundary,
+                xlim=(-1, 1),
+                ylim=(-1, 1),
+                graticule_lines=[np.arange(6)],
+            )
+
+    def test_second_graticule_index_reported_in_error(self, axes, globe_boundary, meridian):
+        """Report the correct index when a later graticule line is bad.
+
+        Test scenario:
+            The first polyline is valid; the second is malformed, so the
+            error names ``graticule_lines[1]``.
+        """
+        with pytest.raises(ValueError, match=r"graticule_lines\[1\]"):
+            apply_projection_frame(
+                axes,
+                boundary_xy=globe_boundary,
+                xlim=(-1, 1),
+                ylim=(-1, 1),
+                graticule_lines=[meridian, np.arange(6)],
+            )


### PR DESCRIPTION
## Summary

Adds `cleopatra/projection.py` with `apply_projection_frame` — a stateless, **PROJ-free** helper that turns a plain matplotlib `Axes` into a static projected ("globe") frame:

- sets equal aspect + projected x/y limits,
- draws the projection **boundary** as a `PathPatch` (returned, also used as the clip path),
- draws **graticule** polylines,
- **clips** existing data layers (`images`/`collections`/`lines`) and the graticule to the boundary,
- turns the axis decorations off.

All geometry (boundary vertices, graticule polylines, limits) is supplied as plain arrays, so the module has **no PROJ/CRS dependency** — the upstream engine owns reprojection, cleopatra owns matplotlib. This mirrors the existing `tiles.py` engine split.

## Notes

- Purely additive: no existing module, signature, or import surface changed; no new runtime dependency (uses only core matplotlib `PathPatch`/`Path`).
- Robustness over the issue sketch: `TypeError` for a non-Axes `ax`, `ValueError` for bad `(N, 2)`/limit shapes, `np.asarray` coercion so plain lists work, and style-default constants merged with caller overrides.
- `projection` added to the documented submodule list in `__init__.py` (no re-export, per package convention).

## Definition of done

- [x] given a circular boundary + graticule polylines, a plain axes renders a globe frame with equal aspect
- [x] data layers drawn before the call are clipped to the boundary
- [x] no new runtime dependency (geometry comes in as arrays; no PROJ)
- [x] tests: boundary patch present; an artist is clipped; `ax.get_aspect() == 1`

## Tests

- `tests/test_projection.py`: **14 passed** (covers full DoD plus limits, axis-off, graticule, `clip_artists=False`, style overrides, list coercion, validation errors)
- doctests in `projection.py`: **2 passed**

Closes #141