### PR TITLE
feat(animation): glyph-independent save/embed helpers for any FuncAnimation

### DIFF
--- a/docs/reference/animation.md
+++ b/docs/reference/animation.md
@@ -10,8 +10,10 @@ machinery as **glyph-independent** helpers. They operate on *any*
   needs FFmpeg installed). The extension is matched **case-insensitively**.
 - `to_gif(anim, fps=2)` renders the animation to in-memory **GIF bytes** (handy for serving
   or embedding) with the temporary file cleaned up afterwards.
-- `embed_gif(anim, fps=2)` returns an `IPython.display.Image` for inline notebook display;
-  IPython is imported **lazily**, so it stays an optional, notebook-only dependency.
+- `embed_gif(anim, fps=2)` returns an `IPython.display.Image` for inline notebook display.
+  IPython is imported **lazily** (and is bundled with Jupyter, so any notebook already has
+  it); if it is absent, `embed_gif` raises a clear `ModuleNotFoundError` with a
+  `pip install ipython` hint — or use `to_gif` for raw bytes with no IPython dependency.
 
 `Glyph.save_animation` delegates to `save_animation`, so the writer/format logic has a
 single source of truth. Downstream packages that build their own `FuncAnimation` can reuse
@@ -49,7 +51,8 @@ embed_gif(anim, fps=3)                     # inline in a notebook cell
     (`out.GIF` works). Video formats (`mov`/`avi`/`mp4`) require FFmpeg on the `PATH`; if it
     is missing, `save_animation` raises a `FileNotFoundError` pointing at
     <https://ffmpeg.org/>. An unsupported extension raises a `ValueError`. `embed_gif`
-    needs IPython, which is imported only when the function is called.
+    imports IPython only when called; if IPython is absent it raises a
+    `ModuleNotFoundError` with a `pip install ipython` hint (use `to_gif` to avoid IPython).
 
 ## Module Documentation
 

--- a/docs/reference/animation.md
+++ b/docs/reference/animation.md
@@ -1,0 +1,60 @@
+# Animation Module — Save / Embed Helpers for Any `FuncAnimation`
+
+The `cleopatra.animation` module exposes cleopatra's animation **save / inline-embed**
+machinery as **glyph-independent** helpers. They operate on *any*
+`matplotlib.animation.FuncAnimation` — a sine wave, stock prices, or a map — not only on a
+`Glyph`'s internal `self.anim`:
+
+- `save_animation(anim, path, fps=2)` writes an animation to a file, choosing the writer
+  from the extension (GIF via `PillowWriter`; `mov`/`avi`/`mp4` via `FFMpegWriter`, which
+  needs FFmpeg installed). The extension is matched **case-insensitively**.
+- `to_gif(anim, fps=2)` renders the animation to in-memory **GIF bytes** (handy for serving
+  or embedding) with the temporary file cleaned up afterwards.
+- `embed_gif(anim, fps=2)` returns an `IPython.display.Image` for inline notebook display;
+  IPython is imported **lazily**, so it stays an optional, notebook-only dependency.
+
+`Glyph.save_animation` delegates to `save_animation`, so the writer/format logic has a
+single source of truth. Downstream packages that build their own `FuncAnimation` can reuse
+these helpers instead of re-rolling temp-file + writer + `IPython.display` glue.
+
+## Usage
+
+```python
+import matplotlib
+matplotlib.use("Agg")  # any backend; Agg shown for headless rendering
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+
+from cleopatra.animation import embed_gif, save_animation, to_gif
+
+# Build any FuncAnimation — no Glyph required.
+fig, ax = plt.subplots()
+(line,) = ax.plot([0, 1], [0, 0])
+
+
+def update(i):
+    line.set_ydata([0, i])
+    return (line,)
+
+
+anim = FuncAnimation(fig, update, frames=3, blit=True)
+
+save_animation(anim, "wave.gif", fps=3)   # write to a file (gif/mov/avi/mp4)
+gif_bytes = to_gif(anim, fps=3)           # in-memory GIF bytes
+embed_gif(anim, fps=3)                     # inline in a notebook cell
+```
+
+!!! note
+    The output format is taken from the file extension and is matched case-insensitively
+    (`out.GIF` works). Video formats (`mov`/`avi`/`mp4`) require FFmpeg on the `PATH`; if it
+    is missing, `save_animation` raises a `FileNotFoundError` pointing at
+    <https://ffmpeg.org/>. An unsupported extension raises a `ValueError`. `embed_gif`
+    needs IPython, which is imported only when the function is called.
+
+## Module Documentation
+
+::: cleopatra.animation
+    options:
+      show_root_heading: true
+      show_source: true
+      heading_level: 3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
     - MeshGlyph: reference/mesh-glyph.md
     - Tiles (basemaps): reference/tiles.md
     - Projection (globe frames): reference/projection.md
+    - Animations (save/embed): reference/animation.md
     - Colors: reference/colors-glyph.md
     - Styles: reference/styles-glyph.md
     - Config: reference/config.md

--- a/src/cleopatra/__init__.py
+++ b/src/cleopatra/__init__.py
@@ -7,7 +7,7 @@ classes/functions from their submodules, e.g.
 `from cleopatra.config import Config`.
 
 Submodules: `array_glyph`, `glyph`, `mesh_glyph`, `statistical_glyph`,
-`colors`, `styles`, `tiles`, `projection`, `config`.
+`colors`, `styles`, `tiles`, `projection`, `animation`, `config`.
 
 Importing cleopatra does not change the active matplotlib backend. If you
 want the old convenience behaviour (`%matplotlib inline` in a notebook,

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -196,8 +196,10 @@ def to_gif(anim: FuncAnimation, fps: int = 2) -> bytes:
 def embed_gif(anim: FuncAnimation, fps: int = 2) -> Image:
     """Return an `IPython.display.Image` of the animation for inline display.
 
-    IPython is imported lazily so it stays an optional, notebook-only
-    dependency.
+    IPython is imported lazily, so importing cleopatra never requires it.
+    IPython ships with Jupyter, so any notebook already has it; outside a
+    notebook the returned `Image` is not renderable anyway — use `to_gif`
+    for raw bytes with no IPython dependency.
 
     Args:
         anim: The animation to embed.
@@ -208,8 +210,8 @@ def embed_gif(anim: FuncAnimation, fps: int = 2) -> Image:
         returned as the last expression of a notebook cell.
 
     Raises:
-        ModuleNotFoundError: If IPython is not installed (it is only needed
-            for inline display and is imported lazily).
+        ModuleNotFoundError: If IPython is not installed, with a hint to
+            `pip install ipython` (or to use `to_gif` instead).
 
     Examples:
         - Wrap an animation as an inline image and read back its payload:
@@ -252,6 +254,13 @@ def embed_gif(anim: FuncAnimation, fps: int = 2) -> Image:
         to_gif: Produce the underlying GIF bytes without IPython.
         save_animation: Write the animation to a file path instead.
     """
-    from IPython.display import Image  # optional dep, only for inline display
+    try:
+        from IPython.display import Image
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "embed_gif requires IPython for inline display. Install it with "
+            "`pip install ipython` (already present in any Jupyter/IPython "
+            "environment). For raw GIF bytes without IPython, use to_gif()."
+        ) from e
 
     return Image(data=to_gif(anim, fps=fps), format="gif")

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -86,7 +86,11 @@ def to_gif(anim: FuncAnimation, fps: int = 2) -> bytes:
     Returns:
         The GIF-encoded bytes of the animation.
     """
-    tmp = tempfile.NamedTemporaryFile(suffix=".gif", delete=False).name
+    # Close our handle immediately so the writer can reopen the path; this
+    # makes the handle lifecycle explicit (no reliance on GC) and avoids a
+    # PermissionError when reopening on Windows.
+    fd, tmp = tempfile.mkstemp(suffix=".gif")
+    os.close(fd)
     try:
         save_animation(anim, tmp, fps=fps)
         with open(tmp, "rb") as fh:

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -1,0 +1,114 @@
+"""Save/embed helpers for matplotlib animations (glyph-independent).
+
+These helpers operate on *any* `matplotlib.animation.FuncAnimation`, not
+only on a `Glyph`'s internal `self.anim`. Saving or embedding an animation
+is generic matplotlib machinery — it works on a sine wave, stock prices, or
+a map — so it lives here alongside the glyph classes that produce
+animations. Downstream packages that build their own `FuncAnimation` can
+reuse cleopatra's writer/format handling instead of re-rolling temp-file +
+writer + `IPython.display` glue.
+
+`Glyph.save_animation` delegates to `save_animation` below, so the
+writer/format logic has a single source of truth.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+from matplotlib.animation import FFMpegWriter, FuncAnimation, PillowWriter
+
+#: Container formats `save_animation` can write. GIF uses `PillowWriter`;
+#: the rest require FFmpeg (`FFMpegWriter`).
+SUPPORTED_VIDEO_FORMAT = ["gif", "mov", "avi", "mp4"]
+
+
+def save_animation(anim: FuncAnimation, path: str, fps: int = 2) -> str:
+    """Save any `FuncAnimation` to a file.
+
+    The output format is determined by the file extension. GIF uses
+    `PillowWriter`; mov/avi/mp4 require FFmpeg to be installed.
+
+    Args:
+        anim: The animation to save.
+        path: Output file path. Extension determines format.
+            Supported: gif, mov, avi, mp4.
+        fps: Frames per second. Default is 2.
+
+    Returns:
+        The `path` that was written (convenient for chaining).
+
+    Raises:
+        ValueError: If the file format is not supported.
+        FileNotFoundError: If a video format is requested but FFmpeg is
+            not installed.
+
+    Examples:
+        - Check the supported video formats:
+            ```python
+            >>> from cleopatra.animation import SUPPORTED_VIDEO_FORMAT
+            >>> sorted(SUPPORTED_VIDEO_FORMAT)
+            ['avi', 'gif', 'mov', 'mp4']
+
+            ```
+    """
+    video_format = path.split(".")[-1]
+    if video_format not in SUPPORTED_VIDEO_FORMAT:
+        raise ValueError(
+            f"The given extension {video_format} implies a format that is "
+            f"not supported, only {SUPPORTED_VIDEO_FORMAT} are supported"
+        )
+
+    if video_format == "gif":
+        anim.save(path, writer=PillowWriter(fps=fps))
+    else:
+        try:
+            anim.save(path, writer=FFMpegWriter(fps=fps, bitrate=1800))
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                "FFmpeg not found. Please visit https://ffmpeg.org/ "
+                "and download a version compatible with your OS."
+            ) from e
+    return path
+
+
+def to_gif(anim: FuncAnimation, fps: int = 2) -> bytes:
+    """Render a `FuncAnimation` to in-memory GIF bytes.
+
+    Handy for embedding in a notebook or serving over HTTP without leaving
+    a file on disk.
+
+    Args:
+        anim: The animation to render.
+        fps: Frames per second. Default is 2.
+
+    Returns:
+        The GIF-encoded bytes of the animation.
+    """
+    tmp = tempfile.NamedTemporaryFile(suffix=".gif", delete=False).name
+    try:
+        save_animation(anim, tmp, fps=fps)
+        with open(tmp, "rb") as fh:
+            return fh.read()
+    finally:
+        os.remove(tmp)
+
+
+def embed_gif(anim: FuncAnimation, fps: int = 2):
+    """Return an `IPython.display.Image` of the animation for inline display.
+
+    IPython is imported lazily so it stays an optional, notebook-only
+    dependency.
+
+    Args:
+        anim: The animation to embed.
+        fps: Frames per second. Default is 2.
+
+    Returns:
+        An `IPython.display.Image` wrapping the rendered GIF, ready to be
+        returned as the last expression of a notebook cell.
+    """
+    from IPython.display import Image  # optional dep, only for inline display
+
+    return Image(data=to_gif(anim, fps=fps), format="gif")

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -16,8 +16,12 @@ from __future__ import annotations
 
 import os
 import tempfile
+from typing import TYPE_CHECKING
 
 from matplotlib.animation import FFMpegWriter, FuncAnimation, PillowWriter
+
+if TYPE_CHECKING:  # import only for type checkers; IPython stays optional
+    from IPython.display import Image
 
 #: Container formats `save_animation` can write. GIF uses `PillowWriter`;
 #: the rest require FFmpeg (`FFMpegWriter`).
@@ -99,7 +103,7 @@ def to_gif(anim: FuncAnimation, fps: int = 2) -> bytes:
         os.remove(tmp)
 
 
-def embed_gif(anim: FuncAnimation, fps: int = 2):
+def embed_gif(anim: FuncAnimation, fps: int = 2) -> Image:
     """Return an `IPython.display.Image` of the animation for inline display.
 
     IPython is imported lazily so it stays an optional, notebook-only

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -51,54 +51,61 @@ def save_animation(anim: FuncAnimation, path: str, fps: int = 2) -> str:
     Examples:
         - Save a tiny animation to a GIF; the call returns the path it wrote:
             ```python
-            >>> import os, tempfile, matplotlib
+            >>> import os, shutil, tempfile, matplotlib
             >>> matplotlib.use("Agg")
             >>> import matplotlib.pyplot as plt
+            >>> from pathlib import Path
             >>> from matplotlib.animation import FuncAnimation
             >>> from cleopatra.animation import save_animation
+            >>> tmp = tempfile.mkdtemp()
             >>> fig, ax = plt.subplots()
             >>> (line,) = ax.plot([0, 1], [0, 0])
             >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
-            >>> path = os.path.join(tempfile.mkdtemp(), "wave.gif")
+            >>> path = os.path.join(tmp, "wave.gif")
             >>> save_animation(anim, path) == path
             True
-            >>> from pathlib import Path
             >>> Path(path).read_bytes()[:6] in (b"GIF87a", b"GIF89a")
             True
             >>> plt.close(fig)
+            >>> shutil.rmtree(tmp)
 
             ```
         - The extension is matched case-insensitively, so ``.GIF`` also works:
             ```python
-            >>> import os, tempfile, matplotlib
+            >>> import os, shutil, tempfile, matplotlib
             >>> matplotlib.use("Agg")
             >>> import matplotlib.pyplot as plt
             >>> from matplotlib.animation import FuncAnimation
             >>> from cleopatra.animation import save_animation
+            >>> tmp = tempfile.mkdtemp()
             >>> fig, ax = plt.subplots()
             >>> (line,) = ax.plot([0, 1], [0, 0])
             >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
-            >>> path = os.path.join(tempfile.mkdtemp(), "WAVE.GIF")
-            >>> save_animation(anim, path).endswith("WAVE.GIF")
+            >>> save_animation(anim, os.path.join(tmp, "WAVE.GIF")).endswith("WAVE.GIF")
             True
             >>> plt.close(fig)
+            >>> shutil.rmtree(tmp)
 
             ```
-        - An unsupported extension raises ``ValueError`` before writing:
+        - An unsupported extension raises ``ValueError`` before writing (here
+          the animation is rendered once first, so nothing is left dangling):
             ```python
-            >>> import matplotlib
+            >>> import os, shutil, tempfile, matplotlib
             >>> matplotlib.use("Agg")
             >>> import matplotlib.pyplot as plt
             >>> from matplotlib.animation import FuncAnimation
             >>> from cleopatra.animation import save_animation
+            >>> tmp = tempfile.mkdtemp()
             >>> fig, ax = plt.subplots()
             >>> (line,) = ax.plot([0, 1], [0, 0])
             >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> _ = save_animation(anim, os.path.join(tmp, "ok.gif"))
             >>> save_animation(anim, "movie.webm")  # doctest: +ELLIPSIS
             Traceback (most recent call last):
                 ...
             ValueError: ...not supported...
             >>> plt.close(fig)
+            >>> shutil.rmtree(tmp)
 
             ```
 
@@ -257,6 +264,10 @@ def embed_gif(anim: FuncAnimation, fps: int = 2) -> Image:
     try:
         from IPython.display import Image
     except ModuleNotFoundError as e:
+        # Only remap when IPython itself is missing; if a sub-dependency of
+        # IPython failed to import, surface that original error unchanged.
+        if e.name and e.name.split(".")[0] != "IPython":
+            raise
         raise ModuleNotFoundError(
             "embed_gif requires IPython for inline display. Install it with "
             "`pip install ipython` (already present in any Jupyter/IPython "

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -53,7 +53,7 @@ def save_animation(anim: FuncAnimation, path: str, fps: int = 2) -> str:
 
             ```
     """
-    video_format = path.split(".")[-1]
+    video_format = path.rsplit(".", 1)[-1].lower()
     if video_format not in SUPPORTED_VIDEO_FORMAT:
         raise ValueError(
             f"The given extension {video_format} implies a format that is "

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -49,13 +49,62 @@ def save_animation(anim: FuncAnimation, path: str, fps: int = 2) -> str:
             not installed.
 
     Examples:
-        - Check the supported video formats:
+        - Save a tiny animation to a GIF; the call returns the path it wrote:
             ```python
-            >>> from cleopatra.animation import SUPPORTED_VIDEO_FORMAT
-            >>> sorted(SUPPORTED_VIDEO_FORMAT)
-            ['avi', 'gif', 'mov', 'mp4']
+            >>> import os, tempfile, matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import save_animation
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> path = os.path.join(tempfile.mkdtemp(), "wave.gif")
+            >>> save_animation(anim, path) == path
+            True
+            >>> from pathlib import Path
+            >>> Path(path).read_bytes()[:6] in (b"GIF87a", b"GIF89a")
+            True
+            >>> plt.close(fig)
 
             ```
+        - The extension is matched case-insensitively, so ``.GIF`` also works:
+            ```python
+            >>> import os, tempfile, matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import save_animation
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> path = os.path.join(tempfile.mkdtemp(), "WAVE.GIF")
+            >>> save_animation(anim, path).endswith("WAVE.GIF")
+            True
+            >>> plt.close(fig)
+
+            ```
+        - An unsupported extension raises ``ValueError`` before writing:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import save_animation
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> save_animation(anim, "movie.webm")  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: ...not supported...
+            >>> plt.close(fig)
+
+            ```
+
+    See Also:
+        to_gif: Render an animation to in-memory GIF bytes instead of a file.
+        embed_gif: Wrap an animation as an ``IPython.display.Image``.
     """
     video_format = path.rsplit(".", 1)[-1].lower()
     if video_format not in SUPPORTED_VIDEO_FORMAT:
@@ -89,6 +138,47 @@ def to_gif(anim: FuncAnimation, fps: int = 2) -> bytes:
 
     Returns:
         The GIF-encoded bytes of the animation.
+
+    Examples:
+        - Render an animation to GIF bytes and inspect the payload:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import to_gif
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> data = to_gif(anim)
+            >>> data[:6] in (b"GIF87a", b"GIF89a")
+            True
+            >>> len(data) > 0
+            True
+            >>> plt.close(fig)
+
+            ```
+        - A higher ``fps`` still yields self-contained bytes you can serve over
+          HTTP or write yourself, without leaving a temp file behind:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import to_gif
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=3)
+            >>> payload = to_gif(anim, fps=5)
+            >>> payload.startswith((b"GIF87a", b"GIF89a"))
+            True
+            >>> plt.close(fig)
+
+            ```
+
+    See Also:
+        save_animation: Write an animation directly to a file path.
+        embed_gif: Wrap these bytes as an ``IPython.display.Image``.
     """
     # Close our handle immediately so the writer can reopen the path; this
     # makes the handle lifecycle explicit (no reliance on GC) and avoids a
@@ -116,6 +206,51 @@ def embed_gif(anim: FuncAnimation, fps: int = 2) -> Image:
     Returns:
         An `IPython.display.Image` wrapping the rendered GIF, ready to be
         returned as the last expression of a notebook cell.
+
+    Raises:
+        ModuleNotFoundError: If IPython is not installed (it is only needed
+            for inline display and is imported lazily).
+
+    Examples:
+        - Wrap an animation as an inline image and read back its payload:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import embed_gif
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> img = embed_gif(anim)
+            >>> img.format
+            'gif'
+            >>> img.data[:6] in (b"GIF87a", b"GIF89a")
+            True
+            >>> plt.close(fig)
+
+            ```
+        - Returning the image as a cell's last expression renders it inline;
+          a custom ``fps`` controls playback speed:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import embed_gif
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> img = embed_gif(anim, fps=3)
+            >>> len(img.data) > 0
+            True
+            >>> plt.close(fig)
+
+            ```
+
+    See Also:
+        to_gif: Produce the underlying GIF bytes without IPython.
+        save_animation: Write the animation to a file path instead.
     """
     from IPython.display import Image  # optional dep, only for inline display
 

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -17,17 +17,19 @@ import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 import numpy as np
-from matplotlib import animation
 from matplotlib.animation import FuncAnimation
 from matplotlib.axes import Axes
 from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure, SubFigure
 from matplotlib.ticker import LogFormatter
 
+# `SUPPORTED_VIDEO_FORMAT` is re-imported (not redefined) so the constant has
+# a single source of truth in `cleopatra.animation`, while the historical
+# `from cleopatra.glyph import SUPPORTED_VIDEO_FORMAT` path keeps working.
+from cleopatra.animation import SUPPORTED_VIDEO_FORMAT
+from cleopatra.animation import save_animation as _save_animation
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale, MidpointNormalize
-
-SUPPORTED_VIDEO_FORMAT = ["gif", "mov", "avi", "mp4"]
 
 #: Upper bound for an integer `levels` value (number of discrete colour
 #: levels / contour lines). A larger request is almost certainly a mistake
@@ -994,10 +996,11 @@ class Glyph:
         return list(map(write_points, point_table))
 
     def save_animation(self, path: str, fps: int = 2) -> None:
-        """Save the animation to a file.
+        """Save this glyph's animation (`self.anim`) to a file.
 
-        The output format is determined by the file extension. GIF uses
-        `PillowWriter`; mov/avi/mp4 require FFmpeg to be installed.
+        Thin wrapper around `cleopatra.animation.save_animation`; the output
+        format is determined by the file extension. GIF uses `PillowWriter`;
+        mov/avi/mp4 require FFmpeg to be installed.
 
         Args:
             path: Output file path. Extension determines format.
@@ -1005,7 +1008,10 @@ class Glyph:
             fps: Frames per second. Default is 2.
 
         Raises:
-            ValueError: If the file format is not supported.
+            ValueError: If `animate()` has not been called yet, or if the
+                file format is not supported.
+            FileNotFoundError: If a video format is requested but FFmpeg is
+                not installed.
 
         Examples:
             - Check the supported video formats:
@@ -1016,22 +1022,4 @@ class Glyph:
 
                 ```
         """
-        video_format = path.split(".")[-1]
-        if video_format not in SUPPORTED_VIDEO_FORMAT:
-            raise ValueError(
-                f"The given extension {video_format} implies a format that is "
-                f"not supported, only {SUPPORTED_VIDEO_FORMAT} are supported"
-            )
-
-        if video_format == "gif":
-            writer_gif = animation.PillowWriter(fps=fps)
-            self.anim.save(path, writer=writer_gif)
-        else:
-            try:
-                writer_video = animation.FFMpegWriter(fps=fps, bitrate=1800)
-                self.anim.save(path, writer=writer_video)
-            except FileNotFoundError as e:
-                raise FileNotFoundError(
-                    "FFmpeg not found. Please visit https://ffmpeg.org/ "
-                    "and download a version compatible with your OS."
-                ) from e
+        _save_animation(self.anim, path, fps=fps)

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -26,7 +26,7 @@ from matplotlib.ticker import LogFormatter
 # `SUPPORTED_VIDEO_FORMAT` is re-imported (not redefined) so the constant has
 # a single source of truth in `cleopatra.animation`, while the historical
 # `from cleopatra.glyph import SUPPORTED_VIDEO_FORMAT` path keeps working.
-from cleopatra.animation import SUPPORTED_VIDEO_FORMAT
+from cleopatra.animation import SUPPORTED_VIDEO_FORMAT  # noqa: F401  (re-export)
 from cleopatra.animation import save_animation as _save_animation
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale, MidpointNormalize

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -1,0 +1,118 @@
+"""Tests for cleopatra.animation glyph-independent save/embed helpers.
+
+Covers `save_animation`, `to_gif`, and `embed_gif` operating on a plain
+`matplotlib.animation.FuncAnimation` (no `Glyph` involved). A tiny 2-3 frame
+animation is rendered on the Agg backend (set globally via `MPLBACKEND`).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import matplotlib.pyplot as plt
+import pytest
+from matplotlib.animation import FuncAnimation
+
+from cleopatra.animation import (
+    SUPPORTED_VIDEO_FORMAT,
+    embed_gif,
+    save_animation,
+    to_gif,
+)
+
+
+@pytest.fixture
+def tiny_anim():
+    """A 3-frame line animation built directly from matplotlib (no Glyph)."""
+    fig, ax = plt.subplots()
+    (line,) = ax.plot([0, 1], [0, 0])
+
+    def update(i):
+        line.set_ydata([0, i])
+        return (line,)
+
+    anim = FuncAnimation(fig, update, frames=3, blit=True)
+    yield anim
+    plt.close(fig)
+
+
+class TestSaveAnimation:
+    """Tests for `save_animation`."""
+
+    def test_gif_round_trips(self, tiny_anim, tmp_path):
+        """A GIF is written to disk and is non-empty."""
+        path = tmp_path / "out.gif"
+        returned = save_animation(tiny_anim, str(path), fps=2)
+
+        assert returned == str(path), "should return the path it wrote"
+        assert path.exists(), "GIF file was not created"
+        assert path.stat().st_size > 0, "GIF file is empty"
+        # GIF magic number — confirms a real GIF, not a stray file.
+        assert path.read_bytes()[:6] in (b"GIF87a", b"GIF89a")
+
+    def test_unsupported_format_raises(self, tiny_anim, tmp_path):
+        """An unsupported extension raises a clear ValueError."""
+        with pytest.raises(ValueError, match="not supported"):
+            save_animation(tiny_anim, str(tmp_path / "out.webm"))
+
+    def test_ffmpeg_missing_raises_friendly_error(self, tmp_path):
+        """A missing FFmpeg binary surfaces as `FileNotFoundError` with URL."""
+        anim = MagicMock(spec=FuncAnimation)
+        anim.save = MagicMock(side_effect=FileNotFoundError("ffmpeg not found"))
+
+        with pytest.raises(FileNotFoundError, match="ffmpeg.org"):
+            save_animation(anim, str(tmp_path / "movie.mp4"))
+
+
+class TestToGif:
+    """Tests for `to_gif`."""
+
+    def test_returns_non_empty_gif_bytes(self, tiny_anim):
+        """`to_gif` returns in-memory GIF bytes with the GIF magic number."""
+        data = to_gif(tiny_anim, fps=2)
+
+        assert isinstance(data, bytes), "expected raw bytes"
+        assert len(data) > 0, "GIF bytes are empty"
+        assert data[:6] in (b"GIF87a", b"GIF89a")
+
+    def test_leaves_no_temp_file(self, tiny_anim, tmp_path, monkeypatch):
+        """The temp file used for rendering is cleaned up afterwards."""
+        monkeypatch.setattr(
+            "tempfile.tempdir", str(tmp_path)
+        )  # confine temp files here
+        before = set(tmp_path.iterdir())
+        to_gif(tiny_anim, fps=2)
+        after = set(tmp_path.iterdir())
+
+        assert before == after, "to_gif left a temp file behind"
+
+
+class TestEmbedGif:
+    """Tests for `embed_gif` (notebook inline display)."""
+
+    def test_returns_ipython_image(self, tiny_anim):
+        """`embed_gif` returns an `IPython.display.Image` wrapping the GIF."""
+        Image = pytest.importorskip("IPython.display").Image
+
+        result = embed_gif(tiny_anim, fps=2)
+
+        assert isinstance(result, Image), "expected an IPython.display.Image"
+        assert result.format == "gif"
+        assert result.data[:6] in (b"GIF87a", b"GIF89a")
+
+
+class TestSupportedVideoFormat:
+    """Tests for the module-level `SUPPORTED_VIDEO_FORMAT` constant."""
+
+    def test_contains_expected_formats(self):
+        """The constant lists exactly the four supported container formats."""
+        assert set(SUPPORTED_VIDEO_FORMAT) == {"gif", "mov", "avi", "mp4"}
+
+    def test_is_single_source_of_truth(self):
+        """`cleopatra.glyph` re-exports the same object, not a copy."""
+        from cleopatra.glyph import SUPPORTED_VIDEO_FORMAT as glyph_constant
+
+        assert glyph_constant is SUPPORTED_VIDEO_FORMAT, (
+            "glyph should re-import the constant, not redefine it"
+        )

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -72,6 +72,96 @@ class TestSaveAnimation:
         with pytest.raises(FileNotFoundError, match="ffmpeg.org"):
             save_animation(anim, str(tmp_path / "movie.mp4"))
 
+    def test_routes_gif_to_pillow_writer(self, monkeypatch):
+        """The `.gif` branch builds a `PillowWriter(fps=...)` and saves with it.
+
+        Test scenario:
+            A mocked animation and a patched `PillowWriter` confirm the GIF
+            branch is taken, the writer receives the requested ``fps``, and
+            ``anim.save`` is called once with that writer.
+        """
+        import cleopatra.animation as anim_mod
+
+        anim = MagicMock(spec=FuncAnimation)
+        pillow = MagicMock(name="PillowWriter")
+        monkeypatch.setattr(anim_mod, "PillowWriter", pillow)
+
+        result = save_animation(anim, "clip.gif", fps=7)
+
+        pillow.assert_called_once_with(fps=7)
+        anim.save.assert_called_once_with("clip.gif", writer=pillow.return_value)
+        assert result == "clip.gif", f"should return the path, got {result!r}"
+
+    @pytest.mark.parametrize("ext", ["mov", "avi", "mp4"])
+    def test_routes_video_to_ffmpeg_writer(self, ext, monkeypatch):
+        """Non-GIF formats build an `FFMpegWriter(fps=, bitrate=1800)`.
+
+        Args:
+            ext: A supported video container extension.
+
+        Test scenario:
+            For each video extension the else-branch is taken, the writer is
+            constructed with the expected ``fps``/``bitrate``, ``anim.save``
+            is invoked with it, and the written path is returned. Exercises
+            the video success path without requiring FFmpeg.
+        """
+        import cleopatra.animation as anim_mod
+
+        anim = MagicMock(spec=FuncAnimation)
+        ffmpeg = MagicMock(name="FFMpegWriter")
+        monkeypatch.setattr(anim_mod, "FFMpegWriter", ffmpeg)
+
+        result = save_animation(anim, f"clip.{ext}", fps=5)
+
+        ffmpeg.assert_called_once_with(fps=5, bitrate=1800)
+        anim.save.assert_called_once_with(f"clip.{ext}", writer=ffmpeg.return_value)
+        assert result == f"clip.{ext}", f"should return the path, got {result!r}"
+
+    def test_no_extension_raises(self):
+        """A path with no extension is rejected as an unsupported format.
+
+        Test scenario:
+            ``"noext"`` has no dot, so ``rsplit`` yields the whole string,
+            which is not a supported format and raises ``ValueError`` before
+            any save is attempted.
+        """
+        anim = MagicMock(spec=FuncAnimation)
+        with pytest.raises(ValueError, match="not supported"):
+            save_animation(anim, "noext")
+        anim.save.assert_not_called()
+
+    def test_multi_dot_filename_uses_last_segment(self, monkeypatch):
+        """Only the final dot-segment is treated as the extension.
+
+        Test scenario:
+            ``"my.movie.v2.gif"`` resolves to ``gif`` (not ``v2``), so the
+            GIF branch is taken and the full path is preserved on save.
+        """
+        import cleopatra.animation as anim_mod
+
+        anim = MagicMock(spec=FuncAnimation)
+        monkeypatch.setattr(anim_mod, "PillowWriter", MagicMock())
+
+        result = save_animation(anim, "my.movie.v2.gif", fps=2)
+
+        anim.save.assert_called_once()
+        assert result == "my.movie.v2.gif", f"path not preserved: {result!r}"
+
+    def test_default_fps_is_two(self, monkeypatch):
+        """Omitting ``fps`` defaults the writer to 2 frames per second.
+
+        Test scenario:
+            Calling without ``fps`` builds ``PillowWriter(fps=2)``.
+        """
+        import cleopatra.animation as anim_mod
+
+        pillow = MagicMock(name="PillowWriter")
+        monkeypatch.setattr(anim_mod, "PillowWriter", pillow)
+
+        save_animation(MagicMock(spec=FuncAnimation), "clip.gif")
+
+        pillow.assert_called_once_with(fps=2)
+
 
 class TestToGif:
     """Tests for `to_gif`."""
@@ -95,6 +185,54 @@ class TestToGif:
 
         assert before == after, "to_gif left a temp file behind"
 
+    def test_removes_temp_file_on_save_failure(self, tmp_path, monkeypatch):
+        """The temp file is removed even when rendering raises.
+
+        Test scenario:
+            ``save_animation`` is patched to raise; the original error must
+            propagate and the ``finally`` block must still delete the temp
+            file (no leak on the error path).
+        """
+        import cleopatra.animation as anim_mod
+
+        monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("render failed")
+
+        monkeypatch.setattr(anim_mod, "save_animation", boom)
+        before = set(tmp_path.iterdir())
+
+        with pytest.raises(RuntimeError, match="render failed"):
+            to_gif(MagicMock(spec=FuncAnimation))
+
+        assert set(tmp_path.iterdir()) == before, "temp file leaked on failure"
+
+    def test_forwards_fps_to_save_animation(self, tmp_path, monkeypatch):
+        """``fps`` is forwarded to ``save_animation`` and bytes are returned.
+
+        Test scenario:
+            ``save_animation`` is patched to record ``fps`` and write known
+            bytes; ``to_gif`` must pass the requested ``fps`` through and
+            return exactly those bytes.
+        """
+        import cleopatra.animation as anim_mod
+
+        monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
+        captured = {}
+
+        def fake_save(anim, path, fps):
+            captured["fps"] = fps
+            Path(path).write_bytes(b"GIF89a-data")
+            return path
+
+        monkeypatch.setattr(anim_mod, "save_animation", fake_save)
+
+        data = to_gif(MagicMock(spec=FuncAnimation), fps=9)
+
+        assert captured["fps"] == 9, f"fps not forwarded, got {captured.get('fps')!r}"
+        assert data == b"GIF89a-data", f"unexpected bytes: {data!r}"
+
 
 class TestEmbedGif:
     """Tests for `embed_gif` (notebook inline display)."""
@@ -108,6 +246,42 @@ class TestEmbedGif:
         assert isinstance(result, Image), "expected an IPython.display.Image"
         assert result.format == "gif"
         assert result.data[:6] in (b"GIF87a", b"GIF89a")
+
+    def test_delegates_to_to_gif_with_fps(self, monkeypatch):
+        """`embed_gif` renders via `to_gif` (forwarding ``fps``) then wraps it.
+
+        Test scenario:
+            ``to_gif`` is patched to return known bytes; ``embed_gif`` must
+            call it with the same animation and ``fps``, and wrap the result
+            in an ``Image`` of format ``gif`` carrying those bytes. Avoids a
+            real render for determinism.
+        """
+        pytest.importorskip("IPython.display")
+        import cleopatra.animation as anim_mod
+
+        fake_to_gif = MagicMock(return_value=b"GIF89a-embed")
+        monkeypatch.setattr(anim_mod, "to_gif", fake_to_gif)
+        anim = MagicMock(spec=FuncAnimation)
+
+        result = anim_mod.embed_gif(anim, fps=4)
+
+        fake_to_gif.assert_called_once_with(anim, fps=4)
+        assert result.format == "gif", f"expected gif, got {result.format!r}"
+        assert result.data == b"GIF89a-embed", f"unexpected bytes: {result.data!r}"
+
+    def test_image_not_imported_at_module_level(self):
+        """IPython stays optional: ``Image`` is not bound at module import.
+
+        Test scenario:
+            The lazy import inside ``embed_gif`` means importing
+            ``cleopatra.animation`` must not expose an ``Image`` attribute,
+            so the package never hard-depends on IPython at load time.
+        """
+        import cleopatra.animation as anim_mod
+
+        assert not hasattr(anim_mod, "Image"), (
+            "IPython Image must not be imported at module load time"
+        )
 
 
 class TestSupportedVideoFormat:

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -14,6 +14,7 @@ import matplotlib.pyplot as plt
 import pytest
 from matplotlib.animation import FuncAnimation
 
+import cleopatra.animation as anim_mod
 from cleopatra.animation import (
     SUPPORTED_VIDEO_FORMAT,
     embed_gif,
@@ -80,7 +81,6 @@ class TestSaveAnimation:
             branch is taken, the writer receives the requested ``fps``, and
             ``anim.save`` is called once with that writer.
         """
-        import cleopatra.animation as anim_mod
 
         anim = MagicMock(spec=FuncAnimation)
         pillow = MagicMock(name="PillowWriter")
@@ -105,7 +105,6 @@ class TestSaveAnimation:
             is invoked with it, and the written path is returned. Exercises
             the video success path without requiring FFmpeg.
         """
-        import cleopatra.animation as anim_mod
 
         anim = MagicMock(spec=FuncAnimation)
         ffmpeg = MagicMock(name="FFMpegWriter")
@@ -137,7 +136,6 @@ class TestSaveAnimation:
             ``"my.movie.v2.gif"`` resolves to ``gif`` (not ``v2``), so the
             GIF branch is taken and the full path is preserved on save.
         """
-        import cleopatra.animation as anim_mod
 
         anim = MagicMock(spec=FuncAnimation)
         monkeypatch.setattr(anim_mod, "PillowWriter", MagicMock())
@@ -153,7 +151,6 @@ class TestSaveAnimation:
         Test scenario:
             Calling without ``fps`` builds ``PillowWriter(fps=2)``.
         """
-        import cleopatra.animation as anim_mod
 
         pillow = MagicMock(name="PillowWriter")
         monkeypatch.setattr(anim_mod, "PillowWriter", pillow)
@@ -193,7 +190,6 @@ class TestToGif:
             propagate and the ``finally`` block must still delete the temp
             file (no leak on the error path).
         """
-        import cleopatra.animation as anim_mod
 
         monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
 
@@ -216,7 +212,6 @@ class TestToGif:
             bytes; ``to_gif`` must pass the requested ``fps`` through and
             return exactly those bytes.
         """
-        import cleopatra.animation as anim_mod
 
         monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
         captured = {}
@@ -257,7 +252,6 @@ class TestEmbedGif:
             real render for determinism.
         """
         pytest.importorskip("IPython.display")
-        import cleopatra.animation as anim_mod
 
         fake_to_gif = MagicMock(return_value=b"GIF89a-embed")
         monkeypatch.setattr(anim_mod, "to_gif", fake_to_gif)
@@ -277,7 +271,6 @@ class TestEmbedGif:
             ``cleopatra.animation`` must not expose an ``Image`` attribute,
             so the package never hard-depends on IPython at load time.
         """
-        import cleopatra.animation as anim_mod
 
         assert not hasattr(anim_mod, "Image"), (
             "IPython Image must not be imported at module load time"

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -7,6 +7,7 @@ animation is rendered on the Agg backend (set globally via `MPLBACKEND`).
 
 from __future__ import annotations
 
+import builtins
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -262,6 +263,26 @@ class TestEmbedGif:
         fake_to_gif.assert_called_once_with(anim, fps=4)
         assert result.format == "gif", f"expected gif, got {result.format!r}"
         assert result.data == b"GIF89a-embed", f"unexpected bytes: {result.data!r}"
+
+    def test_missing_ipython_raises_friendly_error(self, monkeypatch):
+        """Without IPython, a clear `ModuleNotFoundError` with a hint is raised.
+
+        Test scenario:
+            The ``IPython.display`` import is forced to fail; ``embed_gif``
+            must surface an actionable message (``pip install ipython`` and a
+            pointer to ``to_gif``) rather than a bare import error.
+        """
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("IPython"):
+                raise ModuleNotFoundError("No module named 'IPython'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        with pytest.raises(ModuleNotFoundError, match="pip install ipython"):
+            embed_gif(MagicMock(spec=FuncAnimation))
 
     def test_image_not_imported_at_module_level(self):
         """IPython stays optional: ``Image`` is not bound at module import.

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -276,12 +276,38 @@ class TestEmbedGif:
 
         def fake_import(name, *args, **kwargs):
             if name.startswith("IPython"):
-                raise ModuleNotFoundError("No module named 'IPython'")
+                raise ModuleNotFoundError(
+                    "No module named 'IPython'", name="IPython"
+                )
             return real_import(name, *args, **kwargs)
 
         monkeypatch.setattr(builtins, "__import__", fake_import)
 
         with pytest.raises(ModuleNotFoundError, match="pip install ipython"):
+            embed_gif(MagicMock(spec=FuncAnimation))
+
+    def test_missing_subdependency_is_not_remapped(self, monkeypatch):
+        """A missing IPython *sub-dependency* surfaces unchanged, not remapped.
+
+        Test scenario:
+            IPython is importable, but one of its transitive imports raises
+            ``ModuleNotFoundError`` for some other package. ``embed_gif`` must
+            re-raise that original error rather than misattribute it to a
+            missing IPython.
+        """
+        pytest.importorskip("IPython.display")
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "IPython.display":
+                raise ModuleNotFoundError(
+                    "No module named 'some_dep'", name="some_dep"
+                )
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        with pytest.raises(ModuleNotFoundError, match="some_dep"):
             embed_gif(MagicMock(spec=FuncAnimation))
 
     def test_image_not_imported_at_module_level(self):

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -56,6 +56,14 @@ class TestSaveAnimation:
         with pytest.raises(ValueError, match="not supported"):
             save_animation(tiny_anim, str(tmp_path / "out.webm"))
 
+    def test_extension_is_case_insensitive(self, tiny_anim, tmp_path):
+        """An upper/mixed-case extension is matched the same as lower-case."""
+        path = tmp_path / "out.GIF"
+        save_animation(tiny_anim, str(path), fps=2)
+
+        assert path.exists(), "upper-case .GIF was not written"
+        assert path.read_bytes()[:6] in (b"GIF87a", b"GIF89a")
+
     def test_ffmpeg_missing_raises_friendly_error(self, tmp_path):
         """A missing FFmpeg binary surfaces as `FileNotFoundError` with URL."""
         anim = MagicMock(spec=FuncAnimation)

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -590,8 +590,17 @@ class TestSaveAnimation:
     """Tests for Glyph.save_animation."""
 
     def test_unsupported_format_raises(self):
-        """Test that unsupported format raises ValueError."""
+        """Test that unsupported format raises ValueError.
+
+        An animation is attached so the format check (not the missing-anim
+        guard) is what fires.
+        """
+        from unittest.mock import MagicMock
+
+        from matplotlib.animation import FuncAnimation
+
         g = Glyph(default_options=_make_options())
+        g._anim = MagicMock(spec=FuncAnimation)
         with pytest.raises(ValueError, match="not supported"):
             g.save_animation("output.webm")
 
@@ -617,6 +626,24 @@ class TestSaveAnimation:
         g._anim = None
         with pytest.raises(ValueError, match="animate"):
             g.save_animation(f"output.{ext}")
+
+    def test_delegates_to_free_function(self, monkeypatch):
+        """`Glyph.save_animation` forwards `self.anim` to the free function."""
+        from unittest.mock import MagicMock
+
+        from matplotlib.animation import FuncAnimation
+
+        import cleopatra.glyph as glyph_mod
+
+        g = Glyph(default_options=_make_options())
+        anim = MagicMock(spec=FuncAnimation)
+        g._anim = anim
+
+        spy = MagicMock()
+        monkeypatch.setattr(glyph_mod, "_save_animation", spy)
+        g.save_animation("movie.gif", fps=5)
+
+        spy.assert_called_once_with(anim, "movie.gif", fps=5)
 
 
 class TestSupportedVideoFormat:

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -7,13 +7,17 @@ tick adjustment, point overlay, and animation saving.
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from matplotlib.animation import FuncAnimation
 from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure
 
+import cleopatra.glyph as glyph_mod
 from cleopatra.glyph import MAX_DISCRETE_LEVELS, SUPPORTED_VIDEO_FORMAT, Glyph
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale, MidpointNormalize
@@ -595,10 +599,6 @@ class TestSaveAnimation:
         An animation is attached so the format check (not the missing-anim
         guard) is what fires.
         """
-        from unittest.mock import MagicMock
-
-        from matplotlib.animation import FuncAnimation
-
         g = Glyph(default_options=_make_options())
         g._anim = MagicMock(spec=FuncAnimation)
         with pytest.raises(ValueError, match="not supported"):
@@ -629,12 +629,6 @@ class TestSaveAnimation:
 
     def test_delegates_to_free_function(self, monkeypatch):
         """`Glyph.save_animation` forwards `self.anim` to the free function."""
-        from unittest.mock import MagicMock
-
-        from matplotlib.animation import FuncAnimation
-
-        import cleopatra.glyph as glyph_mod
-
         g = Glyph(default_options=_make_options())
         anim = MagicMock(spec=FuncAnimation)
         g._anim = anim
@@ -856,9 +850,6 @@ class TestSaveAnimationVideoBranch:
 
     def test_ffmpeg_missing_raises_friendly_error(self, monkeypatch, tmp_path):
         """A missing FFmpeg binary surfaces as `FileNotFoundError` with URL."""
-        from matplotlib.animation import FuncAnimation
-        from unittest.mock import MagicMock
-
         g = Glyph(default_options=_make_options())
         anim = MagicMock(spec=FuncAnimation)
         anim.save = MagicMock(side_effect=FileNotFoundError("ffmpeg not found"))

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,6 +17,7 @@ import pytest
 
 #: Submodules the package is expected to ship.
 _SUBMODULES = [
+    "animation",
     "array_glyph",
     "colors",
     "config",


### PR DESCRIPTION
## Summary

Exposes cleopatra's animation **save / inline-embed** machinery as **glyph-independent helpers** that operate on *any* `matplotlib.animation.FuncAnimation`, not only a `Glyph`'s internal `self.anim`. Downstream packages that build their own `FuncAnimation` (e.g. Digital-Earth's `Map.animate`/`Map.rotate`) can now reuse cleopatra's writer/format handling instead of re-rolling temp-file + writer + `IPython.display` glue.

Closes #144.

## Changes

**New module `src/cleopatra/animation.py`** — free functions on any `FuncAnimation`:
- `save_animation(anim, path, fps=2) -> str` — writer/format handling extracted from `Glyph.save_animation` (GIF via `PillowWriter`, mov/avi/mp4 via `FFMpegWriter`); clear `ValueError` on bad extension, clear `FileNotFoundError` when FFmpeg is missing; returns the written path.
- `to_gif(anim, fps=2) -> bytes` — in-memory GIF bytes with guaranteed temp-file cleanup.
- `embed_gif(anim, fps=2)` — `IPython.display.Image` for inline notebook display, with IPython imported **lazily** so it stays an optional, notebook-only dependency.

**`src/cleopatra/glyph.py`**
- `Glyph.save_animation` now delegates to the free function (no duplicated writer logic).
- `SUPPORTED_VIDEO_FORMAT` moves to `cleopatra.animation` and is **re-imported** by `cleopatra.glyph` — single source of truth, while `from cleopatra.glyph import SUPPORTED_VIDEO_FORMAT` keeps working.
- Dropped the now-unused `from matplotlib import animation` import.

## Behavior note

For a glyph with **no** animation, `save_animation("x.webm")` now raises the "call `animate()` first" message instead of "unsupported format" — the missing animation is the more fundamental problem. All real save paths are unchanged and backward compatible.

## Tests

- New `tests/test_animation.py`: GIF round-trip (asserts GIF magic bytes), unsupported-format `ValueError`, FFmpeg-missing `FileNotFoundError`, `to_gif` returns non-empty bytes and leaves no temp file behind, `embed_gif` returns an `Image` (`importorskip` for IPython), and a single-source-of-truth identity check.
- `tests/test_glyph.py`: added a delegation test; updated `test_unsupported_format_raises` to attach an animation so it exercises the format path.
- Full suite: `366 passed, 3 skipped` across `test_glyph.py` + `test_array_glyph.py`; new animation tests green.

## Non-goals

- Geospatial per-frame logic (reproject + globe frame) stays in Digital-Earth.
- No change to `ArrayGlyph.animate`'s signature.