### PR TITLE
feat(array_glyph): inline contour labels via plot(kind="contour", labels=True)

### DIFF
--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -207,8 +207,9 @@ class ArrayGlyph(Glyph):
             or `None` when none was drawn (RGB, or `add_colorbar=False`).
         contour_labels (list): The inline contour-label `Text` artists from
             the most recent `plot(kind="contour", labels=True)`, or `None`
-            when no labels were drawn (the default, and for every kind other
-            than `"contour"`).
+            when labelling was not requested (the default, and for every
+            kind other than `"contour"`). A labelled contour with no
+            isolines (e.g. a constant-value field) yields an empty list.
 
     Notes:
         This class provides methods for:
@@ -1811,7 +1812,8 @@ class ArrayGlyph(Glyph):
                         False. Ignored for `kind="contourf"` and every
                         non-contour kind (filled contours have no lines
                         to label). The label `Text` artists are stored
-                        on the instance as `self.contour_labels`.
+                        on the instance as `self.contour_labels` (an
+                        empty list when the contour has no isolines).
                     label_kw : dict, optional
                         Extra keyword arguments forwarded to
                         `ax.clabel` when `labels=True`, by default None.
@@ -1873,7 +1875,7 @@ class ArrayGlyph(Glyph):
                 ```python
                 >>> from matplotlib.text import Text
                 >>> y, x = np.mgrid[-3:3:30j, -3:3:30j]
-                >>> z = np.exp(-(x ** 2 + y ** 2))
+                >>> z = np.exp(-(x**2 + y**2))
                 >>> glyph = ArrayGlyph(z, figsize=(6, 6))
                 >>> fig, ax = glyph.plot(kind="contour", labels=True, label_kw={"fmt": "%.2f"})
                 >>> bool(glyph.contour_labels) and all(

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -558,8 +558,9 @@ class ArrayGlyph(Glyph):
         self.im = None
         self.cbar = None
         # Inline contour-label artists from the most recent
-        # `plot(kind="contour", labels=True)`, or `None` when no labels
-        # were drawn (the default, and for every non-contour kind).
+        # `plot(kind="contour", labels=True)`, or `None` when labelling
+        # was not requested (the default, and for every non-contour
+        # kind); an empty list when the contour has no isolines.
         self.contour_labels = None
 
     @property

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -59,6 +59,8 @@ ARRAY_DEFAULT_OPTIONS = {
     "extend": None,
     "cbar_kwargs": None,
     "add_colorbar": True,
+    "labels": False,
+    "label_kw": None,
 }
 ARRAY_DEFAULT_OPTIONS = STYLE_DEFAULTS | ARRAY_DEFAULT_OPTIONS
 #: Backwards-compatible alias for the array glyph's default options
@@ -203,6 +205,10 @@ class ArrayGlyph(Glyph):
             the colour limits without scraping `ax.images`/`ax.collections`.
         cbar (matplotlib.colorbar.Colorbar): The colorbar drawn by the glyph,
             or `None` when none was drawn (RGB, or `add_colorbar=False`).
+        contour_labels (list): The inline contour-label `Text` artists from
+            the most recent `plot(kind="contour", labels=True)`, or `None`
+            when no labels were drawn (the default, and for every kind other
+            than `"contour"`).
 
     Notes:
         This class provides methods for:
@@ -550,6 +556,10 @@ class ArrayGlyph(Glyph):
         # reachable as public attributes, even before the first render.
         self.im = None
         self.cbar = None
+        # Inline contour-label artists from the most recent
+        # `plot(kind="contour", labels=True)`, or `None` when no labels
+        # were drawn (the default, and for every non-contour kind).
+        self.contour_labels = None
 
     @property
     def arr(self):
@@ -1338,6 +1348,11 @@ class ArrayGlyph(Glyph):
         vmin = ticks[0]
         vmax = ticks[-1]
 
+        # Reset any inline contour labels from a previous render; the
+        # contour branch repopulates this when `labels=True`, every other
+        # kind leaves it `None`.
+        self.contour_labels = None
+
         # midpoint normalization needs unmasked NaN-filled data; the
         # other kinds can handle a masked array directly but contour /
         # contourf misbehave on masked arrays as well, so fill there too.
@@ -1401,6 +1416,17 @@ class ArrayGlyph(Glyph):
                 im = plot_fn(*base_args, level_edges, **contour_kwargs)
             else:
                 im = plot_fn(*base_args, **contour_kwargs)
+            # Inline numeric labels on the isolines. Only meaningful for
+            # line `contour` (filled `contourf` has no lines to label), so
+            # `labels=True` is a documented no-op for `contourf`.
+            if kind == "contour" and self.default_options.get("labels"):
+                label_kw = {
+                    "inline": True,
+                    "fontsize": 8,
+                    "fmt": "%g",
+                    **(self.default_options.get("label_kw") or {}),
+                }
+                self.contour_labels = ax.clabel(im, **label_kw)
         else:
             raise ValueError(
                 f"Invalid kind={kind!r}. Valid kinds are {VALID_PLOT_KINDS}."
@@ -1778,6 +1804,23 @@ class ArrayGlyph(Glyph):
                         `aspect`, `orientation`, `pad`,
                         `ticks`. By default None.
 
+                Contour options:
+                    labels : bool, optional
+                        Draw inline numeric labels on the isolines of a
+                        line `contour` (via `ax.clabel`), by default
+                        False. Ignored for `kind="contourf"` and every
+                        non-contour kind (filled contours have no lines
+                        to label). The label `Text` artists are stored
+                        on the instance as `self.contour_labels`.
+                    label_kw : dict, optional
+                        Extra keyword arguments forwarded to
+                        `ax.clabel` when `labels=True`, by default None.
+                        Merges over cleopatra's defaults (`inline=True`,
+                        `fontsize=8`, `fmt="%g"`) so user keys win on
+                        collision. Common keys: `levels` (subset of
+                        levels to label), `colors`, `fmt`, `fontsize`,
+                        `inline_spacing`.
+
                 Cell value display options:
                     display_cell_value : bool, optional
                         Whether to display the values of cells as text, by default False.
@@ -1822,6 +1865,32 @@ class ArrayGlyph(Glyph):
 
             ```
         ![array-plot](./../images/array_glyph/array-plot.png)
+
+        - Labelled line contours (`kind="contour"`, `labels=True`):
+
+            - inline numeric labels are drawn on the isolines and the
+                label `Text` artists are kept on `glyph.contour_labels`:
+                ```python
+                >>> from matplotlib.text import Text
+                >>> y, x = np.mgrid[-3:3:30j, -3:3:30j]
+                >>> z = np.exp(-(x ** 2 + y ** 2))
+                >>> glyph = ArrayGlyph(z, figsize=(6, 6))
+                >>> fig, ax = glyph.plot(kind="contour", labels=True, label_kw={"fmt": "%.2f"})
+                >>> bool(glyph.contour_labels) and all(
+                ...     isinstance(t, Text) for t in glyph.contour_labels
+                ... )
+                True
+
+                ```
+                Without `labels` (the default) no labels are drawn and
+                `contour_labels` stays `None`:
+                ```python
+                >>> glyph = ArrayGlyph(z, figsize=(6, 6))
+                >>> fig, ax = glyph.plot(kind="contour")
+                >>> glyph.contour_labels is None
+                True
+
+                ```
 
         - Color bar customization:
 

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -565,11 +565,37 @@ class ArrayGlyph(Glyph):
 
     @property
     def arr(self):
-        """array"""
+        """The (masked) array held by the glyph.
+
+        The array is stored as a `numpy.ma.MaskedArray`; cells matching
+        `exclude_value` (or NaN) are masked so they are excluded from the
+        colour range and rendered as gaps.
+
+        Returns:
+            numpy.ma.MaskedArray: The array backing this glyph.
+
+        Examples:
+            - Read the array back and inspect its shape and a value:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.array_glyph import ArrayGlyph
+                >>> glyph = ArrayGlyph(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+                >>> glyph.arr.shape
+                (2, 3)
+                >>> float(glyph.arr[0, 0])
+                1.0
+
+                ```
+        """
         return self._arr
 
     @arr.setter
     def arr(self, value):
+        """Set the backing array.
+
+        Args:
+            value: The new array to store (see the `arr` property).
+        """
         self._arr = value
 
     @property
@@ -581,6 +607,21 @@ class ArrayGlyph(Glyph):
 
         Returns:
             int: Same value as `num_domain_cells`.
+
+        Examples:
+            - The deprecated alias returns the same count as
+                `num_domain_cells`:
+                ```python
+                >>> import warnings
+                >>> import numpy as np
+                >>> from cleopatra.array_glyph import ArrayGlyph
+                >>> glyph = ArrayGlyph(np.array([[1.0, 2.0], [3.0, 4.0]]))
+                >>> with warnings.catch_warnings():
+                ...     warnings.simplefilter("ignore")
+                ...     glyph.no_elem == glyph.num_domain_cells
+                True
+
+                ```
         """
         warnings.warn(
             "`ArrayGlyph.no_elem` is deprecated; use `num_domain_cells` instead.",
@@ -892,11 +933,48 @@ class ArrayGlyph(Glyph):
 
     @property
     def exclude_value(self):
-        """exclude_value"""
+        """Value(s) treated as nodata and masked out of the array.
+
+        Cells equal to `exclude_value` are masked so they are excluded
+        from the colour range and rendered as gaps. Defaults to `nan`.
+
+        Returns:
+            The excluded value, or a list of excluded values.
+
+        Examples:
+            - With no explicit nodata, NaN is excluded by default:
+                ```python
+                >>> import math
+                >>> import numpy as np
+                >>> from cleopatra.array_glyph import ArrayGlyph
+                >>> glyph = ArrayGlyph(np.array([[1.0, 2.0], [3.0, 4.0]]))
+                >>> math.isnan(glyph.exclude_value)
+                True
+
+                ```
+            - Excluding a sentinel masks the matching cells:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.array_glyph import ArrayGlyph
+                >>> arr = np.array([[1.0, 2.0], [3.0, -9.0]])
+                >>> glyph = ArrayGlyph(arr, exclude_value=[-9.0])
+                >>> glyph.exclude_value
+                [-9.0]
+                >>> int(glyph.arr.mask.sum())
+                1
+
+                ```
+        """
         return self._exclude_value
 
     @exclude_value.setter
     def exclude_value(self, value):
+        """Set the excluded nodata value(s).
+
+        Args:
+            value: The value (or list of values) to mask out (see the
+                `exclude_value` property).
+        """
         self._exclude_value = value
 
     @staticmethod
@@ -1482,6 +1560,10 @@ class ArrayGlyph(Glyph):
 
         Args:
             arr: array. if None, the array in the object will be used.
+
+        Returns:
+            PIL.Image.Image: An RGB image built from the array (values
+                scaled to the 0-255 `uint8` range unless already `uint8`).
 
         Examples:
         ```python

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -1,6 +1,7 @@
 import os
 import re
 import shutil
+import warnings
 
 import pytest
 
@@ -1280,7 +1281,7 @@ class TestContourLabels:
     def _smooth_arr() -> np.ndarray:
         """A smooth 2-D field that yields several labelled isolines."""
         y, x = np.mgrid[-3:3:30j, -3:3:30j]
-        return np.exp(-(x ** 2 + y ** 2))
+        return np.exp(-(x**2 + y**2))
 
     def test_labels_true_draws_and_exposes_text(self):
         """`labels=True` populates `contour_labels` with `Text` artists."""
@@ -1336,6 +1337,25 @@ class TestContourLabels:
         assert glyph.contour_labels is not None
         glyph.plot(kind="imshow")
         assert glyph.contour_labels is None
+
+    def test_labels_on_constant_field_is_empty_list(self):
+        """A labelled contour with no isolines yields [] (not None), no raise."""
+        glyph = ArrayGlyph(np.full((5, 5), 3.0))
+        with warnings.catch_warnings():
+            # A constant field has no contour lines; the colorbar-skip
+            # warning is expected and unrelated to labelling.
+            warnings.simplefilter("ignore")
+            fig, ax = glyph.plot(kind="contour", labels=True)
+        assert isinstance(fig, Figure)
+        assert glyph.contour_labels == []
+
+    def test_label_kw_overrides_cleopatra_defaults(self):
+        """User `label_kw` keys win over cleopatra's clabel defaults."""
+        glyph = ArrayGlyph(self._smooth_arr())
+        # Default fontsize is 8; the user value must take precedence.
+        fig, ax = glyph.plot(kind="contour", labels=True, label_kw={"fontsize": 14})
+        assert len(glyph.contour_labels) > 0
+        assert all(t.get_fontsize() == 14 for t in glyph.contour_labels)
 
 
 @pytest.mark.plot

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -8,7 +8,7 @@ import pytest
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.animation import FuncAnimation
-from matplotlib.colors import BoundaryNorm
+from matplotlib.colors import BoundaryNorm, to_rgba
 from matplotlib.figure import Figure
 from matplotlib.text import Text
 from PIL import Image
@@ -1356,6 +1356,96 @@ class TestContourLabels:
         fig, ax = glyph.plot(kind="contour", labels=True, label_kw={"fontsize": 14})
         assert len(glyph.contour_labels) > 0
         assert all(t.get_fontsize() == 14 for t in glyph.contour_labels)
+
+    def test_contour_labels_none_before_any_render(self):
+        """`contour_labels` is None on a freshly constructed glyph.
+
+        Test scenario:
+            The attribute is initialised in `__init__`, so it must be
+            reachable and `None` before `plot`/`animate` is ever called.
+        """
+        glyph = ArrayGlyph(self._smooth_arr())
+        assert (
+            glyph.contour_labels is None
+        ), f"Expected None before render, got {glyph.contour_labels!r}"
+
+    @pytest.mark.parametrize("kind", ["imshow", "pcolormesh", "auto"])
+    def test_labels_true_is_noop_for_non_contour_kinds(self, kind):
+        """`labels=True` is silently ignored for every non-contour kind.
+
+        Args:
+            kind: A render kind that draws no isolines.
+
+        Test scenario:
+            `imshow`/`pcolormesh`/`auto` (which routes to `imshow` here)
+            must not draw labels; `contour_labels` stays None. Complements
+            the dedicated `contourf` no-op test.
+        """
+        glyph = ArrayGlyph(self._smooth_arr())
+        fig, ax = glyph.plot(kind=kind, labels=True)
+        assert isinstance(fig, Figure)
+        assert (
+            glyph.contour_labels is None
+        ), f"kind={kind!r} should not draw labels, got {glyph.contour_labels!r}"
+
+    def test_label_kw_forwards_arbitrary_clabel_kwarg(self):
+        """A non-default `label_kw` key (`colors`) reaches `ax.clabel`.
+
+        Test scenario:
+            Proves the passthrough is not limited to `fmt`/`fontsize`: a
+            `colors="red"` entry must colour every label red.
+        """
+        glyph = ArrayGlyph(self._smooth_arr())
+        fig, ax = glyph.plot(
+            kind="contour", labels=True, label_kw={"colors": "red"}
+        )
+        assert len(glyph.contour_labels) > 0
+        red = to_rgba("red")
+        assert all(
+            to_rgba(t.get_color()) == red for t in glyph.contour_labels
+        ), "every label should be red when label_kw={'colors': 'red'}"
+
+    def test_labels_with_curvilinear_coords(self):
+        """`labels=True` works on the `coords=` (curvilinear) contour path.
+
+        Test scenario:
+            With `coords` supplied the contour branch forwards `(x, y, z)`
+            positionally; labelling must still populate `contour_labels`.
+        """
+        arr = self._smooth_arr()
+        ny, nx = arr.shape
+        x = np.linspace(-3.0, 3.0, nx)
+        y = np.linspace(-3.0, 3.0, ny)
+        glyph = ArrayGlyph(arr, coords=(x, y))
+        fig, ax = glyph.plot(kind="contour", labels=True)
+        assert len(glyph.contour_labels) > 0
+        assert all(isinstance(t, Text) for t in glyph.contour_labels)
+
+    def test_labels_with_discrete_levels(self):
+        """`labels=True` works on the `levels=` (level-edges) contour path.
+
+        Test scenario:
+            Setting integer `levels` routes through the `level_edges`
+            branch; labels must still be drawn and exposed.
+        """
+        glyph = ArrayGlyph(self._smooth_arr())
+        fig, ax = glyph.plot(kind="contour", labels=True, levels=5)
+        assert len(glyph.contour_labels) > 0
+        assert all(isinstance(t, Text) for t in glyph.contour_labels)
+
+    def test_labels_with_masked_array(self):
+        """`labels=True` works when the source is a masked array.
+
+        Test scenario:
+            An `exclude_value` builds a masked array that the contour path
+            fills with NaN before drawing; labelling must still succeed.
+        """
+        arr = self._smooth_arr().copy()
+        arr[0, 0] = -999.0
+        glyph = ArrayGlyph(arr, exclude_value=[-999.0])
+        fig, ax = glyph.plot(kind="contour", labels=True)
+        assert len(glyph.contour_labels) > 0
+        assert all(isinstance(t, Text) for t in glyph.contour_labels)
 
 
 @pytest.mark.plot

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -9,6 +9,7 @@ import numpy as np
 from matplotlib.animation import FuncAnimation
 from matplotlib.colors import BoundaryNorm
 from matplotlib.figure import Figure
+from matplotlib.text import Text
 from PIL import Image
 
 from cleopatra.array_glyph import (
@@ -1269,6 +1270,72 @@ class TestContourLevelsAndNorm:
         fig, ax = glyph.plot(kind="contour", color_scale="midpoint", midpoint=0.0)
         assert isinstance(fig, Figure)
         assert len(ax.collections) >= 1
+
+
+@pytest.mark.plot
+class TestContourLabels:
+    """`plot(kind="contour", labels=...)` inline label support (issue #148)."""
+
+    @staticmethod
+    def _smooth_arr() -> np.ndarray:
+        """A smooth 2-D field that yields several labelled isolines."""
+        y, x = np.mgrid[-3:3:30j, -3:3:30j]
+        return np.exp(-(x ** 2 + y ** 2))
+
+    def test_labels_true_draws_and_exposes_text(self):
+        """`labels=True` populates `contour_labels` with `Text` artists."""
+        glyph = ArrayGlyph(self._smooth_arr())
+        fig, ax = glyph.plot(kind="contour", labels=True)
+        assert isinstance(fig, Figure)
+        assert isinstance(glyph.contour_labels, list)
+        assert len(glyph.contour_labels) > 0
+        assert all(isinstance(t, Text) for t in glyph.contour_labels)
+        # The label artists are attached to the axes' text list.
+        assert set(glyph.contour_labels).issubset(set(ax.texts))
+
+    def test_labels_default_is_noop(self):
+        """Default (`labels=False`) draws no labels; `contour_labels` is None."""
+        glyph = ArrayGlyph(self._smooth_arr())
+        fig, ax = glyph.plot(kind="contour")
+        assert glyph.contour_labels is None
+        assert len(ax.texts) == 0
+
+    def test_label_kw_forwarded_to_clabel(self):
+        """`label_kw` reaches `ax.clabel` (custom `fmt`/`fontsize` applied)."""
+        glyph = ArrayGlyph(self._smooth_arr())
+        fig, ax = glyph.plot(
+            kind="contour",
+            labels=True,
+            label_kw={"fmt": "%.3f", "fontsize": 6},
+        )
+        assert len(glyph.contour_labels) > 0
+        # The custom fontsize on every label proves label_kw was forwarded.
+        assert all(t.get_fontsize() == 6 for t in glyph.contour_labels)
+        # The "%.3f" format yields three decimal places in every label.
+        assert all(re.search(r"\.\d{3}$", t.get_text()) for t in glyph.contour_labels)
+
+    def test_labels_true_on_contourf_is_noop(self):
+        """`labels=True` is ignored for `contourf` (no isolines to label)."""
+        glyph = ArrayGlyph(self._smooth_arr())
+        fig, ax = glyph.plot(kind="contourf", labels=True)
+        assert isinstance(fig, Figure)
+        assert glyph.contour_labels is None
+
+    def test_replot_without_labels_resets_contour_labels(self):
+        """Re-plotting with `labels=False` clears a prior render's labels."""
+        glyph = ArrayGlyph(self._smooth_arr())
+        glyph.plot(kind="contour", labels=True)
+        assert glyph.contour_labels is not None
+        glyph.plot(kind="contour", labels=False)
+        assert glyph.contour_labels is None
+
+    def test_switching_kind_resets_contour_labels(self):
+        """A subsequent non-contour render clears stale label artists."""
+        glyph = ArrayGlyph(self._smooth_arr())
+        glyph.plot(kind="contour", labels=True)
+        assert glyph.contour_labels is not None
+        glyph.plot(kind="imshow")
+        assert glyph.contour_labels is None
 
 
 @pytest.mark.plot


### PR DESCRIPTION
Closes #148.

## What

Adds inline contour-label support to `ArrayGlyph.plot`. A line contour can now
carry numeric labels on its isolines (e.g. `980`/`1000`/`1020` on pressure
contours) the way ECMWF Magics / cartopy / earthkit-plots label them:

```python
glyph = ArrayGlyph(z)
fig, ax = glyph.plot(kind="contour", labels=True)
glyph.contour_labels  # list[matplotlib.text.Text]
```

Previously the `QuadContourSet` was returned as the mappable, so callers *could*
label it externally — but every downstream consumer re-rolled the same
`ax.clabel` glue. Labelling is generic matplotlib that operates on the contour
set `ArrayGlyph` already owns, so it belongs here.

## API

- `labels: bool = False` — draw inline labels via `ax.clabel` (defaults
  `inline=True`, `fontsize=8`, `fmt="%g"`); the `Text` artists are kept on
  `self.contour_labels`.
- `label_kw: dict | None = None` — merged over those defaults and forwarded to
  `ax.clabel` (e.g. `fmt`, `fontsize`, `levels`, `colors`, `inline_spacing`).

## Behaviour notes

- **No behaviour change for existing callers**: `labels=False` (default) draws
  nothing and leaves `contour_labels` as `None`.
- `labels=True` is a **documented no-op** for `kind="contourf"` and every
  non-contour kind (filled contours have no isolines to label). The options live
  in the global option dict — consistent with how `levels` is silently
  irrelevant to `imshow` — so they are accepted but ignored off the contour path.
- `contour_labels` resets to `None` on every render, so re-plotting without
  labels (or switching `kind`) clears stale label artists.

## Tests

New `TestContourLabels` (6 tests): labels drawn + exposed, default no-op,
`label_kw` forwarding (custom `fmt`/`fontsize`), `contourf` no-op, and the two
reset paths. Plus a runnable doctest on `plot()`.

- `tests/test_array_glyph.py`: **242 passed, 3 skipped**
- `--doctest-modules src/cleopatra/array_glyph.py`: **19 passed**