### PR TITLE
feat(mesh_glyph): inline labels for line tricontours via labels= (closes #151)

### DIFF
--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -846,6 +846,11 @@ class MeshGlyph(Glyph):
         ticks = self.get_ticks()
         norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
 
+        # An animation draws no inline contour labels, so clear any left on
+        # `self.contour_labels` by a previous `plot(labels=True)` call rather
+        # than letting stale label artists leak into the animation state.
+        self.contour_labels = None
+
         # Render the first frame.
         tpc = self._render_mesh(
             ax,

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -42,6 +42,8 @@ from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 MESH_DEFAULT_OPTIONS = {
     "vmin": None,
     "vmax": None,
+    "labels": False,
+    "label_kw": None,
 }
 MESH_DEFAULT_OPTIONS = STYLE_DEFAULTS | MESH_DEFAULT_OPTIONS
 
@@ -73,6 +75,11 @@ class MeshGlyph(Glyph):
         n_faces: Number of faces in the mesh.
         n_nodes: Number of nodes in the mesh.
         n_edges: Number of edges (0 if edge connectivity not provided).
+        contour_labels: The inline contour-label `Text` artists from the
+            most recent `plot(location="node", filled=False, labels=True)`,
+            or `None` when labelling was not requested (the default, and
+            for `tripcolor`/`tricontourf`). A labelled line tricontour with
+            no isolines (e.g. a constant-value field) yields an empty list.
 
     Examples:
         - Create a MeshGlyph and inspect its topology:
@@ -149,6 +156,12 @@ class MeshGlyph(Glyph):
         #: Colour-mapped artist from the most recent `plot` call (the
         #: `tripcolor`/`tricontour(f)` mappable); `None` before first render.
         self.im = None
+        #: Inline contour-label `Text` artists from the most recent
+        #: `plot(location="node", filled=False, labels=True)`, or `None`
+        #: when labelling was not requested (the default, and for
+        #: `tripcolor`/`tricontourf`); an empty list when the line
+        #: tricontour has no isolines.
+        self.contour_labels = None
 
     @property
     def node_x(self) -> np.ndarray:
@@ -527,7 +540,20 @@ class MeshGlyph(Glyph):
                 vmin, vmax, color_scale, gamma, midpoint, bounds,
                 ticks_spacing, cbar_orientation, cbar_label, figsize,
                 etc.) or pass extra rendering kwargs (levels for
-                tricontourf / tricontour).
+                tricontourf / tricontour). Two label options are
+                honoured **only** for line tricontours
+                (`location="node"`, `filled=False`):
+
+                - `labels` (bool, default `False`): when truthy, draw
+                  inline numeric labels on the isolines via `ax.clabel`
+                  and store the resulting `Text` artists on
+                  `self.contour_labels`. A documented no-op for
+                  `tripcolor` (face data) and `tricontourf`
+                  (`filled=True`), which leave `contour_labels` as `None`.
+                - `label_kw` (dict): forwarded to `ax.clabel`, merged
+                  over cleopatra's defaults (`inline=True`, `fontsize=8`,
+                  `fmt="%g"`) so user keys (`fmt`, `fontsize`, `colors`,
+                  `inline_spacing`, …) win on collision.
 
         Returns:
             tuple[Figure, Axes]: The matplotlib Figure and Axes objects.
@@ -580,6 +606,26 @@ class MeshGlyph(Glyph):
                 ...     location="node",
                 ...     filled=False,
                 ... )
+
+                ```
+            - Label the line tricontours inline (`labels=True`); the
+                `Text` artists are exposed on `glyph.contour_labels`:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.mesh_glyph import MeshGlyph
+                >>> node_x = np.array([0.0, 1.0, 0.5, 1.5])
+                >>> node_y = np.array([0.0, 0.0, 1.0, 1.0])
+                >>> faces = np.array([[0, 1, 2], [1, 3, 2]])
+                >>> mg = MeshGlyph(node_x, node_y, faces)
+                >>> fig, ax = mg.plot(
+                ...     np.array([0.0, 1.0, 2.0, 3.0]),
+                ...     location="node",
+                ...     filled=False,
+                ...     labels=True,
+                ...     label_kw={"fmt": "%.1f"},
+                ... )
+                >>> isinstance(mg.contour_labels, list)
+                True
 
                 ```
             - Plot with power color scale:
@@ -647,6 +693,11 @@ class MeshGlyph(Glyph):
         ticks = self.get_ticks()
         norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
 
+        # Reset any inline contour labels from a previous render; the
+        # line-tricontour branch below repopulates this when `labels=True`,
+        # every other path leaves it `None`.
+        self.contour_labels = None
+
         tpc = self._render_mesh(
             self.ax,
             data,
@@ -661,6 +712,18 @@ class MeshGlyph(Glyph):
         # caller can attach a colorbar/register the layer without scraping
         # `ax.collections` (mirrors `ArrayGlyph.im` / the other glyphs).
         self.im = tpc
+
+        # Inline numeric labels on the isolines. Only meaningful for line
+        # tricontours (`location="node"`, `filled=False`); `labels=True` is
+        # a documented no-op for `tripcolor` (face data) and `tricontourf`.
+        if location == "node" and not filled and self.default_options.get("labels"):
+            label_kw = {
+                "inline": True,
+                "fontsize": 8,
+                "fmt": "%g",
+                **(self.default_options.get("label_kw") or {}),
+            }
+            self.contour_labels = self.ax.clabel(tpc, **label_kw)
 
         # Remove previous colorbar before adding a new one.
         if self._cbar is not None:

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -165,27 +165,153 @@ class MeshGlyph(Glyph):
 
     @property
     def node_x(self) -> np.ndarray:
-        """Node x-coordinates."""
+        """Node x-coordinates.
+
+        Returns:
+            np.ndarray: 1D float array of node x-coordinates, in node
+                order (length ``n_nodes``).
+
+        Examples:
+            - Read back the x-coordinates and pick out a single node:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.mesh_glyph import MeshGlyph
+                >>> mg = MeshGlyph(
+                ...     np.array([0.0, 1.0, 0.5]),
+                ...     np.array([0.0, 0.0, 1.0]),
+                ...     np.array([[0, 1, 2]]),
+                ... )
+                >>> mg.node_x
+                array([0. , 1. , 0.5])
+                >>> float(mg.node_x[1])
+                1.0
+
+                ```
+        """
         return self._node_x
 
     @property
     def node_y(self) -> np.ndarray:
-        """Node y-coordinates."""
+        """Node y-coordinates.
+
+        Returns:
+            np.ndarray: 1D float array of node y-coordinates, in node
+                order (length ``n_nodes``).
+
+        Examples:
+            - Read back the y-coordinates and take their maximum:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.mesh_glyph import MeshGlyph
+                >>> mg = MeshGlyph(
+                ...     np.array([0.0, 1.0, 0.5]),
+                ...     np.array([0.0, 0.0, 1.0]),
+                ...     np.array([[0, 1, 2]]),
+                ... )
+                >>> mg.node_y
+                array([0., 0., 1.])
+                >>> float(mg.node_y.max())
+                1.0
+
+                ```
+        """
         return self._node_y
 
     @property
     def n_faces(self) -> int:
-        """Number of faces in the mesh."""
+        """Number of faces in the mesh.
+
+        Returns:
+            int: Count of faces (rows of the face-node connectivity),
+                regardless of how many nodes each face has.
+
+        Examples:
+            - A two-face mesh reports two faces, one row per face:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.mesh_glyph import MeshGlyph
+                >>> mg = MeshGlyph(
+                ...     np.array([0.0, 1.0, 0.5, 1.5]),
+                ...     np.array([0.0, 0.0, 1.0, 1.0]),
+                ...     np.array([[0, 1, 2], [1, 3, 2]]),
+                ... )
+                >>> mg.n_faces
+                2
+
+                ```
+        """
         return self._face_nodes.shape[0]
 
     @property
     def n_nodes(self) -> int:
-        """Number of nodes in the mesh."""
+        """Number of nodes in the mesh.
+
+        Returns:
+            int: Count of nodes, i.e. the length of the coordinate
+                arrays ``node_x``/``node_y``.
+
+        Examples:
+            - The node count matches the coordinate array length:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.mesh_glyph import MeshGlyph
+                >>> mg = MeshGlyph(
+                ...     np.array([0.0, 1.0, 0.5, 1.5]),
+                ...     np.array([0.0, 0.0, 1.0, 1.0]),
+                ...     np.array([[0, 1, 2], [1, 3, 2]]),
+                ... )
+                >>> mg.n_nodes
+                4
+
+                ```
+        """
         return len(self._node_x)
 
     @property
     def n_edges(self) -> int:
-        """Number of edges (0 if edge connectivity not provided)."""
+        """Number of edges (0 if edge connectivity not provided).
+
+        Edges are only counted when explicit ``edge_node_connectivity``
+        was supplied at construction; otherwise this is 0 even though the
+        mesh has implicit polygon edges (which ``plot_outline`` derives on
+        demand).
+
+        Returns:
+            int: Number of rows in ``edge_node_connectivity``, or 0 when
+                no edge connectivity was given.
+
+        Examples:
+            - Without explicit edges the count is 0:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.mesh_glyph import MeshGlyph
+                >>> mg = MeshGlyph(
+                ...     np.array([0.0, 1.0, 0.5]),
+                ...     np.array([0.0, 0.0, 1.0]),
+                ...     np.array([[0, 1, 2]]),
+                ... )
+                >>> mg.n_edges
+                0
+
+                ```
+            - Supplying ``edge_node_connectivity`` makes the count match
+                the number of edge rows:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.mesh_glyph import MeshGlyph
+                >>> mg = MeshGlyph(
+                ...     np.array([0.0, 1.0, 1.0, 0.0]),
+                ...     np.array([0.0, 0.0, 1.0, 1.0]),
+                ...     np.array([[0, 1, 2, 3]]),
+                ...     edge_node_connectivity=np.array(
+                ...         [[0, 1], [1, 2], [2, 3], [3, 0]]
+                ...     ),
+                ... )
+                >>> mg.n_edges
+                4
+
+                ```
+        """
         return self._edge_nodes.shape[0] if self._edge_nodes is not None else 0
 
     @property
@@ -781,6 +907,12 @@ class MeshGlyph(Glyph):
         Raises:
             ValueError: If `data` frames don't match mesh topology
                 or `time` length doesn't match frame count.
+
+        Notes:
+            An animation draws no inline contour labels, so this clears
+            `contour_labels` back to `None`; any label artists left by a
+            previous `plot(filled=False, labels=True)` call do not leak
+            into the animation state.
 
         Examples:
             - Animate face data over 3 time steps:

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -602,8 +602,8 @@ class TestContourLabels:
         faces = np.column_stack([a, a + 1, a + n + 1, a + n])
         return MeshGlyph(node_x, node_y, faces)
 
-    @classmethod
-    def _smooth_field(cls, mg: MeshGlyph) -> np.ndarray:
+    @staticmethod
+    def _smooth_field(mg: MeshGlyph) -> np.ndarray:
         """A smooth Gaussian node field that yields many isolines."""
         return np.exp(-(mg.node_x**2 + mg.node_y**2))
 
@@ -740,6 +740,18 @@ class TestContourLabels:
         assert (
             mg.contour_labels is None
         ), f"Expected None before render, got {mg.contour_labels!r}"
+
+    def test_animate_resets_stale_contour_labels(self):
+        """`animate()` clears labels left by a prior `plot(labels=True)`."""
+        mg = self._grid_glyph()
+        field = self._smooth_field(mg)
+        mg.plot(field, location="node", filled=False, labels=True)
+        assert mg.contour_labels is not None
+        # An animation draws no inline labels; the stale list must be cleared.
+        anim = mg.animate([field, field * 2.0], time=["t0", "t1"], location="node")
+        assert mg.contour_labels is None
+        assert anim is not None
+        plt.close(mg.fig)
 
 
 class TestPlotOutline:

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -6,11 +6,15 @@ fan triangulation, face-to-triangle value mapping, and edge cases.
 
 from __future__ import annotations
 
+import re
 import time
+import warnings
 
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+from matplotlib.colors import to_rgba
+from matplotlib.text import Text
 
 from cleopatra.mesh_glyph import MeshGlyph
 
@@ -565,6 +569,177 @@ class TestPlotLineContour:
         )
         assert fig is not None, "Face data should render irrespective of filled"
         plt.close(fig)
+
+
+class TestContourLabels:
+    """Inline label support for line tricontours (issue #151).
+
+    Mirrors `ArrayGlyph`'s `plot(kind="contour", labels=True)` (#148/#149)
+    on `MeshGlyph`'s unstructured `tricontour` path.
+    """
+
+    @staticmethod
+    def _grid_glyph(n: int = 12) -> MeshGlyph:
+        """A quad grid mesh over [-3, 3]^2 with `n` nodes per side.
+
+        Args:
+            n: Number of nodes along each axis.
+
+        Returns:
+            MeshGlyph: A glyph whose node field can carry several
+                labelled isolines.
+        """
+        xs = np.linspace(-3.0, 3.0, n)
+        gx, gy = np.meshgrid(xs, xs)
+        node_x = gx.ravel()
+        node_y = gy.ravel()
+        # Quad faces over the structured grid (fanned into triangles
+        # internally by the glyph).
+        i = np.arange(n - 1)
+        j = np.arange(n - 1)
+        jj, ii = np.meshgrid(j, i, indexing="ij")
+        a = (jj * n + ii).ravel()
+        faces = np.column_stack([a, a + 1, a + n + 1, a + n])
+        return MeshGlyph(node_x, node_y, faces)
+
+    @classmethod
+    def _smooth_field(cls, mg: MeshGlyph) -> np.ndarray:
+        """A smooth Gaussian node field that yields many isolines."""
+        return np.exp(-(mg.node_x**2 + mg.node_y**2))
+
+    def test_labels_true_draws_and_exposes_text(self):
+        """`labels=True` populates `contour_labels` with `Text` artists."""
+        mg = self._grid_glyph()
+        fig, ax = mg.plot(
+            self._smooth_field(mg), location="node", filled=False, labels=True
+        )
+        assert isinstance(mg.contour_labels, list)
+        assert len(mg.contour_labels) > 0
+        assert all(isinstance(t, Text) for t in mg.contour_labels)
+        # The label artists are attached to the axes' text list.
+        assert set(mg.contour_labels).issubset(set(ax.texts))
+        plt.close(fig)
+
+    def test_labels_default_is_noop(self):
+        """Default (`labels=False`) draws no labels; `contour_labels` is None."""
+        mg = self._grid_glyph()
+        fig, ax = mg.plot(self._smooth_field(mg), location="node", filled=False)
+        assert mg.contour_labels is None
+        assert len(ax.texts) == 0
+        plt.close(fig)
+
+    def test_label_kw_forwarded_to_clabel(self):
+        """`label_kw` reaches `ax.clabel` (custom `fmt`/`fontsize` applied)."""
+        mg = self._grid_glyph()
+        fig, ax = mg.plot(
+            self._smooth_field(mg),
+            location="node",
+            filled=False,
+            labels=True,
+            label_kw={"fmt": "%.3f", "fontsize": 6},
+        )
+        assert len(mg.contour_labels) > 0
+        # The custom fontsize on every label proves label_kw was forwarded.
+        assert all(t.get_fontsize() == 6 for t in mg.contour_labels)
+        # The "%.3f" format yields three decimal places in every label.
+        assert all(re.search(r"\.\d{3}$", t.get_text()) for t in mg.contour_labels)
+        plt.close(fig)
+
+    def test_labels_on_tricontourf_is_noop(self):
+        """`labels=True` is ignored for `filled=True` (no isolines to label)."""
+        mg = self._grid_glyph()
+        fig, ax = mg.plot(
+            self._smooth_field(mg), location="node", filled=True, labels=True
+        )
+        assert mg.contour_labels is None
+        plt.close(fig)
+
+    def test_labels_on_face_data_is_noop(self, triangle_glyph):
+        """`labels=True` is ignored for face data (`tripcolor`)."""
+        fig, ax = triangle_glyph.plot(
+            np.array([1.0, 2.0]), location="face", labels=True
+        )
+        assert triangle_glyph.contour_labels is None
+        plt.close(fig)
+
+    def test_replot_without_labels_resets_contour_labels(self):
+        """Re-plotting with `labels=False` clears a prior render's labels."""
+        mg = self._grid_glyph()
+        data = self._smooth_field(mg)
+        mg.plot(data, location="node", filled=False, labels=True)
+        assert mg.contour_labels is not None
+        fig, ax = mg.plot(data, location="node", filled=False)
+        assert mg.contour_labels is None
+        plt.close(fig)
+
+    def test_switching_to_filled_resets_contour_labels(self):
+        """A subsequent filled render clears stale label artists."""
+        mg = self._grid_glyph()
+        data = self._smooth_field(mg)
+        mg.plot(data, location="node", filled=False, labels=True)
+        assert mg.contour_labels is not None
+        fig, ax = mg.plot(data, location="node", filled=True, labels=True)
+        assert mg.contour_labels is None
+        plt.close(fig)
+
+    def test_labels_on_constant_field_is_empty_list(self):
+        """A labelled contour with no isolines yields [] (not None), no raise."""
+        mg = self._grid_glyph()
+        constant = np.full(mg.n_nodes, 3.0)
+        with warnings.catch_warnings():
+            # A constant field has no contour lines; matplotlib's
+            # "no contour levels" warning is expected and unrelated.
+            # `colorbar=False` avoids matplotlib's colorbar choking on a
+            # line set with zero isolines (an orthogonal limitation).
+            warnings.simplefilter("ignore")
+            fig, ax = mg.plot(
+                constant,
+                location="node",
+                filled=False,
+                labels=True,
+                colorbar=False,
+            )
+        assert mg.contour_labels == []
+        plt.close(fig)
+
+    def test_label_kw_overrides_cleopatra_defaults(self):
+        """User `label_kw` keys win over cleopatra's clabel defaults."""
+        mg = self._grid_glyph()
+        # Default fontsize is 8; the user value must take precedence.
+        fig, ax = mg.plot(
+            self._smooth_field(mg),
+            location="node",
+            filled=False,
+            labels=True,
+            label_kw={"fontsize": 14},
+        )
+        assert len(mg.contour_labels) > 0
+        assert all(t.get_fontsize() == 14 for t in mg.contour_labels)
+        plt.close(fig)
+
+    def test_label_kw_forwards_arbitrary_clabel_kwarg(self):
+        """A non-default `label_kw` key (`colors`) reaches `ax.clabel`."""
+        mg = self._grid_glyph()
+        fig, ax = mg.plot(
+            self._smooth_field(mg),
+            location="node",
+            filled=False,
+            labels=True,
+            label_kw={"colors": "red"},
+        )
+        assert len(mg.contour_labels) > 0
+        red = to_rgba("red")
+        assert all(
+            to_rgba(t.get_color()) == red for t in mg.contour_labels
+        ), "every label should be red when label_kw={'colors': 'red'}"
+        plt.close(fig)
+
+    def test_contour_labels_none_before_any_render(self):
+        """`contour_labels` is None on a freshly constructed glyph."""
+        mg = self._grid_glyph()
+        assert (
+            mg.contour_labels is None
+        ), f"Expected None before render, got {mg.contour_labels!r}"
 
 
 class TestPlotOutline:

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -570,6 +570,26 @@ class TestPlotLineContour:
         assert fig is not None, "Face data should render irrespective of filled"
         plt.close(fig)
 
+    def test_render_mesh_norm_none_unset_vmin_vmax(self):
+        """`_render_mesh` omits vmin/vmax when both are None and norm is None.
+
+        Test scenario:
+            Calling `_render_mesh` directly with `norm=None` while
+            `default_options["vmin"]`/`["vmax"]` are still their unset
+            `None` defaults must skip both colour-limit kwargs (the
+            `else` branch where neither bound is forwarded) and still
+            render a line contour set.
+        """
+        mg = self._node_glyph()
+        mg.fig, mg.ax = mg.create_figure_axes()
+        mg.default_options["vmin"] = None
+        mg.default_options["vmax"] = None
+        cs = mg._render_mesh(
+            mg.ax, np.array([0.0, 1.0, 2.0, 3.0]), "node", filled=False
+        )
+        assert cs.filled is False, "Should render line contours with no vmin/vmax"
+        plt.close(mg.fig)
+
 
 class TestContourLabels:
     """Inline label support for line tricontours (issue #151).
@@ -1165,6 +1185,21 @@ class TestPlotReuse:
         fig, ax = mg.plot(np.array([5.0, 5.0]))
         assert fig is not None, "Should return a Figure for constant data"
 
+    def test_explicit_ticks_spacing_preserved(self):
+        """User-supplied `ticks_spacing` skips auto-computation.
+
+        Test scenario:
+            Passing `ticks_spacing` to plot() must take the explicit
+            value (the branch that does not recompute spacing from the
+            data range) rather than `(vmax - vmin) / 10`.
+        """
+        mg = _make_tri_mg()
+        fig, ax = mg.plot(np.array([0.0, 10.0]), ticks_spacing=2.5)
+        assert mg.ticks_spacing == 2.5, (
+            f"Expected explicit ticks_spacing=2.5, got {mg.ticks_spacing}"
+        )
+        plt.close(fig)
+
     def test_all_nan_data_raises(self):
         """Test that all-NaN data raises a clear ValueError.
 
@@ -1253,6 +1288,57 @@ class TestAnimate:
         frames = [np.array([1.0, 2.0]), np.array([3.0])]  # second frame wrong length
         with pytest.raises(ValueError, match="Frame 1"):
             mg.animate(frames, time=["t0", "t1"])
+
+    def test_animate_explicit_options_and_title(self):
+        """animate honours explicit text_loc, vmin/vmax, ticks_spacing, title.
+
+        Test scenario:
+            Supplying all of `text_loc`, `vmin`, `vmax`, `ticks_spacing`
+            and `title` exercises the non-default branches: the time
+            label uses the given position, the colour limits and tick
+            spacing are taken verbatim (not recomputed from frames), and
+            the axes title is set.
+        """
+        mg = _make_tri_mg()
+        frames = np.array([[1.0, 2.0], [3.0, 4.0]])
+        anim = mg.animate(
+            frames,
+            time=["t0", "t1"],
+            text_loc=[0.5, 0.5],
+            vmin=0.0,
+            vmax=10.0,
+            ticks_spacing=2.0,
+            title="My Animation",
+        )
+        assert anim is not None, "Should return a FuncAnimation"
+        assert mg.vmin == 0.0, f"Expected explicit vmin=0.0, got {mg.vmin}"
+        assert mg.vmax == 10.0, f"Expected explicit vmax=10.0, got {mg.vmax}"
+        assert mg.ticks_spacing == 2.0, (
+            f"Expected explicit ticks_spacing=2.0, got {mg.ticks_spacing}"
+        )
+        assert mg.ax.get_title() == "My Animation", (
+            f"Expected title 'My Animation', got {mg.ax.get_title()!r}"
+        )
+        plt.close(mg.fig)
+
+    def test_animate_update_advances_frame(self):
+        """Driving the frame-update callback re-renders and relabels.
+
+        Test scenario:
+            Invoking the `FuncAnimation` update function for frame 1
+            removes the previous mappable and sets the time-label text,
+            exercising the `_update` closure that a non-rendered
+            animation otherwise never runs.
+        """
+        mg = _make_tri_mg()
+        frames = np.array([[1.0, 2.0], [3.0, 4.0]])
+        anim = mg.animate(frames, time=["t0", "t1"])
+        anim._func(1)
+        time_labels = [
+            t.get_text() for t in mg.ax.texts if t.get_text() == "t1"
+        ]
+        assert time_labels, "Frame update should set the time label to 't1'"
+        plt.close(mg.fig)
 
     def test_save_animation_gif(self, tmp_path):
         """Test saving mesh animation as GIF."""


### PR DESCRIPTION
# Description

- Adds inline contour-label support to `MeshGlyph`: two new `plot` options,
  `labels` (bool) and `label_kw` (dict), label node **line tricontours**
  (`location="node"`, `filled=False`) via `ax.clabel`, storing the resulting
  `Text` artists on a new `self.contour_labels` attribute.
- This is the unstructured (`tricontour`) mirror of the `ArrayGlyph` contour
  labels shipped in 0.14.0 (#148/#149). Previously the `TriContourSet` mappable
  was returned but every caller had to re-roll the same `ax.clabel` glue, and an
  unknown `labels=` kwarg would have reached `ax.tricontour` and raised.
- `label_kw` is merged over cleopatra's defaults (`inline=True`, `fontsize=8`,
  `fmt="%g"`) so user keys win on collision. Labelling is a documented no-op for
  `tripcolor` (face data) and `tricontourf` (`filled=True`); a labelled line set
  with no isolines yields an empty list. `contour_labels` resets to `None` on
  every `plot()` and `animate()` render so stale label artists never leak.
- Motivation: lets unstructured-mesh isolines be labelled the same way regular
  grids already can; the downstream Digital-Earth `Map.tricontour(labels=...)`
  consumes it by straight passthrough.
- Dependencies: none (additive, default-off; no new packages).

# Issues
- Fixes #151

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

- Added `TestContourLabels` (12 cases) plus coverage tests for the
  render/animate option branches; raises `mesh_glyph` line+branch coverage from
  96% to 98%.
- Ran the module's unit tests and doctests on the `Agg` backend.
- Reproduce:
  - `pytest tests/test_mesh_glyph.py`
  - `pytest tests/test_mesh_glyph.py --doctest-modules src/cleopatra/mesh_glyph.py`

- [x] Test A: `pytest tests/test_mesh_glyph.py` → 107 passed
- [x] Test B: `pytest tests/test_mesh_glyph.py --doctest-modules src/cleopatra/mesh_glyph.py` → 123 passed

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
