### PR TITLE
feat(scatter_glyph): value-to-size scaling + size legend

### DIFF
--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -39,12 +39,16 @@ import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.collections import PathCollection
 from matplotlib.figure import Figure
+from matplotlib.legend import Legend
 
 from cleopatra.glyph import Glyph
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+from cleopatra.styles import resolve_sizes, size_legend
 
 #: Option keys for ScatterGlyph. `ticks_spacing` is `None` so the shared
 #: `_prepare_scalar_mapping` helper auto-derives it from the data range.
+#: The `size_*` keys drive value→size scaling and its legend (see `plot`);
+#: they are inert unless a `sizes` array is supplied at construction.
 SCATTER_DEFAULT_OPTIONS = {
     "marker": "o",
     "point_size": 20,
@@ -53,6 +57,11 @@ SCATTER_DEFAULT_OPTIONS = {
     "levels": None,
     "ticks_spacing": None,
     "add_colorbar": True,
+    "size_limits": (10, 200),
+    "size_scale": "linear",
+    "size_legend": False,
+    "size_legend_values": None,
+    "size_legend_kwargs": None,
 }
 SCATTER_DEFAULT_OPTIONS = STYLE_DEFAULTS | SCATTER_DEFAULT_OPTIONS
 
@@ -63,7 +72,9 @@ class ScatterGlyph(Glyph):
     Wraps `matplotlib.axes.Axes.scatter`. With no `values`, points are
     drawn in a single colour. With a per-point `values` array, points
     are colour-mapped through the shared scalar-mapping pipeline and a
-    matching colorbar is attached.
+    matching colorbar is attached. An independent per-point `sizes` array
+    scales the marker area (with an optional size legend), so colour and
+    size can encode two different quantities at once.
 
     Args:
         x: 1D array of point x-coordinates.
@@ -72,6 +83,11 @@ class ScatterGlyph(Glyph):
         values: Optional 1D array of per-point scalar values used for
             colour mapping. Must match the length of `x` when given.
             Default is None (uncoloured points).
+        sizes: Optional 1D array of per-point magnitudes used for *size*
+            mapping (kept separate from `values`, which drives colour, so a
+            point can encode both). Must match the length of `x` when
+            given. When None, the scalar `point_size` option is used for
+            every point (the original behaviour). Default is None.
         ax: Pre-existing axes to draw on. Default is None.
         fig: Pre-existing figure. Default is None.
         **kwargs: Override any key in `SCATTER_DEFAULT_OPTIONS`
@@ -79,11 +95,17 @@ class ScatterGlyph(Glyph):
             `levels`, `color_scale`, `ticks_spacing`, `cbar_label`,
             `figsize`, `title`). Set `add_colorbar=False` to suppress the
             per-glyph colorbar (default True) for shared-axes composition
-            where the host owns a single aggregated colorbar.
+            where the host owns a single aggregated colorbar. The
+            `size_limits` (min/max marker area in points², default
+            `(10, 200)`), `size_scale` (`"linear"` / `"log"` / `"sqrt"`,
+            default `"linear"`), `size_legend` (bool, default False),
+            `size_legend_values` (explicit representative magnitudes), and
+            `size_legend_kwargs` (forwarded to the legend) options control
+            the `sizes` mapping and its legend.
 
     Raises:
-        ValueError: If `x` and `y` (or `values`, when given) have
-            mismatched lengths.
+        ValueError: If `x` and `y` (or `values` / `sizes`, when given)
+            have mismatched lengths.
 
     Examples:
         - Colour points by value and read back the mapped array:
@@ -100,10 +122,29 @@ class ScatterGlyph(Glyph):
             [1.0, 5.0, 9.0]
 
             ```
+        - Size points by a magnitude; the areas span `size_limits`:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.scatter_glyph import ScatterGlyph
+            >>> glyph = ScatterGlyph(
+            ...     np.array([0.0, 1.0, 2.0]),
+            ...     np.array([0.0, 1.0, 0.0]),
+            ...     sizes=np.array([1.0, 5.0, 9.0]),
+            ...     size_limits=(10, 200),
+            ... )
+            >>> fig, ax, paths = glyph.plot()
+            >>> [float(s) for s in paths.get_sizes()]
+            [10.0, 105.0, 200.0]
+
+            ```
 
     See Also:
         cleopatra.glyph.Glyph._prepare_scalar_mapping: Shared
             norm/colorbar/ticks pipeline used for the coloured path.
+        cleopatra.styles.resolve_sizes: The value→size helper used for the
+            `sizes` mapping (reusable by other size-encoding glyphs).
+        cleopatra.styles.size_legend: Builds the size legend drawn when
+            `size_legend` is truthy.
     """
 
     #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
@@ -115,6 +156,7 @@ class ScatterGlyph(Glyph):
         y: np.ndarray,
         values: np.ndarray | None = None,
         *,
+        sizes: np.ndarray | None = None,
         ax: Axes = None,
         fig: Figure = None,
         **kwargs,
@@ -136,8 +178,19 @@ class ScatterGlyph(Glyph):
                     f"values must match x/y shape {self.x.shape}, got "
                     f"{values.shape}."
                 )
+        if sizes is not None:
+            sizes = np.asarray(sizes)
+            if sizes.shape != self.x.shape:
+                raise ValueError(
+                    f"sizes must match x/y shape {self.x.shape}, got "
+                    f"{sizes.shape}."
+                )
         self.values = values
+        self.sizes = sizes
         self.cbar = None
+        #: The size legend created by `plot` when `size_legend` is truthy
+        #: (None otherwise); built via `cleopatra.styles.size_legend`.
+        self.size_legend_artist = None
 
     def plot(
         self,
@@ -145,13 +198,21 @@ class ScatterGlyph(Glyph):
         title: str | None = None,
         add_colorbar: bool | None = None,
     ) -> tuple[Figure, Axes, PathCollection]:
-        """Draw the point cloud, colour-mapping by value when present.
+        """Draw the point cloud, colour- and/or size-mapping per point.
 
         When `values` was supplied at construction, the colour scale,
         norm, ticks, and colorbar are resolved through
         `_prepare_scalar_mapping`, so `vmin` / `vmax` / `levels` /
         `color_scale` behave as for the other glyphs. With no values,
         a single-colour scatter is drawn and no colorbar is added.
+
+        When `sizes` was supplied, each marker's area is resolved from
+        that magnitude via `cleopatra.styles.resolve_sizes` (honouring
+        `size_limits` / `size_scale`); otherwise the scalar `point_size`
+        option is used for every point. Colour and size are independent,
+        so a point can encode two quantities at once. If `size_legend` is
+        truthy, a size legend is drawn via `cleopatra.styles.size_legend`
+        and stored on `self.size_legend_artist`.
 
         Args:
             ax: Axes to draw on. Falls back to the axes supplied at
@@ -193,6 +254,24 @@ class ScatterGlyph(Glyph):
                 'Stations'
 
                 ```
+            - Combine colour and size, with a size legend:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.scatter_glyph import ScatterGlyph
+                >>> glyph = ScatterGlyph(
+                ...     np.array([0.0, 1.0, 2.0]),
+                ...     np.array([0.0, 1.0, 0.0]),
+                ...     values=np.array([1.0, 2.0, 3.0]),
+                ...     sizes=np.array([5.0, 10.0, 20.0]),
+                ...     size_legend=True,
+                ... )
+                >>> fig, ax, paths = glyph.plot()
+                >>> bool(paths.get_sizes()[0] < paths.get_sizes()[-1])
+                True
+                >>> glyph.size_legend_artist is not None
+                True
+
+                ```
         """
         if ax is not None:
             self.ax = ax
@@ -210,11 +289,13 @@ class ScatterGlyph(Glyph):
             opts["add_colorbar"] if add_colorbar is None else add_colorbar
         )
 
+        marker_area = self._resolve_marker_area()
+
         if self.values is None:
             paths = ax.scatter(
                 self.x,
                 self.y,
-                s=opts["point_size"],
+                s=marker_area,
                 marker=opts["marker"],
             )
         else:
@@ -223,7 +304,7 @@ class ScatterGlyph(Glyph):
                 self.x,
                 self.y,
                 c=np.asarray(self.values),
-                s=opts["point_size"],
+                s=marker_area,
                 marker=opts["marker"],
                 cmap=opts["cmap"],
                 norm=norm,
@@ -233,7 +314,62 @@ class ScatterGlyph(Glyph):
             if draw_colorbar:
                 self.cbar = self.create_color_bar(ax, paths, cbar_kw)
 
+        if self.sizes is not None and opts["size_legend"]:
+            self.size_legend_artist = self._draw_size_legend(ax, marker_area)
+
         if opts["title"]:
             ax.set_title(opts["title"], fontsize=opts["title_size"])
 
         return self.fig, ax, paths
+
+    def _resolve_marker_area(self) -> float | np.ndarray:
+        """Resolve the scatter `s` (marker area) for this glyph.
+
+        Returns the per-point areas mapped from `sizes` when a `sizes`
+        array was supplied (via `cleopatra.styles.resolve_sizes`, honouring
+        the `size_limits` / `size_scale` options), or the scalar
+        `point_size` option when no `sizes` were given.
+
+        Returns:
+            float or np.ndarray: A scalar area (no `sizes`) or a per-point
+                area array spanning `size_limits` monotonically in `sizes`.
+        """
+        if self.sizes is None:
+            return self.default_options["point_size"]
+        size_min, size_max = self.default_options["size_limits"]
+        return resolve_sizes(
+            self.sizes,
+            size_min,
+            size_max,
+            scale=self.default_options["size_scale"],
+        )
+
+    def _draw_size_legend(self, ax: Axes, marker_area: np.ndarray) -> Legend:
+        """Draw a size legend for the resolved per-point areas.
+
+        Picks representative magnitudes (`size_legend_values`, or the min /
+        median / max of `sizes` when unset), maps each to its plotted
+        marker area by interpolating the already-computed `(sizes ->
+        marker_area)` mapping (so the swatches match the points exactly),
+        and hands them to `cleopatra.styles.size_legend`.
+
+        Args:
+            ax: The axes to attach the legend to.
+            marker_area: The per-point marker areas returned by
+                `_resolve_marker_area`.
+
+        Returns:
+            matplotlib.legend.Legend: The size legend added to `ax`.
+        """
+        sizes = np.asarray(self.sizes, dtype=float)
+        legend_values = self.default_options["size_legend_values"]
+        if legend_values is None:
+            legend_values = np.quantile(sizes, [0.0, 0.5, 1.0])
+        legend_values = np.asarray(legend_values, dtype=float)
+        order = np.argsort(sizes)
+        legend_areas = np.interp(
+            legend_values, sizes[order], np.asarray(marker_area)[order]
+        )
+        labels = [f"{v:g}" for v in legend_values]
+        legend_kwargs = self.default_options["size_legend_kwargs"] or {}
+        return size_legend(ax, legend_areas, labels, **legend_kwargs)

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -15,6 +15,7 @@ from matplotlib.cm import ScalarMappable
 from matplotlib.colorbar import Colorbar
 from matplotlib.container import BarContainer
 from matplotlib.legend import Legend
+from matplotlib.lines import Line2D
 from matplotlib.patches import Patch
 
 
@@ -583,6 +584,119 @@ class Scale:
         return new_value
 
 
+#: Accepted values for the `size_scale` of `resolve_sizes` — the transform
+#: applied to the magnitudes before they are linearly rescaled into the output
+#: range. `"sqrt"` matches perceived marker *area*; `"log"` suits magnitudes
+#: that span orders of magnitude.
+SIZE_SCALES = ("linear", "log", "sqrt")
+
+
+def resolve_sizes(
+    values: np.ndarray | Sequence[float],
+    out_min: float,
+    out_max: float,
+    scale: str = "linear",
+) -> np.ndarray:
+    """Map per-item magnitudes to a visual size range.
+
+    The reusable value→size primitive shared by size-encoding glyphs: it
+    turns a per-item magnitude array into an array of visual sizes spanning
+    `[out_min, out_max]`, optionally pre-transforming the magnitudes
+    (`"log"` / `"sqrt"`) before the linear rescale. `ScatterGlyph` uses it
+    for marker area (`s`); a future `FlowGlyph` can reuse it for line width.
+    The linear rescale itself is delegated to `Scale.rescale`, so this never
+    re-implements the range mapping.
+
+    The mapping is monotonic in the input, so larger magnitudes always map
+    to larger sizes. When every (finite) magnitude is equal, there is no
+    spread to encode and the midpoint of the output range is returned for
+    each item.
+
+    Args:
+        values: The per-item magnitudes to map. Non-finite entries are kept
+            in place in the output (mapped from a domain that ignores them)
+            — callers that pre-filter their data will not hit this.
+        out_min: The smallest output size (maps to the minimum magnitude).
+        out_max: The largest output size (maps to the maximum magnitude).
+        scale: The pre-transform: `"linear"` (identity), `"log"`
+            (`log10`, requires strictly positive magnitudes), or `"sqrt"`
+            (requires non-negative magnitudes). Case-insensitive. Default
+            is `"linear"`.
+
+    Returns:
+        np.ndarray: The mapped sizes, the same shape as `values`, spanning
+            `[out_min, out_max]` for non-degenerate input.
+
+    Raises:
+        ValueError: If `values` has no finite entries, if `scale` is not one
+            of `SIZE_SCALES`, if `scale="log"` and any magnitude is
+            non-positive, or if `scale="sqrt"` and any magnitude is negative.
+
+    Examples:
+        - Linear mapping spans the output range, smallest→`out_min`:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import resolve_sizes
+            >>> sizes = resolve_sizes(np.array([0.0, 5.0, 10.0]), 10.0, 200.0)
+            >>> [float(s) for s in sizes]
+            [10.0, 105.0, 200.0]
+
+            ```
+        - The mapping is monotonic, so ranking is preserved:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import resolve_sizes
+            >>> sizes = resolve_sizes(np.array([3.0, 1.0, 2.0]), 0.0, 1.0)
+            >>> bool(sizes[1] < sizes[2] < sizes[0])
+            True
+
+            ```
+        - All-equal magnitudes map to the output midpoint:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import resolve_sizes
+            >>> [float(s) for s in resolve_sizes(np.full(3, 4.0), 10.0, 50.0)]
+            [30.0, 30.0, 30.0]
+
+            ```
+    """
+    values = np.asarray(values, dtype=float)
+    scale = str(scale).lower()
+    if scale not in SIZE_SCALES:
+        valid = ", ".join(repr(s) for s in SIZE_SCALES)
+        raise ValueError(
+            f"Invalid size_scale {scale!r}. Expected one of {valid}."
+        )
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        raise ValueError(
+            "Cannot resolve sizes: `values` has no finite entries."
+        )
+    if scale == "log":
+        if np.any(finite <= 0):
+            raise ValueError(
+                "size_scale='log' requires strictly positive magnitudes."
+            )
+        transformed = Scale.log_scale(values)
+        domain = Scale.log_scale(finite)
+    elif scale == "sqrt":
+        if np.any(finite < 0):
+            raise ValueError(
+                "size_scale='sqrt' requires non-negative magnitudes."
+            )
+        transformed = np.sqrt(values)
+        domain = np.sqrt(finite)
+    else:  # linear
+        transformed = values
+        domain = finite
+
+    lo, hi = float(domain.min()), float(domain.max())
+    if hi == lo:
+        midpoint = (out_min + out_max) / 2.0
+        return np.full(values.shape, midpoint, dtype=float)
+    return Scale.rescale(transformed, lo, hi, out_min, out_max)
+
+
 class MidpointNormalize(colors.Normalize):
     """A normalization class that scales data with a midpoint.
 
@@ -873,6 +987,92 @@ def disjoint_legend(
     handles = [
         Patch(facecolor=color, edgecolor=edgecolor, label=label)
         for color, label in zip(colors, labels)
+    ]
+    return ax.legend(handles=handles, **kwargs)
+
+
+def size_legend(
+    ax: Axes,
+    marker_sizes: Sequence[float],
+    labels: Sequence[str],
+    *,
+    color: str = "0.4",
+    marker: str = "o",
+    **kwargs,
+) -> Legend:
+    """Attach a legend whose marker *sizes* encode magnitude.
+
+    The size counterpart to `disjoint_legend`: where that varies the swatch
+    *colour*, this varies the marker *size*, so it is the right legend for a
+    bubble / size-scaled scatter (e.g. `ScatterGlyph(..., sizes=...)`). One
+    proxy marker is drawn per entry, sized to match the points it
+    represents.
+
+    `marker_sizes` are scatter-style **areas** (points², the same unit as a
+    glyph's resolved `s`); each is converted to the matplotlib `Line2D`
+    `markersize` (a diameter in points) via `sqrt`, so the swatches match
+    the plotted points visually.
+
+    Args:
+        ax: The axes the legend is attached to.
+        marker_sizes: The representative marker areas (points²), one per
+            legend entry. Must be the same length as `labels`.
+        labels: The text drawn next to each marker. Must be the same length
+            as `marker_sizes`.
+        color: Fill colour for every proxy marker. Defaults to a neutral
+            grey (`"0.4"`) because the legend encodes size, not colour.
+        marker: The marker style for the proxies. Defaults to `"o"`.
+        **kwargs: Forwarded verbatim to `Axes.legend` (e.g. `title`, `loc`,
+            `labelspacing`, `bbox_to_anchor`).
+
+    Returns:
+        Legend: The created legend artist, already added to `ax`.
+
+    Raises:
+        ValueError: If `marker_sizes` and `labels` have different lengths.
+
+    Examples:
+        - Build a three-entry size legend and read back its labels:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import size_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = size_legend(ax, [20.0, 100.0, 200.0], ["low", "mid", "high"])
+            >>> [t.get_text() for t in legend.get_texts()]
+            ['low', 'mid', 'high']
+
+            ```
+        - Larger areas produce larger proxy markers (diameters in points):
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import size_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = size_legend(ax, [16.0, 64.0], ["small", "big"])
+            >>> handles = legend.legend_handles
+            >>> round(handles[0].get_markersize(), 1), round(handles[1].get_markersize(), 1)
+            (4.0, 8.0)
+
+            ```
+    """
+    marker_sizes = list(marker_sizes)
+    labels = list(labels)
+    if len(marker_sizes) != len(labels):
+        raise ValueError(
+            "marker_sizes and labels must have the same length, got "
+            f"{len(marker_sizes)} and {len(labels)}."
+        )
+    handles = [
+        Line2D(
+            [],
+            [],
+            linestyle="none",
+            marker=marker,
+            markerfacecolor=color,
+            markeredgecolor=color,
+            markersize=np.sqrt(max(size, 0.0)),
+            label=label,
+        )
+        for size, label in zip(marker_sizes, labels)
     ]
     return ax.legend(handles=handles, **kwargs)
 

--- a/tests/test_value_to_size.py
+++ b/tests/test_value_to_size.py
@@ -1,0 +1,379 @@
+"""Tests for value-to-size scaling and the size legend — issue #155.
+
+Covers:
+
+* `cleopatra.styles.resolve_sizes` (each `size_scale`, monotonicity, range
+  spanning, degenerate input, and error paths) and the `SIZE_SCALES` constant.
+* `cleopatra.styles.size_legend` (area→markersize mapping, label round-trip,
+  and the length-mismatch guard).
+* `ScatterGlyph`'s `sizes` parameter and `size_*` options, including the
+  `_resolve_marker_area` / `_draw_size_legend` helpers and the `sizes=None`
+  regression.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.collections import PathCollection
+from matplotlib.legend import Legend
+
+from cleopatra.scatter_glyph import ScatterGlyph
+from cleopatra.styles import SIZE_SCALES, resolve_sizes, size_legend
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def xy():
+    """Five points on a horizontal line.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: x (0..4) and y (zeros) arrays.
+    """
+    x = np.arange(5.0)
+    return x, np.zeros_like(x)
+
+
+class TestResolveSizes:
+    """Tests for the ``resolve_sizes`` value→size helper."""
+
+    def test_size_scales_constant(self):
+        """``SIZE_SCALES`` enumerates exactly the supported transforms.
+
+        Test scenario:
+            The accepted scales are linear, log, and sqrt.
+        """
+        assert set(SIZE_SCALES) == {"linear", "log", "sqrt"}, (
+            f"Unexpected SIZE_SCALES: {SIZE_SCALES}"
+        )
+
+    def test_linear_spans_output_range(self):
+        """Linear scaling maps min→out_min and max→out_max.
+
+        Test scenario:
+            A 0..10 ramp maps onto [10, 200] with the midpoint centred.
+        """
+        sizes = resolve_sizes(np.array([0.0, 5.0, 10.0]), 10.0, 200.0)
+        assert np.allclose(sizes, [10.0, 105.0, 200.0]), f"Unexpected sizes: {sizes}"
+
+    @pytest.mark.parametrize("scale", ["linear", "log", "sqrt"])
+    def test_monotonic_in_input(self, scale):
+        """Every scale preserves the ranking of the input magnitudes.
+
+        Args:
+            scale: The size scale under test.
+
+        Test scenario:
+            The argsort of the output equals the argsort of the input, so
+            larger magnitudes always map to larger sizes.
+        """
+        values = np.array([3.0, 1.0, 2.0, 8.0, 5.0])
+        sizes = resolve_sizes(values, 10.0, 200.0, scale=scale)
+        assert np.array_equal(np.argsort(sizes), np.argsort(values)), (
+            f"{scale} mapping is not monotonic: {sizes}"
+        )
+
+    @pytest.mark.parametrize("scale", ["linear", "log", "sqrt"])
+    def test_spans_exactly_the_limits(self, scale):
+        """The smallest/largest outputs equal out_min/out_max for each scale.
+
+        Args:
+            scale: The size scale under test.
+
+        Test scenario:
+            With positive, non-degenerate input the output min and max are
+            exactly the requested limits.
+        """
+        values = np.array([1.0, 2.0, 4.0, 8.0])
+        sizes = resolve_sizes(values, 5.0, 50.0, scale=scale)
+        assert np.isclose(sizes.min(), 5.0), f"min should be 5.0, got {sizes.min()}"
+        assert np.isclose(sizes.max(), 50.0), f"max should be 50.0, got {sizes.max()}"
+
+    def test_log_compresses_orders_of_magnitude(self):
+        """Log scaling makes evenly-spaced decades evenly-spaced sizes.
+
+        Test scenario:
+            [1, 10, 100] over [0, 1] maps to [0, 0.5, 1] (log10 is linear in
+            decades).
+        """
+        sizes = resolve_sizes(np.array([1.0, 10.0, 100.0]), 0.0, 1.0, scale="log")
+        assert np.allclose(sizes, [0.0, 0.5, 1.0]), f"Unexpected log sizes: {sizes}"
+
+    def test_sqrt_uses_area_perception(self):
+        """Sqrt scaling places 4 at the midpoint of [0, 4]→sizes.
+
+        Test scenario:
+            sqrt([0, 1, 4]) = [0, 1, 2] maps onto [0, 1] as [0, 0.5, 1].
+        """
+        sizes = resolve_sizes(np.array([0.0, 1.0, 4.0]), 0.0, 1.0, scale="sqrt")
+        assert np.allclose(sizes, [0.0, 0.5, 1.0]), f"Unexpected sqrt sizes: {sizes}"
+
+    def test_all_equal_maps_to_midpoint(self):
+        """Constant input maps every item to the output midpoint.
+
+        Test scenario:
+            No spread to encode -> each size is (out_min + out_max) / 2.
+        """
+        sizes = resolve_sizes(np.full(4, 7.0), 10.0, 50.0)
+        assert np.allclose(sizes, 30.0), f"Constant input should map to 30.0, got {sizes}"
+
+    def test_preserves_input_shape(self):
+        """The output has the same shape as the input array.
+
+        Test scenario:
+            A length-5 input yields a length-5 output.
+        """
+        sizes = resolve_sizes(np.arange(5.0), 1.0, 2.0)
+        assert sizes.shape == (5,), f"Expected shape (5,), got {sizes.shape}"
+
+    def test_unknown_scale_raises(self):
+        """An unrecognised ``scale`` raises ``ValueError`` listing valid ones.
+
+        Test scenario:
+            "cubic" is not a supported size scale.
+        """
+        with pytest.raises(ValueError, match="Invalid size_scale"):
+            resolve_sizes(np.arange(5.0), 1.0, 2.0, scale="cubic")
+
+    def test_log_non_positive_raises(self):
+        """``scale='log'`` with a non-positive magnitude raises ``ValueError``.
+
+        Test scenario:
+            A zero magnitude cannot be log-scaled.
+        """
+        with pytest.raises(ValueError, match="strictly positive"):
+            resolve_sizes(np.array([0.0, 1.0, 2.0]), 1.0, 2.0, scale="log")
+
+    def test_sqrt_negative_raises(self):
+        """``scale='sqrt'`` with a negative magnitude raises ``ValueError``.
+
+        Test scenario:
+            A negative magnitude cannot be sqrt-scaled.
+        """
+        with pytest.raises(ValueError, match="non-negative"):
+            resolve_sizes(np.array([-1.0, 1.0, 2.0]), 1.0, 2.0, scale="sqrt")
+
+    def test_all_non_finite_raises(self):
+        """All-non-finite input raises a clear ``ValueError``.
+
+        Test scenario:
+            No finite magnitude is available to define the domain.
+        """
+        with pytest.raises(ValueError, match="no finite entries"):
+            resolve_sizes(np.array([np.nan, np.inf]), 1.0, 2.0)
+
+
+class TestSizeLegend:
+    """Tests for the ``size_legend`` helper."""
+
+    def test_labels_round_trip(self):
+        """The legend exposes the labels it was given, in order.
+
+        Test scenario:
+            Three labels come back unchanged from the legend texts.
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [20.0, 100.0, 200.0], ["low", "mid", "high"])
+        texts = [t.get_text() for t in legend.get_texts()]
+        assert texts == ["low", "mid", "high"], f"Unexpected legend labels: {texts}"
+
+    def test_marker_size_is_sqrt_of_area(self):
+        """Proxy ``markersize`` is the square root of the supplied area.
+
+        Test scenario:
+            Areas 16 and 64 (points²) become markersizes 4 and 8 (points).
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [16.0, 64.0], ["small", "big"])
+        handles = legend.legend_handles
+        assert np.isclose(handles[0].get_markersize(), 4.0), "16 -> markersize 4"
+        assert np.isclose(handles[1].get_markersize(), 8.0), "64 -> markersize 8"
+
+    def test_returns_legend_attached_to_axes(self):
+        """The returned legend is the one registered on the axes.
+
+        Test scenario:
+            ``ax.get_legend()`` is the object returned by ``size_legend``.
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [10.0, 20.0], ["a", "b"])
+        assert ax.get_legend() is legend, "Legend should be attached to the axes"
+
+    def test_forwards_legend_kwargs(self):
+        """``Axes.legend`` kwargs such as ``title`` are forwarded.
+
+        Test scenario:
+            A ``title`` passed through reaches the legend title text.
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [10.0, 20.0], ["a", "b"], title="Population")
+        assert legend.get_title().get_text() == "Population", "title kwarg should be forwarded"
+
+    def test_negative_area_clamped(self):
+        """A negative area is clamped to zero markersize (no math error).
+
+        Test scenario:
+            ``sqrt`` of a clamped negative area is 0, not NaN.
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [-4.0, 16.0], ["neg", "pos"])
+        handles = legend.legend_handles
+        assert handles[0].get_markersize() == 0.0, "Negative area should clamp to 0"
+
+    def test_length_mismatch_raises(self):
+        """Mismatched ``marker_sizes`` / ``labels`` lengths raise ``ValueError``.
+
+        Test scenario:
+            Two sizes but one label is rejected.
+        """
+        fig, ax = plt.subplots()
+        with pytest.raises(ValueError, match="same length"):
+            size_legend(ax, [10.0, 20.0], ["only-one"])
+
+
+class TestScatterGlyphSizes:
+    """Integration tests for the ``sizes`` parameter and ``size_*`` options."""
+
+    def test_sizes_span_limits_monotonically(self, xy):
+        """A ``sizes`` array yields per-point areas spanning ``size_limits``.
+
+        Test scenario:
+            ``get_sizes`` runs monotonically with the input and its extremes
+            equal the configured ``size_limits``.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.array([2.0, 1.0, 5.0, 3.0, 9.0]),
+                             size_limits=(10, 200))
+        _, _, paths = glyph.plot()
+        out = paths.get_sizes()
+        assert np.isclose(out.min(), 10.0), f"min area should be 10, got {out.min()}"
+        assert np.isclose(out.max(), 200.0), f"max area should be 200, got {out.max()}"
+        assert np.array_equal(
+            np.argsort(out), np.argsort([2.0, 1.0, 5.0, 3.0, 9.0])
+        ), f"Areas not monotonic in input: {out}"
+
+    def test_size_scale_option_applied(self, xy):
+        """The ``size_scale`` option drives the transform used.
+
+        Test scenario:
+            With ``size_scale='log'`` and decade-spaced input, the middle
+            point sits at the midpoint of the limits.
+        """
+        x, y = xy[0][:3], xy[1][:3]
+        glyph = ScatterGlyph(x, y, sizes=np.array([1.0, 10.0, 100.0]),
+                             size_limits=(0, 100), size_scale="log")
+        _, _, paths = glyph.plot()
+        out = paths.get_sizes()
+        assert np.isclose(out[1], 50.0), f"log midpoint should be 50, got {out[1]}"
+
+    def test_size_legend_renders_default_entries(self, xy):
+        """``size_legend=True`` draws a three-entry legend by default.
+
+        Test scenario:
+            With no explicit values, the min/median/max quantiles give three
+            legend entries stored on ``size_legend_artist``.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.arange(1.0, 6.0), size_legend=True)
+        glyph.plot()
+        assert isinstance(glyph.size_legend_artist, Legend), "A size legend should be drawn"
+        texts = [t.get_text() for t in glyph.size_legend_artist.get_texts()]
+        assert len(texts) == 3, f"Default legend should have 3 entries, got {texts}"
+
+    def test_size_legend_values_honoured(self, xy):
+        """Explicit ``size_legend_values`` control the legend entries.
+
+        Test scenario:
+            Two representative magnitudes give two labelled legend entries.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.arange(1.0, 6.0), size_legend=True,
+                             size_legend_values=[2.0, 4.0])
+        glyph.plot()
+        texts = [t.get_text() for t in glyph.size_legend_artist.get_texts()]
+        assert texts == ["2", "4"], f"Legend should honour explicit values, got {texts}"
+
+    def test_no_legend_when_disabled(self, xy):
+        """No size legend is drawn when ``size_legend`` is False.
+
+        Test scenario:
+            Sizes given but ``size_legend`` left at its default False.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.arange(1.0, 6.0))
+        glyph.plot()
+        assert glyph.size_legend_artist is None, "No legend should be drawn when disabled"
+
+    def test_color_and_size_independent(self, xy):
+        """Colour (``values``) and size (``sizes``) combine independently.
+
+        Test scenario:
+            The scatter carries the raw colour array AND size-scaled areas at
+            once.
+        """
+        x, y = xy
+        values = np.array([5.0, 4.0, 3.0, 2.0, 1.0])
+        sizes = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        glyph = ScatterGlyph(x, y, values=values, sizes=sizes, size_limits=(10, 100))
+        _, _, paths = glyph.plot()
+        assert np.array_equal(paths.get_array(), values), "Colour array must be the raw values"
+        out = paths.get_sizes()
+        assert np.array_equal(np.argsort(out), np.argsort(sizes)), "Sizes must follow sizes array"
+
+    def test_sizes_none_regression(self, xy):
+        """``sizes=None`` keeps the original scalar-size behaviour.
+
+        Test scenario:
+            Every marker uses the scalar ``point_size`` and no legend is made.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, point_size=42)
+        _, _, paths = glyph.plot()
+        out = paths.get_sizes()
+        assert np.all(out == 42), f"All markers should use point_size 42, got {set(out)}"
+        assert glyph.size_legend_artist is None, "No legend without sizes"
+
+    def test_resolve_marker_area_scalar_without_sizes(self, xy):
+        """``_resolve_marker_area`` returns the scalar ``point_size``.
+
+        Test scenario:
+            With no ``sizes`` the helper returns the scalar option, not an
+            array.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, point_size=33)
+        assert glyph._resolve_marker_area() == 33, "Should return scalar point_size"
+
+    def test_resolve_marker_area_array_with_sizes(self, xy):
+        """``_resolve_marker_area`` returns a per-point area array with sizes.
+
+        Test scenario:
+            With ``sizes`` the helper returns an array spanning ``size_limits``.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.arange(1.0, 6.0), size_limits=(10, 200))
+        areas = glyph._resolve_marker_area()
+        assert isinstance(areas, np.ndarray), "Should return a per-point array"
+        assert np.isclose(areas.min(), 10.0) and np.isclose(areas.max(), 200.0), (
+            f"Areas should span size_limits, got [{areas.min()}, {areas.max()}]"
+        )
+
+    def test_mismatched_sizes_raises(self, xy):
+        """A ``sizes`` array not matching x/y length raises ``ValueError``.
+
+        Test scenario:
+            len(sizes) != len(x) is rejected at construction.
+        """
+        x, y = xy
+        with pytest.raises(ValueError, match="sizes must match"):
+            ScatterGlyph(x, y, sizes=np.array([1.0, 2.0]))


### PR DESCRIPTION
## Summary

Wires **value→size scaling** and an optional **size legend** into `ScatterGlyph`, and factors the value→size step into a small reusable helper so a future `FlowGlyph` can reuse it for line width.

Closes #155.

## What changed

- **`ScatterGlyph`**
  - New `sizes` parameter — a per-point magnitude that drives marker **area**, kept **separate** from `values` (which drives colour), so a point can encode both (like geoplot's `pointplot`).
  - New options in `SCATTER_DEFAULT_OPTIONS`: `size_limits=(10, 200)` (min/max area in points²), `size_scale="linear"` (`linear`/`log`/`sqrt`), `size_legend=False`, `size_legend_values=None`, `size_legend_kwargs=None`.
  - `plot` resolves `s` per point from `sizes`, falling back to the scalar `point_size` when `sizes is None`. Helpers `_resolve_marker_area` / `_draw_size_legend` keep `plot` readable.
- **`cleopatra.styles.resolve_sizes`** — the reusable value→size primitive. Built on the existing `Scale.rescale` / `Scale.log_scale` (does **not** re-implement rescaling); monotonic, spans `[out_min, out_max]`, all-equal input maps to the midpoint, with `linear` / `log` / `sqrt` transforms.
- **`cleopatra.styles.size_legend`** — the size counterpart to `disjoint_legend`. Builds `Line2D` proxy handles whose **marker size** encodes magnitude (area→markersize via `sqrt`).

## Design note

The issue suggested reusing `disjoint_legend` for the size legend, but that helper only varies swatch **colour** (`Patch`) and cannot represent size. I added a dedicated `size_legend` (varying `markersize`) instead, which is the correct representation; `disjoint_legend` is unchanged.

## Dependency safety

Pure **numpy + matplotlib** — no new dependency.

## Tests

`tests/test_value_to_size.py` (32 tests): `resolve_sizes` for each scale (linear/log/sqrt) — monotonicity, range spanning, all-equal→midpoint, shape preservation, and error paths (unknown scale, non-positive for log, negative for sqrt, all-non-finite); `size_legend` area→markersize mapping, label round-trip, kwargs forwarding, negative-area clamp, and length-mismatch guard; and `ScatterGlyph` integration (`get_sizes` spans `size_limits` monotonically, `size_legend=True` renders the right number of entries, explicit `size_legend_values` honoured, combined colour+size independence, `sizes=None` regression, the `_resolve_marker_area` helper, and the `sizes`/x shape-mismatch `ValueError`).

- `scatter_glyph.py`: 100% line+branch coverage from the new + existing tests.
- Full suite: **773 passed, 4 skipped**.
- New docstring examples validated via doctest.