### PR TITLE
feat(kde_glyph): 2-D kernel-density (isochrone) plot glyph (numpy-only)

### DIFF
--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -1,0 +1,371 @@
+"""2-D kernel-density (isochrone) visualization.
+
+Provides `KDEGlyph` for drawing a 2-D Gaussian kernel-density estimate of a
+point cloud as filled (`contourf`) or line (`contour`) density bands. The
+density is evaluated on a regular grid with a few lines of numpy — **no
+scipy** — and coloured through the shared `Glyph._prepare_scalar_mapping`
+pipeline, so `vmin` / `vmax`, `levels`, `ticks_spacing`, and `color_scale`
+behave exactly as they do for the other glyphs. The glyph is geometry- and
+CRS-agnostic: it takes plain `x` / `y` arrays plus an optional matplotlib
+clip path.
+
+The estimator uses an isotropic Gaussian kernel with Scott's-rule bandwidth
+(scaled by an optional `bw_method` multiplier). It is intended for typical
+scientific point clouds; it is **not** a drop-in for
+`scipy.stats.gaussian_kde` (no anisotropic/diagonal bandwidth, no weights).
+
+Examples:
+    - Filled density of a small cluster:
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.kde_glyph import KDEGlyph
+        >>> rng = np.random.default_rng(0)
+        >>> x = rng.normal(size=200)
+        >>> y = rng.normal(size=200)
+        >>> glyph = KDEGlyph(x, y, gridsize=40)
+        >>> fig, ax, cs = glyph.plot()
+
+        ```
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.patches import Patch
+from matplotlib.path import Path as MplPath
+
+from cleopatra.glyph import Glyph
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+
+#: Upper bound on the number of (grid-cell × data-point) products evaluated in
+#: a single numpy block. The density sum is chunked over the data points so a
+#: large `gridsize` / point count never materialises one giant array; this caps
+#: the temporary at ~`MAX_KDE_BLOCK` floats (a few tens of MB).
+MAX_KDE_BLOCK = 4_000_000
+
+#: Option keys for KDEGlyph. `ticks_spacing` is `None` so the shared
+#: `_prepare_scalar_mapping` helper auto-derives it from the density range.
+KDE_DEFAULT_OPTIONS = {
+    "levels": 10,
+    "shade": True,
+    "bw_method": None,
+    "gridsize": 100,
+    "vmin": None,
+    "vmax": None,
+    "ticks_spacing": None,
+    "add_colorbar": True,
+}
+KDE_DEFAULT_OPTIONS = STYLE_DEFAULTS | KDE_DEFAULT_OPTIONS
+
+
+class KDEGlyph(Glyph):
+    """Visualization class for 2-D kernel-density estimates.
+
+    Evaluates an isotropic Gaussian KDE of a `(x, y)` point cloud on a
+    regular grid (numpy only, no scipy) and draws it as filled or line
+    density contours, coloured through the shared scalar-mapping pipeline.
+
+    Args:
+        x: 1D array of point x-coordinates.
+        y: 1D array of point y-coordinates. Must match the length of `x`.
+        clip_path: Optional matplotlib `Path` or `Patch` that clips the
+            drawn contours (e.g. a country/basin outline supplied by the
+            caller). A `Patch` is used directly; a `Path` is interpreted in
+            data coordinates. Default is None (no clipping).
+        ax: Pre-existing axes to draw on. Default is None.
+        fig: Pre-existing figure. Default is None.
+        **kwargs: Override any key in `KDE_DEFAULT_OPTIONS`: `levels` (int
+            count or explicit sequence of density levels, default 10),
+            `shade` (filled `contourf` vs line `contour`, default True),
+            `bw_method` (None for Scott's rule, or a positive float
+            bandwidth multiplier), `gridsize` (density grid resolution,
+            default 100), plus the shared colour options (`cmap`, `vmin`,
+            `vmax`, `color_scale`, `ticks_spacing`, `cbar_label`,
+            `figsize`, `title`). Set `add_colorbar=False` to suppress the
+            per-glyph colorbar (default True).
+
+    Raises:
+        ValueError: If `x` and `y` have mismatched shapes, if fewer than
+            two points are given, if `bw_method` is non-positive, or if a
+            coordinate has zero spread (a degenerate kernel).
+
+    Examples:
+        - Evaluate the density grid directly (no rendering):
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.kde_glyph import KDEGlyph
+            >>> rng = np.random.default_rng(1)
+            >>> x = rng.normal(size=500)
+            >>> y = rng.normal(size=500)
+            >>> glyph = KDEGlyph(x, y, gridsize=50)
+            >>> gx, gy, density = glyph.evaluate()
+            >>> density.shape
+            (50, 50)
+            >>> bool(density.sum() > 0)
+            True
+
+            ```
+
+    See Also:
+        cleopatra.glyph.Glyph._prepare_scalar_mapping: Shared
+            norm/colorbar/ticks pipeline used to colour the density.
+        cleopatra.mesh_glyph.MeshGlyph: Contour rendering for unstructured
+            meshes.
+    """
+
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = KDE_DEFAULT_OPTIONS
+
+    def __init__(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        *,
+        clip_path: MplPath | Patch | None = None,
+        ax: Axes = None,
+        fig: Figure = None,
+        **kwargs,
+    ):
+        super().__init__(
+            default_options=KDE_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
+        )
+        self.x = np.asarray(x, dtype=float)
+        self.y = np.asarray(y, dtype=float)
+        if self.x.shape != self.y.shape:
+            raise ValueError(
+                f"x and y must have the same shape, got {self.x.shape} "
+                f"and {self.y.shape}."
+            )
+        if self.x.size < 2:
+            raise ValueError(
+                f"KDE needs at least 2 points, got {self.x.size}."
+            )
+        bw_method = self.default_options["bw_method"]
+        if bw_method is not None and bw_method <= 0:
+            raise ValueError(
+                f"bw_method must be a positive float or None, got {bw_method}."
+            )
+        self.clip_path = clip_path
+        self.cbar = None
+
+    def _bandwidth(self) -> float:
+        """Return Scott's-rule bandwidth, scaled by the `bw_method` option.
+
+        Scott's rule in `d` dimensions is `n ** (-1 / (d + 4))`; for the 2-D
+        estimator here that is `n ** (-1 / 6)`. The optional `bw_method`
+        multiplier (default 1.0) widens (`> 1`) or narrows (`< 1`) the kernel.
+
+        Returns:
+            float: The bandwidth factor applied to each coordinate's
+                standard deviation.
+        """
+        n = self.x.size
+        multiplier = self.default_options["bw_method"] or 1.0
+        return multiplier * n ** (-1.0 / 6.0)
+
+    def evaluate(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Evaluate the KDE on a regular grid spanning the point bounds.
+
+        Builds a `gridsize × gridsize` grid over the `[x.min, x.max] ×
+        [y.min, y.max]` bounding box and sums an isotropic Gaussian kernel
+        (Scott's-rule bandwidth) over the points. The sum is chunked over
+        the data points so memory stays bounded (see `MAX_KDE_BLOCK`) even
+        for large `gridsize` or point counts.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray, np.ndarray]: The grid `gx`, `gy`
+                (each `gridsize × gridsize`) and the density evaluated on
+                that grid (same shape), normalised to integrate to ~1.
+
+        Raises:
+            ValueError: If either coordinate has zero spread (its standard
+                deviation is 0), which would give a degenerate kernel.
+
+        Examples:
+            - The density peaks near a tight synthetic cluster:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.kde_glyph import KDEGlyph
+                >>> rng = np.random.default_rng(2)
+                >>> pts = rng.normal(scale=0.1, size=300)
+                >>> x = np.concatenate([pts, pts + 5.0])
+                >>> y = np.concatenate([pts, pts + 5.0])
+                >>> gx, gy, d = KDEGlyph(x, y, gridsize=60).evaluate()
+                >>> peak = np.unravel_index(int(np.argmax(d)), d.shape)
+                >>> bool(min(abs(gx[peak] - 0.0), abs(gx[peak] - 5.0)) < 1.0)
+                True
+
+                ```
+        """
+        x, y = self.x, self.y
+        n = x.size
+        bw = self._bandwidth()
+        sx, sy = x.std() * bw, y.std() * bw
+        if sx == 0 or sy == 0:
+            raise ValueError(
+                "Cannot build a KDE: a coordinate has zero spread "
+                "(degenerate kernel). Provide points that vary in x and y."
+            )
+
+        gridsize = int(self.default_options["gridsize"])
+        gx, gy = np.meshgrid(
+            np.linspace(x.min(), x.max(), gridsize),
+            np.linspace(y.min(), y.max(), gridsize),
+        )
+        gx_flat = gx.ravel()[:, None]
+        gy_flat = gy.ravel()[:, None]
+
+        # Sum the kernel over the points in blocks so the temporary
+        # (grid-cells × block) array never exceeds ~MAX_KDE_BLOCK floats.
+        block = max(1, MAX_KDE_BLOCK // gx_flat.shape[0])
+        density_flat = np.zeros(gx_flat.shape[0], dtype=float)
+        for start in range(0, n, block):
+            xs = x[start:start + block]
+            ys = y[start:start + block]
+            dx = (gx_flat - xs) / sx
+            dy = (gy_flat - ys) / sy
+            density_flat += np.exp(-0.5 * (dx ** 2 + dy ** 2)).sum(axis=1)
+
+        density = density_flat.reshape(gx.shape) / (2.0 * np.pi * sx * sy * n)
+        return gx, gy, density
+
+    def _resolve_levels(self, density: np.ndarray) -> np.ndarray:
+        """Resolve the `levels` option to explicit, increasing density edges.
+
+        An integer becomes that many evenly-spaced edges across the density
+        range; an explicit sequence is sorted and used verbatim. Returning
+        explicit edges (rather than an int) keeps `contourf`/`contour` in
+        step with the `BoundaryNorm` the shared pipeline builds from the
+        same `levels` option.
+
+        Args:
+            density: The evaluated density grid (for its value range).
+
+        Returns:
+            np.ndarray: The sorted, increasing contour level edges.
+        """
+        levels = self.default_options["levels"]
+        if isinstance(levels, (int, np.integer)) and not isinstance(levels, bool):
+            return np.linspace(float(density.min()), float(density.max()), int(levels))
+        return np.sort(np.asarray(levels, dtype=float))
+
+    def _apply_clip(self, contour_set: Any) -> None:
+        """Clip the drawn contour set to `self.clip_path`, if any.
+
+        A `Patch` clips directly; a `Path` is clipped in data coordinates
+        (`ax.transData`). No-op when no clip path was supplied.
+
+        Args:
+            contour_set: The `QuadContourSet` returned by
+                `contourf`/`contour`.
+
+        Raises:
+            TypeError: If `clip_path` is neither a matplotlib `Path` nor a
+                `Patch`.
+        """
+        clip = self.clip_path
+        if clip is None:
+            return
+        if isinstance(clip, Patch):
+            contour_set.set_clip_path(clip)
+        elif isinstance(clip, MplPath):
+            contour_set.set_clip_path(clip, transform=self.ax.transData)
+        else:
+            raise TypeError(
+                "clip_path must be a matplotlib Path or Patch, got "
+                f"{type(clip).__name__}."
+            )
+
+    def plot(
+        self,
+        ax: Axes = None,
+        title: str | None = None,
+        add_colorbar: bool | None = None,
+    ):
+        """Render the 2-D density as filled or line contours.
+
+        Evaluates the KDE via `evaluate`, colours it through
+        `_prepare_scalar_mapping`, and draws `contourf` (when `shade`) or
+        `contour` (otherwise). An optional `clip_path` restricts the drawn
+        contours.
+
+        Args:
+            ax: Axes to draw on. Falls back to the axes supplied at
+                construction, otherwise a new figure/axes is created.
+            title: Plot title. Overrides `default_options["title"]` when
+                given.
+            add_colorbar: Override the `add_colorbar` option for this call
+                — True draws the colorbar, False suppresses it. Defaults to
+                None, which keeps the value set at construction.
+
+        Returns:
+            tuple[Figure, Axes, QuadContourSet]: The figure, the axes, and
+                the contour set (the mappable the colorbar attaches to).
+
+        Raises:
+            ValueError: If a coordinate has zero spread (via `evaluate`).
+            TypeError: If `clip_path` is an unsupported type (via the clip
+                step).
+
+        Examples:
+            - Filled contours add a colorbar by default:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.kde_glyph import KDEGlyph
+                >>> rng = np.random.default_rng(3)
+                >>> x, y = rng.normal(size=300), rng.normal(size=300)
+                >>> glyph = KDEGlyph(x, y, gridsize=40)
+                >>> fig, ax, cs = glyph.plot()
+                >>> glyph.cbar is not None
+                True
+
+                ```
+            - Line contours (`shade=False`) and no colorbar:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.kde_glyph import KDEGlyph
+                >>> rng = np.random.default_rng(4)
+                >>> x, y = rng.normal(size=300), rng.normal(size=300)
+                >>> glyph = KDEGlyph(x, y, gridsize=40, shade=False)
+                >>> fig, ax, cs = glyph.plot(add_colorbar=False)
+                >>> glyph.cbar is None
+                True
+
+                ```
+        """
+        if ax is not None:
+            self.ax = ax
+            self.fig = ax.get_figure()
+        elif self.ax is None:
+            self.fig, self.ax = self.create_figure_axes()
+        ax = self.ax
+        opts = self.default_options
+
+        if title is not None:
+            opts["title"] = title
+        draw_colorbar = (
+            opts["add_colorbar"] if add_colorbar is None else add_colorbar
+        )
+
+        gx, gy, density = self.evaluate()
+        level_edges = self._resolve_levels(density)
+        norm, cbar_kw, _ = self._prepare_scalar_mapping(density)
+
+        render = ax.contourf if opts["shade"] else ax.contour
+        contour_set = render(
+            gx, gy, density, levels=level_edges, cmap=opts["cmap"], norm=norm
+        )
+        self._apply_clip(contour_set)
+        self.im = contour_set
+
+        if draw_colorbar:
+            self.cbar = self.create_color_bar(ax, contour_set, cbar_kw)
+
+        if opts["title"]:
+            ax.set_title(opts["title"], fontsize=opts["title_size"])
+
+        return self.fig, ax, contour_set

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,6 +22,7 @@ _SUBMODULES = [
     "colors",
     "config",
     "glyph",
+    "kde_glyph",
     "line_glyph",
     "mesh_glyph",
     "polygon_glyph",

--- a/tests/test_kde_glyph.py
+++ b/tests/test_kde_glyph.py
@@ -1,0 +1,434 @@
+"""Tests for cleopatra.kde_glyph.KDEGlyph — issue #156.
+
+Covers construction/validation, the bandwidth rule, grid evaluation (including
+the memory-chunking path), level resolution, contour clipping, and the
+`plot` rendering contract. The estimator is numpy-only; one test asserts scipy
+is never imported.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.contour import QuadContourSet
+from matplotlib.patches import Circle
+from matplotlib.path import Path as MplPath
+
+import cleopatra.kde_glyph as kde_mod
+from cleopatra.kde_glyph import KDE_DEFAULT_OPTIONS, KDEGlyph
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def cloud():
+    """A reproducible 2-D Gaussian point cloud.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: 400 x and y coordinates from a fixed
+            seed.
+    """
+    rng = np.random.default_rng(1234)
+    return rng.normal(size=400), rng.normal(size=400)
+
+
+@pytest.fixture()
+def bimodal():
+    """Two tight, well-separated clusters at (0, 0) and (5, 5).
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: x and y coordinates of the clusters.
+    """
+    rng = np.random.default_rng(7)
+    a = rng.normal(scale=0.1, size=300)
+    b = rng.normal(scale=0.1, size=300)
+    x = np.concatenate([a, a + 5.0])
+    y = np.concatenate([b, b + 5.0])
+    return x, y
+
+
+class TestKDEGlyphInit:
+    """Tests for KDEGlyph.__init__."""
+
+    def test_stores_coordinates_and_defaults(self, cloud):
+        """Coordinates are stored as float arrays and defaults are present.
+
+        Test scenario:
+            x/y become float ndarrays; clip_path defaults to None and cbar
+            is unset until plot.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y)
+        assert glyph.x.dtype == float, "x should be stored as float"
+        assert glyph.clip_path is None, "clip_path should default to None"
+        assert glyph.cbar is None, "cbar should be None before plotting"
+        assert glyph.default_options["gridsize"] == 100, "default gridsize should be 100"
+
+    def test_clip_path_stored(self, cloud):
+        """A supplied clip_path is stored on the glyph.
+
+        Test scenario:
+            A Circle patch passed at construction is kept for plot time.
+        """
+        x, y = cloud
+        patch = Circle((0, 0), 1.0)
+        glyph = KDEGlyph(x, y, clip_path=patch)
+        assert glyph.clip_path is patch, "clip_path should be stored verbatim"
+
+    def test_mismatched_xy_raises(self):
+        """x and y of different lengths raise ValueError.
+
+        Test scenario:
+            len(x) != len(y) is rejected at construction.
+        """
+        with pytest.raises(ValueError, match="same shape"):
+            KDEGlyph(np.arange(5.0), np.arange(4.0))
+
+    def test_too_few_points_raises(self):
+        """Fewer than two points raise ValueError.
+
+        Test scenario:
+            A single point cannot define a KDE.
+        """
+        with pytest.raises(ValueError, match="at least 2 points"):
+            KDEGlyph(np.array([1.0]), np.array([2.0]))
+
+    @pytest.mark.parametrize("bad_bw", [0.0, -1.0])
+    def test_non_positive_bw_method_raises(self, cloud, bad_bw):
+        """A non-positive ``bw_method`` raises ValueError.
+
+        Args:
+            cloud: The point-cloud fixture.
+            bad_bw: An invalid bandwidth multiplier.
+
+        Test scenario:
+            Zero or negative bandwidth multipliers are rejected.
+        """
+        x, y = cloud
+        with pytest.raises(ValueError, match="positive float or None"):
+            KDEGlyph(x, y, bw_method=bad_bw)
+
+    def test_invalid_kwarg_raises(self, cloud):
+        """An unknown kwarg is rejected by the strict merge.
+
+        Test scenario:
+            A key absent from KDE_DEFAULT_OPTIONS raises ValueError.
+        """
+        x, y = cloud
+        with pytest.raises(ValueError, match="not correct"):
+            KDEGlyph(x, y, not_an_option=1)
+
+
+class TestKDEGlyphBandwidth:
+    """Tests for KDEGlyph._bandwidth."""
+
+    def test_scotts_rule_default(self, cloud):
+        """The default bandwidth is Scott's rule ``n ** (-1/6)``.
+
+        Test scenario:
+            With no bw_method, the factor is n**(-1/6).
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y)
+        expected = x.size ** (-1.0 / 6.0)
+        assert np.isclose(glyph._bandwidth(), expected), (
+            f"Expected Scott's factor {expected}, got {glyph._bandwidth()}"
+        )
+
+    def test_bw_method_multiplier(self, cloud):
+        """``bw_method`` scales Scott's rule linearly.
+
+        Test scenario:
+            bw_method=2 doubles the Scott's-rule factor.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, bw_method=2.0)
+        expected = 2.0 * x.size ** (-1.0 / 6.0)
+        assert np.isclose(glyph._bandwidth(), expected), (
+            f"Expected {expected}, got {glyph._bandwidth()}"
+        )
+
+
+class TestKDEGlyphEvaluate:
+    """Tests for KDEGlyph.evaluate."""
+
+    def test_grid_shape(self, cloud):
+        """The grid and density share the ``gridsize × gridsize`` shape.
+
+        Test scenario:
+            gridsize=50 yields 50×50 gx, gy, and density arrays.
+        """
+        x, y = cloud
+        gx, gy, density = KDEGlyph(x, y, gridsize=50).evaluate()
+        assert gx.shape == (50, 50), f"gx shape should be (50, 50), got {gx.shape}"
+        assert density.shape == (50, 50), f"density shape should be (50, 50), got {density.shape}"
+
+    def test_density_positive(self, cloud):
+        """The density grid is strictly positive everywhere.
+
+        Test scenario:
+            A Gaussian kernel sum is positive across the whole grid.
+        """
+        x, y = cloud
+        _, _, density = KDEGlyph(x, y, gridsize=40).evaluate()
+        assert np.all(density > 0), "Density should be positive everywhere"
+
+    def test_density_integrates_to_about_one(self, cloud):
+        """The density integrates to approximately 1 over the grid.
+
+        Test scenario:
+            A trapezoidal integral of the normalised density is near 1 for a
+            grid that comfortably spans the cloud.
+        """
+        x, y = cloud
+        gx, gy, density = KDEGlyph(x, y, gridsize=200).evaluate()
+        dx = gx[0, 1] - gx[0, 0]
+        dy = gy[1, 0] - gy[0, 0]
+        integral = density.sum() * dx * dy
+        assert 0.8 < integral < 1.2, f"Density integral should be ~1, got {integral}"
+
+    def test_density_peaks_near_cluster(self, bimodal):
+        """The global density peak sits near a cluster centre.
+
+        Test scenario:
+            For clusters at (0,0)/(5,5) the argmax cell is within 1.0 of one
+            centre in each axis.
+        """
+        x, y = bimodal
+        gx, gy, density = KDEGlyph(x, y, gridsize=60).evaluate()
+        peak = np.unravel_index(int(np.argmax(density)), density.shape)
+        near_x = min(abs(gx[peak] - 0.0), abs(gx[peak] - 5.0))
+        near_y = min(abs(gy[peak] - 0.0), abs(gy[peak] - 5.0))
+        assert near_x < 1.0 and near_y < 1.0, (
+            f"Peak {(gx[peak], gy[peak])} not near a cluster centre"
+        )
+
+    @pytest.mark.parametrize("x, y", [
+        (np.zeros(10), np.arange(10.0)),
+        (np.arange(10.0), np.full(10, 3.0)),
+    ])
+    def test_zero_spread_raises(self, x, y):
+        """A zero-spread coordinate raises ValueError.
+
+        Args:
+            x: x-coordinates (constant in one parametrisation).
+            y: y-coordinates (constant in the other).
+
+        Test scenario:
+            A degenerate kernel (std 0 in x or y) is rejected.
+        """
+        with pytest.raises(ValueError, match="zero spread"):
+            KDEGlyph(x, y).evaluate()
+
+    def test_chunking_matches_unchunked(self, cloud, monkeypatch):
+        """Chunked evaluation equals the single-block result.
+
+        Test scenario:
+            Forcing a tiny MAX_KDE_BLOCK (so the point loop runs in many
+            blocks) yields a density identical to the default single block.
+        """
+        x, y = cloud
+        reference = KDEGlyph(x, y, gridsize=30).evaluate()[2]
+        monkeypatch.setattr(kde_mod, "MAX_KDE_BLOCK", 5000)
+        chunked = KDEGlyph(x, y, gridsize=30).evaluate()[2]
+        assert np.allclose(reference, chunked), "Chunked result must match unchunked"
+
+
+class TestKDEGlyphResolveLevels:
+    """Tests for KDEGlyph._resolve_levels."""
+
+    def test_int_levels_evenly_spaced(self, cloud):
+        """An integer ``levels`` gives that many evenly-spaced edges.
+
+        Test scenario:
+            levels=6 yields 6 edges from density.min to density.max.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30, levels=6)
+        _, _, density = glyph.evaluate()
+        edges = glyph._resolve_levels(density)
+        assert edges.size == 6, f"Expected 6 edges, got {edges.size}"
+        assert np.isclose(edges[0], density.min()), "First edge should be density min"
+        assert np.isclose(edges[-1], density.max()), "Last edge should be density max"
+        assert np.allclose(np.diff(edges), np.diff(edges)[0]), "Edges should be evenly spaced"
+
+    def test_sequence_levels_sorted(self, cloud):
+        """An explicit ``levels`` sequence is sorted ascending.
+
+        Test scenario:
+            An unsorted list of edges is returned sorted.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30, levels=[0.3, 0.1, 0.2])
+        edges = glyph._resolve_levels(np.zeros((3, 3)))
+        assert np.allclose(edges, [0.1, 0.2, 0.3]), f"Edges should be sorted, got {edges}"
+
+
+class TestKDEGlyphApplyClip:
+    """Tests for KDEGlyph._apply_clip."""
+
+    def test_none_is_noop(self, cloud):
+        """No clip path leaves the contour set unclipped.
+
+        Test scenario:
+            With clip_path None, the drawn set has the default axes clip
+            (not a custom one).
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30)
+        _, _, cs = glyph.plot()
+        assert glyph.clip_path is None, "clip_path should be None"
+
+    def test_patch_clip_applied(self, cloud):
+        """A Patch clip path is applied to the contour set.
+
+        Test scenario:
+            A Circle patch produces a non-None clip path on the drawn set.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30, clip_path=Circle((0, 0), 1.0))
+        _, _, cs = glyph.plot()
+        assert cs.get_clip_path() is not None, "Patch clip should be applied"
+
+    def test_path_clip_applied(self, cloud):
+        """A Path clip path is applied in data coordinates.
+
+        Test scenario:
+            A square Path produces a non-None clip path on the drawn set.
+        """
+        x, y = cloud
+        square = MplPath([(-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1)])
+        glyph = KDEGlyph(x, y, gridsize=30, clip_path=square)
+        _, _, cs = glyph.plot()
+        assert cs.get_clip_path() is not None, "Path clip should be applied"
+
+    def test_unsupported_clip_type_raises(self, cloud):
+        """An unsupported clip_path type raises TypeError.
+
+        Test scenario:
+            A string clip path is rejected at plot time.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30, clip_path="not-a-path")
+        with pytest.raises(TypeError, match="clip_path must be a matplotlib Path or Patch"):
+            glyph.plot()
+
+
+class TestKDEGlyphPlot:
+    """Tests for KDEGlyph.plot."""
+
+    def test_returns_quadcontourset_with_colorbar(self, cloud):
+        """Filled plot returns a QuadContourSet and adds a colorbar.
+
+        Test scenario:
+            Default shade=True draws filled contours with a colorbar.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=40)
+        fig, ax, cs = glyph.plot()
+        assert isinstance(cs, QuadContourSet), f"Expected QuadContourSet, got {type(cs)}"
+        assert cs.filled, "shade=True should produce filled contours"
+        assert glyph.cbar is not None, "A colorbar should be drawn by default"
+
+    def test_shade_false_line_contours(self, cloud):
+        """``shade=False`` draws line contours.
+
+        Test scenario:
+            The returned contour set is not filled.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=40, shade=False)
+        _, _, cs = glyph.plot()
+        assert not cs.filled, "shade=False should produce line contours"
+
+    def test_add_colorbar_false_suppresses(self, cloud):
+        """``add_colorbar=False`` suppresses the colorbar.
+
+        Test scenario:
+            The plot-time override wins and no colorbar is created.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=40)
+        glyph.plot(add_colorbar=False)
+        assert glyph.cbar is None, "add_colorbar=False should suppress the colorbar"
+
+    def test_title_override(self, cloud):
+        """A title passed to plot overrides the default.
+
+        Test scenario:
+            plot(title=...) sets the axes title.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30)
+        _, ax, _ = glyph.plot(title="Density")
+        assert ax.get_title() == "Density", f"Title should be 'Density', got {ax.get_title()!r}"
+
+    def test_levels_option_controls_contour_count(self, cloud):
+        """The ``levels`` option drives the number of contour levels.
+
+        Test scenario:
+            levels=5 yields five contour levels on the drawn set.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=40, levels=5)
+        _, _, cs = glyph.plot()
+        assert len(cs.levels) == 5, f"Expected 5 levels, got {len(cs.levels)}"
+
+    def test_exposes_im_attribute(self, cloud):
+        """The drawn contour set is exposed as ``glyph.im``.
+
+        Test scenario:
+            ``im`` is the same object the plot returns.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30)
+        _, _, cs = glyph.plot()
+        assert glyph.im is cs, "glyph.im should be the returned contour set"
+
+    def test_plot_on_supplied_axes(self, cloud):
+        """``plot(ax=...)`` draws on the given axes and binds its figure.
+
+        Test scenario:
+            A pre-existing axes is used as-is and its parent figure is
+            adopted by the glyph.
+        """
+        x, y = cloud
+        fig, host_ax = plt.subplots()
+        glyph = KDEGlyph(x, y, gridsize=30)
+        out_fig, out_ax, _ = glyph.plot(ax=host_ax)
+        assert out_ax is host_ax, "plot should draw on the supplied axes"
+        assert glyph.fig is host_ax.get_figure(), "glyph.fig should be the axes' figure"
+
+    def test_plot_uses_axes_from_construction(self, cloud):
+        """``plot()`` reuses an axes supplied at construction.
+
+        Test scenario:
+            With an axes passed to __init__, a no-argument plot() draws on
+            that same axes (the `ax is None`/`self.ax` set branch).
+        """
+        x, y = cloud
+        fig, host_ax = plt.subplots()
+        glyph = KDEGlyph(x, y, gridsize=30, ax=host_ax)
+        _, out_ax, _ = glyph.plot()
+        assert out_ax is host_ax, "plot() should reuse the construction axes"
+
+    def test_no_scipy_imported(self, cloud):
+        """The estimator never imports scipy.
+
+        Test scenario:
+            A full plot leaves scipy absent from sys.modules.
+        """
+        x, y = cloud
+        KDEGlyph(x, y, gridsize=30).plot()
+        assert "scipy" not in sys.modules, "KDEGlyph must not import scipy"


### PR DESCRIPTION
## Summary

Adds **`KDEGlyph`** — a 2-D Gaussian kernel-density estimate of a point cloud, drawn as filled (`contourf`) or line (`contour`) density bands. cleopatra had `StatisticalGlyph` (1-D histograms) but no 2-D density; this is generic matplotlib machinery reusable by any matplotlib user.

Closes #156.

## What changed

- **`cleopatra/kde_glyph.py`** — `KDEGlyph(x, y, *, clip_path=None, ...)` with `KDE_DEFAULT_OPTIONS` (`levels`, `shade`, `bw_method`, `gridsize`, plus the shared colour options).
  - `evaluate()` builds a `gridsize × gridsize` grid over the point bounds and sums an **isotropic Gaussian kernel** (Scott's-rule bandwidth `n**(-1/6)`, scaled by `bw_method`). **numpy only — no scipy.**
  - `plot()` colours the density through the shared `_prepare_scalar_mapping` pipeline and draws `contourf` (when `shade`) or `contour`; returns `(fig, ax, QuadContourSet)`.
  - Optional `clip_path` (matplotlib `Path` or `Patch`) clips the drawn contours via `set_clip_path`.

## Dependency safety & memory

- **No new dependency** — `pyproject.toml` unchanged.
- The grid sum is **chunked over the data points** (`MAX_KDE_BLOCK`) so the temporary `(grid-cells × block)` array never blows up for large `gridsize`/point counts.

## Honest scope notes (per the issue's caveats)

- The estimator is **isotropic, Scott's-rule only** — it is **not** a drop-in for `scipy.stats.gaussian_kde` (no diagonal/anisotropic bandwidth, no weights). This is stated in the module/class docstrings so users coming from seaborn's `kdeplot` aren't surprised. scipy/anisotropic support could be added later behind an optional extra without changing the default numpy path.
- Geometry/CRS-agnostic: the caller supplies plain `x`/`y` and an optional matplotlib clip path; no geographic clipping here.

## Tests

`tests/test_kde_glyph.py` (31 tests, **100% line+branch** on `kde_glyph.py`): construction/validation (shape mismatch, <2 points, non-positive `bw_method`, clip stored), Scott's-rule bandwidth + multiplier, `evaluate` (grid shape, positive density, integrates ~1, peaks near a synthetic cluster, zero-spread `ValueError`, chunked == unchunked via a small `MAX_KDE_BLOCK`), `_resolve_levels` (int → evenly-spaced edges; sequence sorted), `_apply_clip` (Patch / Path / unsupported `TypeError` / None no-op), and `plot` (`QuadContourSet`, filled vs line, colorbar toggle, clip restriction, title, level count, `glyph.im`, **no scipy in `sys.modules`**). `kde_glyph` registered in `tests/test_init.py`'s submodule list.

- Full suite green; new docstring examples validated via doctest.