### PR TITLE
feat(flow_glyph): magnitude-coloured, width-scaled flow/Sankey line glyph

### DIFF
--- a/src/cleopatra/flow_glyph.py
+++ b/src/cleopatra/flow_glyph.py
@@ -1,0 +1,326 @@
+"""Flow / Sankey-style line visualization.
+
+Provides `FlowGlyph` for drawing a collection of polylines whose **colour**
+encodes a per-path magnitude and whose **width** is scaled by a (possibly
+different) per-path magnitude — the rendering primitive behind a spatial
+Sankey / flow map. It mirrors `VectorGlyph` (which colours an artist by a
+per-item magnitude through the shared scalar-mapping pipeline) but draws a
+`matplotlib.collections.LineCollection` and adds value→width scaling via
+`cleopatra.styles.resolve_sizes` (shared with `ScatterGlyph`).
+
+The glyph is geometry-agnostic: it takes plain vertex arrays, so any
+great-circle interpolation or projection is the caller's job.
+
+Examples:
+    - Two flows coloured by value and scaled by width:
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.flow_glyph import FlowGlyph
+        >>> paths = [
+        ...     np.array([[0.0, 0.0], [1.0, 1.0]]),
+        ...     np.array([[0.0, 1.0], [1.0, 0.0]]),
+        ... ]
+        >>> glyph = FlowGlyph(
+        ...     paths, values=np.array([1.0, 5.0]), widths=np.array([2.0, 8.0])
+        ... )
+        >>> fig, ax, lc = glyph.plot()
+
+        ```
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+from matplotlib.figure import Figure
+from matplotlib.legend import Legend
+
+from cleopatra.glyph import Glyph
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+from cleopatra.styles import resolve_sizes, width_legend
+
+#: Option keys for FlowGlyph. `ticks_spacing` is `None` so the shared
+#: `_prepare_scalar_mapping` helper auto-derives it from the values. The
+#: `width_*` / `size_legend*` keys drive value→width scaling and its legend;
+#: they are inert unless a `widths` array is supplied at construction.
+FLOW_DEFAULT_OPTIONS = {
+    "width_limits": (1, 5),
+    "width_scale": "linear",
+    "size_legend": False,
+    "size_legend_values": None,
+    "size_legend_kwargs": None,
+    "vmin": None,
+    "vmax": None,
+    "levels": None,
+    "ticks_spacing": None,
+    "add_colorbar": True,
+}
+FLOW_DEFAULT_OPTIONS = STYLE_DEFAULTS | FLOW_DEFAULT_OPTIONS
+
+
+class FlowGlyph(Glyph):
+    """Visualization class for magnitude-coloured, width-scaled flow paths.
+
+    Renders a sequence of polylines as a `LineCollection`. With a per-path
+    `values` array the lines are colour-mapped through the shared
+    scalar-mapping pipeline and a colorbar is attached (like `VectorGlyph`);
+    with a per-path `widths` array each line's width is scaled via
+    `cleopatra.styles.resolve_sizes` (like `ScatterGlyph`'s `sizes`). Colour
+    and width are independent, so a flow can encode two quantities at once.
+
+    Args:
+        paths: A sequence of `(n_i, 2)` arrays of `(x, y)` vertices, one
+            polyline per flow. Polylines may have different vertex counts.
+        values: Optional per-path magnitude (length = number of paths) used
+            for colour mapping. Default is None (single-colour lines, no
+            colorbar).
+        widths: Optional per-path magnitude (length = number of paths) used
+            for line-width scaling. When None, the scalar `line_width`
+            option is used for every line. Default is None.
+        ax: Pre-existing axes to draw on. Default is None.
+        fig: Pre-existing figure. Default is None.
+        **kwargs: Override any key in `FLOW_DEFAULT_OPTIONS`: `width_limits`
+            (min/max line width in points, default `(1, 5)`), `width_scale`
+            (`"linear"` / `"log"` / `"sqrt"`, default `"linear"`),
+            `size_legend` (bool, default False), `size_legend_values`,
+            `size_legend_kwargs`, plus the shared colour options (`cmap`,
+            `vmin`, `vmax`, `levels`, `color_scale`, `ticks_spacing`,
+            `cbar_label`, `figsize`, `title`). Set `add_colorbar=False` to
+            suppress the per-glyph colorbar (default True).
+
+    Raises:
+        ValueError: If `values` or `widths` lengths do not match the number
+            of paths.
+
+    Examples:
+        - Build flows and read back the width ordering:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.flow_glyph import FlowGlyph
+            >>> paths = [
+            ...     np.array([[0.0, 0.0], [1.0, 0.0]]),
+            ...     np.array([[0.0, 1.0], [1.0, 1.0]]),
+            ...     np.array([[0.0, 2.0], [1.0, 2.0]]),
+            ... ]
+            >>> glyph = FlowGlyph(
+            ...     paths,
+            ...     values=np.array([1.0, 2.0, 3.0]),
+            ...     widths=np.array([10.0, 1.0, 5.0]),
+            ...     width_limits=(1, 5),
+            ... )
+            >>> fig, ax, lc = glyph.plot()
+            >>> lw = lc.get_linewidths()
+            >>> bool(lw[0] == max(lw) and lw[1] == min(lw))
+            True
+
+            ```
+
+    See Also:
+        cleopatra.glyph.Glyph._prepare_scalar_mapping: Shared
+            norm/colorbar/ticks pipeline used to colour by `values`.
+        cleopatra.styles.resolve_sizes: The value→size helper used for line
+            width (shared with `ScatterGlyph`).
+        cleopatra.vector_glyph.VectorGlyph: Magnitude-coloured vector fields.
+    """
+
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = FLOW_DEFAULT_OPTIONS
+
+    def __init__(
+        self,
+        paths: Sequence[np.ndarray],
+        *,
+        values: np.ndarray | None = None,
+        widths: np.ndarray | None = None,
+        ax: Axes = None,
+        fig: Figure = None,
+        **kwargs,
+    ):
+        super().__init__(
+            default_options=FLOW_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
+        )
+        self.paths = [np.asarray(p, dtype=float) for p in paths]
+        n_paths = len(self.paths)
+        if values is not None:
+            values = np.asarray(values)
+            if values.shape != (n_paths,):
+                raise ValueError(
+                    f"values must have one entry per path ({n_paths}), got "
+                    f"shape {values.shape}."
+                )
+        if widths is not None:
+            widths = np.asarray(widths)
+            if widths.shape != (n_paths,):
+                raise ValueError(
+                    f"widths must have one entry per path ({n_paths}), got "
+                    f"shape {widths.shape}."
+                )
+        self.values = values
+        self.widths = widths
+        self.cbar = None
+        #: The width legend created by `plot` when `size_legend` is truthy
+        #: (None otherwise); built via `cleopatra.styles.width_legend`.
+        self.size_legend_artist = None
+
+    def _resolve_linewidths(self) -> float | np.ndarray:
+        """Resolve the per-path line widths for the collection.
+
+        Returns the per-path widths mapped from `widths` when a `widths`
+        array was supplied (via `cleopatra.styles.resolve_sizes`, honouring
+        the `width_limits` / `width_scale` options), or the scalar
+        `line_width` option when no `widths` were given.
+
+        Returns:
+            float or np.ndarray: A scalar width (no `widths`) or a per-path
+                width array spanning `width_limits` monotonically in
+                `widths`.
+        """
+        if self.widths is None:
+            return self.default_options["line_width"]
+        width_min, width_max = self.default_options["width_limits"]
+        return resolve_sizes(
+            self.widths,
+            width_min,
+            width_max,
+            scale=self.default_options["width_scale"],
+        )
+
+    def _draw_width_legend(self, ax: Axes, linewidths: np.ndarray) -> Legend:
+        """Draw a line-width legend for the resolved per-path widths.
+
+        Picks representative magnitudes (`size_legend_values`, or the min /
+        median / max of `widths` when unset), maps each to its plotted line
+        width by interpolating the already-computed `(widths -> linewidth)`
+        mapping, and hands them to `cleopatra.styles.width_legend`.
+
+        Args:
+            ax: The axes to attach the legend to.
+            linewidths: The per-path widths returned by
+                `_resolve_linewidths`.
+
+        Returns:
+            matplotlib.legend.Legend: The width legend added to `ax`.
+        """
+        widths = np.asarray(self.widths, dtype=float)
+        legend_values = self.default_options["size_legend_values"]
+        if legend_values is None:
+            legend_values = np.quantile(widths, [0.0, 0.5, 1.0])
+        legend_values = np.asarray(legend_values, dtype=float)
+        order = np.argsort(widths)
+        legend_widths = np.interp(
+            legend_values, widths[order], np.asarray(linewidths)[order]
+        )
+        labels = [f"{v:g}" for v in legend_values]
+        legend_kwargs = self.default_options["size_legend_kwargs"] or {}
+        return width_legend(ax, legend_widths, labels, **legend_kwargs)
+
+    def plot(
+        self,
+        ax: Axes = None,
+        title: str | None = None,
+        add_colorbar: bool | None = None,
+    ) -> tuple[Figure, Axes, LineCollection]:
+        """Draw the flow paths, colouring by value and scaling by width.
+
+        Builds a `LineCollection` from `paths`. When `values` was supplied,
+        the colour scale, norm, ticks, and colorbar are resolved through
+        `_prepare_scalar_mapping`; otherwise a single-colour collection is
+        drawn with no colorbar. Line widths come from `widths` via
+        `cleopatra.styles.resolve_sizes`, falling back to the scalar
+        `line_width` option. If `size_legend` is truthy and `widths` were
+        given, a width legend is drawn and stored on
+        `self.size_legend_artist`.
+
+        Args:
+            ax: Axes to draw on. Falls back to the axes supplied at
+                construction, otherwise a new figure/axes is created.
+            title: Plot title. Overrides `default_options["title"]` when
+                given.
+            add_colorbar: Override the `add_colorbar` option for this call
+                — True draws the colorbar, False suppresses it. Defaults to
+                None, which keeps the value set at construction.
+
+        Returns:
+            tuple[Figure, Axes, LineCollection]: The figure, the axes, and
+                the `LineCollection` (the mappable the colorbar attaches to
+                when coloured).
+
+        Raises:
+            ValueError: If the values have no finite entries (via
+                `_prepare_scalar_mapping`).
+
+        Examples:
+            - Uncoloured flows draw no colorbar:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.flow_glyph import FlowGlyph
+                >>> paths = [np.array([[0.0, 0.0], [1.0, 1.0]])]
+                >>> glyph = FlowGlyph(paths)
+                >>> fig, ax, lc = glyph.plot()
+                >>> glyph.cbar is None
+                True
+
+                ```
+            - Coloured flows expose the per-path values on the collection:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.flow_glyph import FlowGlyph
+                >>> paths = [
+                ...     np.array([[0.0, 0.0], [1.0, 1.0]]),
+                ...     np.array([[0.0, 1.0], [1.0, 0.0]]),
+                ... ]
+                >>> glyph = FlowGlyph(paths, values=np.array([3.0, 7.0]))
+                >>> fig, ax, lc = glyph.plot(add_colorbar=False)
+                >>> [float(v) for v in lc.get_array()]
+                [3.0, 7.0]
+
+                ```
+        """
+        if ax is not None:
+            self.ax = ax
+            self.fig = ax.get_figure()
+        elif self.ax is None:
+            self.fig, self.ax = self.create_figure_axes()
+        ax = self.ax
+        opts = self.default_options
+
+        if title is not None:
+            opts["title"] = title
+        draw_colorbar = (
+            opts["add_colorbar"] if add_colorbar is None else add_colorbar
+        )
+
+        linewidths = self._resolve_linewidths()
+
+        if self.values is None:
+            lc = LineCollection(
+                self.paths, colors=opts["color_1"], linewidths=linewidths
+            )
+            ax.add_collection(lc)
+        else:
+            norm, cbar_kw, ticks = self._prepare_scalar_mapping(self.values)
+            lc = LineCollection(
+                self.paths,
+                array=np.asarray(self.values),
+                cmap=opts["cmap"],
+                norm=norm,
+                linewidths=linewidths,
+            )
+            if norm is None:
+                lc.set_clim(ticks[0], ticks[-1])
+            ax.add_collection(lc)
+            if draw_colorbar:
+                self.cbar = self.create_color_bar(ax, lc, cbar_kw)
+
+        ax.autoscale_view()
+
+        if self.widths is not None and opts["size_legend"]:
+            self.size_legend_artist = self._draw_width_legend(ax, linewidths)
+
+        if opts["title"]:
+            ax.set_title(opts["title"], fontsize=opts["title_size"])
+
+        return self.fig, ax, lc

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -1077,6 +1077,75 @@ def size_legend(
     return ax.legend(handles=handles, **kwargs)
 
 
+def width_legend(
+    ax: Axes,
+    linewidths: Sequence[float],
+    labels: Sequence[str],
+    *,
+    color: str = "0.4",
+    **kwargs,
+) -> Legend:
+    """Attach a legend whose line *widths* encode magnitude.
+
+    The line-width counterpart to `size_legend` (which varies marker size):
+    each entry is a short line drawn at the given `linewidth`, so it is the
+    right legend for a width-scaled flow / Sankey map
+    (e.g. `FlowGlyph(..., widths=...)`).
+
+    Args:
+        ax: The axes the legend is attached to.
+        linewidths: The representative line widths (points), one per legend
+            entry. Must be the same length as `labels`.
+        labels: The text drawn next to each line. Must be the same length as
+            `linewidths`.
+        color: Colour for every proxy line. Defaults to a neutral grey
+            (`"0.4"`) because the legend encodes width, not colour.
+        **kwargs: Forwarded verbatim to `Axes.legend` (e.g. `title`, `loc`,
+            `labelspacing`, `bbox_to_anchor`).
+
+    Returns:
+        Legend: The created legend artist, already added to `ax`.
+
+    Raises:
+        ValueError: If `linewidths` and `labels` have different lengths.
+
+    Examples:
+        - Build a width legend and read back its labels:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import width_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = width_legend(ax, [1.0, 3.0, 5.0], ["low", "mid", "high"])
+            >>> [t.get_text() for t in legend.get_texts()]
+            ['low', 'mid', 'high']
+
+            ```
+        - Larger magnitudes give thicker proxy lines:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import width_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = width_legend(ax, [1.0, 4.0], ["thin", "thick"])
+            >>> handles = legend.legend_handles
+            >>> handles[0].get_linewidth(), handles[1].get_linewidth()
+            (1.0, 4.0)
+
+            ```
+    """
+    linewidths = list(linewidths)
+    labels = list(labels)
+    if len(linewidths) != len(labels):
+        raise ValueError(
+            "linewidths and labels must have the same length, got "
+            f"{len(linewidths)} and {len(labels)}."
+        )
+    handles = [
+        Line2D([], [], color=color, linewidth=lw, label=label)
+        for lw, label in zip(linewidths, labels)
+    ]
+    return ax.legend(handles=handles, **kwargs)
+
+
 def colorbar_legend(mappable: ScalarMappable, ax: Axes = None, **kwargs) -> Colorbar:
     """Attach a continuous colorbar legend for a mappable.
 

--- a/tests/test_flow_glyph.py
+++ b/tests/test_flow_glyph.py
@@ -1,0 +1,366 @@
+"""Tests for cleopatra.flow_glyph.FlowGlyph and styles.width_legend — issue #157.
+
+Covers the width legend helper, FlowGlyph construction/validation, the
+value→width resolution, the width-legend drawing helper, and the `plot`
+rendering contract (colour by value, width by magnitude, colorbar toggle).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.collections import LineCollection
+from matplotlib.legend import Legend
+
+from cleopatra.flow_glyph import FLOW_DEFAULT_OPTIONS, FlowGlyph
+from cleopatra.styles import width_legend
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def paths():
+    """Five horizontal polylines stacked vertically.
+
+    Returns:
+        list[np.ndarray]: Five `(2, 2)` vertex arrays.
+    """
+    return [np.array([[0.0, float(i)], [1.0, float(i)]]) for i in range(5)]
+
+
+@pytest.fixture()
+def values():
+    """A per-path colour magnitude aligned with the `paths` fixture.
+
+    Returns:
+        np.ndarray: Five ascending values.
+    """
+    return np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+
+@pytest.fixture()
+def widths():
+    """A per-path width magnitude (deliberately unsorted).
+
+    Returns:
+        np.ndarray: Five magnitudes whose ranking differs from `values`.
+    """
+    return np.array([2.0, 1.0, 5.0, 3.0, 9.0])
+
+
+class TestWidthLegend:
+    """Tests for the styles.width_legend helper."""
+
+    def test_labels_round_trip(self):
+        """The legend exposes its labels in order.
+
+        Test scenario:
+            Three labels come back unchanged from the legend texts.
+        """
+        fig, ax = plt.subplots()
+        legend = width_legend(ax, [1.0, 3.0, 5.0], ["low", "mid", "high"])
+        texts = [t.get_text() for t in legend.get_texts()]
+        assert texts == ["low", "mid", "high"], f"Unexpected labels: {texts}"
+
+    def test_linewidth_matches_input(self):
+        """Each proxy line uses the supplied linewidth.
+
+        Test scenario:
+            Inputs 1 and 4 become handle linewidths 1 and 4.
+        """
+        fig, ax = plt.subplots()
+        legend = width_legend(ax, [1.0, 4.0], ["thin", "thick"])
+        handles = legend.legend_handles
+        assert handles[0].get_linewidth() == 1.0, "First handle should be 1.0 wide"
+        assert handles[1].get_linewidth() == 4.0, "Second handle should be 4.0 wide"
+
+    def test_forwards_legend_kwargs(self):
+        """`Axes.legend` kwargs such as `title` are forwarded.
+
+        Test scenario:
+            A title passed through reaches the legend title text.
+        """
+        fig, ax = plt.subplots()
+        legend = width_legend(ax, [1.0, 2.0], ["a", "b"], title="Flow")
+        assert legend.get_title().get_text() == "Flow", "title kwarg should be forwarded"
+
+    def test_length_mismatch_raises(self):
+        """Mismatched lengths raise ValueError.
+
+        Test scenario:
+            Two widths but one label is rejected.
+        """
+        fig, ax = plt.subplots()
+        with pytest.raises(ValueError, match="same length"):
+            width_legend(ax, [1.0, 2.0], ["only-one"])
+
+
+class TestFlowGlyphInit:
+    """Tests for FlowGlyph.__init__."""
+
+    def test_paths_stored_as_float_arrays(self, paths):
+        """Path vertices are stored as float ndarrays.
+
+        Test scenario:
+            Integer-typed vertex lists are converted to float arrays.
+        """
+        glyph = FlowGlyph([[[0, 0], [1, 1]]])
+        assert glyph.paths[0].dtype == float, "Paths should be stored as float arrays"
+        assert glyph.values is None and glyph.widths is None, "values/widths default to None"
+
+    def test_defaults_present(self, paths):
+        """Flow-specific option defaults are exposed.
+
+        Test scenario:
+            width_limits/width_scale defaults and None ticks_spacing.
+        """
+        glyph = FlowGlyph(paths)
+        assert glyph.default_options["width_limits"] == (1, 5), "Default width_limits should be (1, 5)"
+        assert glyph.default_options["width_scale"] == "linear", "Default width_scale should be linear"
+        assert glyph.default_options["ticks_spacing"] is None, "ticks_spacing should auto-derive"
+
+    def test_mismatched_values_raises(self, paths):
+        """A values array not matching the path count raises ValueError.
+
+        Test scenario:
+            len(values) != len(paths) is rejected.
+        """
+        with pytest.raises(ValueError, match="values must have one entry per path"):
+            FlowGlyph(paths, values=np.array([1.0, 2.0]))
+
+    def test_mismatched_widths_raises(self, paths):
+        """A widths array not matching the path count raises ValueError.
+
+        Test scenario:
+            len(widths) != len(paths) is rejected.
+        """
+        with pytest.raises(ValueError, match="widths must have one entry per path"):
+            FlowGlyph(paths, widths=np.array([1.0, 2.0]))
+
+    def test_invalid_kwarg_raises(self, paths):
+        """An unknown kwarg is rejected by the strict merge.
+
+        Test scenario:
+            A key absent from FLOW_DEFAULT_OPTIONS raises ValueError.
+        """
+        with pytest.raises(ValueError, match="not correct"):
+            FlowGlyph(paths, not_an_option=1)
+
+
+class TestFlowGlyphResolveLinewidths:
+    """Tests for FlowGlyph._resolve_linewidths."""
+
+    def test_scalar_when_no_widths(self, paths):
+        """Without widths the scalar `line_width` option is returned.
+
+        Test scenario:
+            A FlowGlyph with no widths resolves to the scalar line_width.
+        """
+        glyph = FlowGlyph(paths, line_width=2.5)
+        assert glyph._resolve_linewidths() == 2.5, "Should return scalar line_width"
+
+    def test_array_spans_width_limits(self, paths, widths):
+        """With widths the result spans width_limits monotonically.
+
+        Test scenario:
+            The per-path widths run from width_limits[0] to width_limits[1]
+            in the order of the input magnitudes.
+        """
+        glyph = FlowGlyph(paths, widths=widths, width_limits=(1, 5))
+        out = np.asarray(glyph._resolve_linewidths())
+        assert np.isclose(out.min(), 1.0), f"min width should be 1.0, got {out.min()}"
+        assert np.isclose(out.max(), 5.0), f"max width should be 5.0, got {out.max()}"
+        assert np.array_equal(np.argsort(out), np.argsort(widths)), "Widths not monotonic in input"
+
+    @pytest.mark.parametrize("scale", ["linear", "log", "sqrt"])
+    def test_width_scale_modes(self, paths, scale):
+        """Each width_scale yields a monotonic per-path width array.
+
+        Args:
+            paths: The polyline fixture.
+            scale: The width scale under test.
+
+        Test scenario:
+            For positive magnitudes every scale preserves the ranking.
+        """
+        widths = np.array([1.0, 2.0, 4.0, 8.0, 16.0])
+        glyph = FlowGlyph(paths, widths=widths, width_scale=scale, width_limits=(1, 5))
+        out = np.asarray(glyph._resolve_linewidths())
+        assert np.array_equal(np.argsort(out), np.argsort(widths)), f"{scale} not monotonic"
+
+
+class TestFlowGlyphDrawWidthLegend:
+    """Tests for FlowGlyph._draw_width_legend (via plot)."""
+
+    def test_default_three_quantile_entries(self, paths, widths):
+        """The default width legend has three (min/median/max) entries.
+
+        Test scenario:
+            size_legend=True with no explicit values draws three entries.
+        """
+        glyph = FlowGlyph(paths, widths=widths, size_legend=True)
+        glyph.plot()
+        assert isinstance(glyph.size_legend_artist, Legend), "A width legend should be drawn"
+        texts = [t.get_text() for t in glyph.size_legend_artist.get_texts()]
+        assert len(texts) == 3, f"Default legend should have 3 entries, got {texts}"
+
+    def test_explicit_legend_values(self, paths, widths):
+        """Explicit size_legend_values control the legend entries.
+
+        Test scenario:
+            Two representative magnitudes give two labelled entries.
+        """
+        glyph = FlowGlyph(paths, widths=widths, size_legend=True,
+                          size_legend_values=[2.0, 8.0])
+        glyph.plot()
+        texts = [t.get_text() for t in glyph.size_legend_artist.get_texts()]
+        assert texts == ["2", "8"], f"Legend should honour explicit values, got {texts}"
+
+    def test_no_legend_without_widths(self, paths, values):
+        """No legend is drawn when there are no widths, even if requested.
+
+        Test scenario:
+            size_legend=True but widths None leaves the legend unset.
+        """
+        glyph = FlowGlyph(paths, values=values, size_legend=True)
+        glyph.plot()
+        assert glyph.size_legend_artist is None, "No width legend without widths"
+
+
+class TestFlowGlyphPlot:
+    """Tests for FlowGlyph.plot."""
+
+    def test_returns_line_collection(self, paths):
+        """plot returns a LineCollection added to the axes.
+
+        Test scenario:
+            The third return value is a LineCollection.
+        """
+        glyph = FlowGlyph(paths)
+        fig, ax, lc = glyph.plot()
+        assert isinstance(lc, LineCollection), f"Expected LineCollection, got {type(lc)}"
+
+    def test_uncoloured_single_colour_no_colorbar(self, paths):
+        """Without values the lines are single-colour with no colorbar.
+
+        Test scenario:
+            values None -> no colour array and no colorbar.
+        """
+        glyph = FlowGlyph(paths)
+        _, _, lc = glyph.plot()
+        assert lc.get_array() is None, "Uncoloured collection should carry no array"
+        assert glyph.cbar is None, "No colorbar without values"
+
+    def test_coloured_carries_values_and_colorbar(self, paths, values):
+        """With values the collection carries them and gains a colorbar.
+
+        Test scenario:
+            get_array equals the input values and a colorbar is attached.
+        """
+        glyph = FlowGlyph(paths, values=values)
+        _, _, lc = glyph.plot()
+        assert np.array_equal(lc.get_array(), values), "Colour array should equal values"
+        assert glyph.cbar is not None, "A colorbar should be drawn by default"
+
+    def test_colorbar_reflects_value_range(self, paths, values):
+        """The colorbar spans the value range.
+
+        Test scenario:
+            The colorbar starts at the value minimum and covers the maximum
+            (its upper limit may round slightly past `vmax` via the shared
+            tick spacing, exactly as for the other glyphs).
+        """
+        glyph = FlowGlyph(paths, values=values)
+        glyph.plot()
+        lo, hi = glyph.cbar.mappable.get_clim()
+        assert np.isclose(lo, values.min()), f"Colorbar should start at {values.min()}, got {lo}"
+        assert hi >= values.max(), f"Colorbar should cover {values.max()}, got {hi}"
+
+    def test_colorbar_with_discrete_levels(self, paths, values):
+        """An integer `levels` colours via a discrete BoundaryNorm.
+
+        Test scenario:
+            With levels set, the collection's norm carries discrete
+            boundaries (and `set_clim` is bypassed).
+        """
+        glyph = FlowGlyph(paths, values=values, levels=4)
+        _, _, lc = glyph.plot()
+        assert lc.norm.boundaries is not None, "levels should yield a BoundaryNorm"
+        assert glyph.cbar is not None, "A colorbar should still be drawn"
+
+    def test_linewidths_monotonic_and_span_limits(self, paths, widths):
+        """get_linewidths runs monotonically with widths and spans limits.
+
+        Test scenario:
+            The drawn linewidths order matches the widths order and the
+            extremes equal width_limits.
+        """
+        glyph = FlowGlyph(paths, widths=widths, width_limits=(1, 5))
+        _, _, lc = glyph.plot()
+        lw = np.asarray(lc.get_linewidths())
+        assert np.array_equal(np.argsort(lw), np.argsort(widths)), "Linewidths not monotonic in widths"
+        assert np.isclose(lw.min(), 1.0) and np.isclose(lw.max(), 5.0), (
+            f"Linewidths should span (1, 5), got [{lw.min()}, {lw.max()}]"
+        )
+
+    def test_add_colorbar_false_suppresses(self, paths, values):
+        """add_colorbar=False suppresses the colorbar.
+
+        Test scenario:
+            The plot-time override wins and no colorbar is created.
+        """
+        glyph = FlowGlyph(paths, values=values)
+        glyph.plot(add_colorbar=False)
+        assert glyph.cbar is None, "add_colorbar=False should suppress the colorbar"
+
+    def test_widths_none_uses_scalar_line_width(self, paths, values):
+        """Without widths every line uses the scalar line_width.
+
+        Test scenario:
+            All linewidths equal the line_width option.
+        """
+        glyph = FlowGlyph(paths, values=values, line_width=2.0)
+        _, _, lc = glyph.plot()
+        lw = np.asarray(lc.get_linewidths())
+        assert np.all(lw == 2.0), f"All linewidths should be 2.0, got {set(lw.tolist())}"
+
+    def test_title_override(self, paths):
+        """A title passed to plot overrides the default.
+
+        Test scenario:
+            plot(title=...) sets the axes title.
+        """
+        glyph = FlowGlyph(paths)
+        _, ax, _ = glyph.plot(title="Flows")
+        assert ax.get_title() == "Flows", f"Title should be 'Flows', got {ax.get_title()!r}"
+
+    def test_plot_on_supplied_axes(self, paths):
+        """plot(ax=...) draws on the supplied axes.
+
+        Test scenario:
+            A pre-existing axes is used and its figure adopted.
+        """
+        fig, host_ax = plt.subplots()
+        glyph = FlowGlyph(paths)
+        _, out_ax, _ = glyph.plot(ax=host_ax)
+        assert out_ax is host_ax, "plot should draw on the supplied axes"
+
+    def test_plot_uses_axes_from_construction(self, paths):
+        """plot() reuses an axes supplied at construction.
+
+        Test scenario:
+            With an axes passed to __init__, a no-arg plot() reuses it.
+        """
+        fig, host_ax = plt.subplots()
+        glyph = FlowGlyph(paths, ax=host_ax)
+        _, out_ax, _ = glyph.plot()
+        assert out_ax is host_ax, "plot() should reuse the construction axes"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,6 +21,7 @@ _SUBMODULES = [
     "array_glyph",
     "colors",
     "config",
+    "flow_glyph",
     "glyph",
     "line_glyph",
     "mesh_glyph",


### PR DESCRIPTION
## Summary

Adds **`FlowGlyph`** — a collection of polylines whose **colour** encodes a per-path magnitude and whose **width** is scaled by a (possibly different) per-path magnitude: the rendering primitive behind a spatial Sankey / flow map. It mirrors `VectorGlyph` (colour by magnitude through the shared `_prepare_scalar_mapping` pipeline) but draws a `matplotlib.collections.LineCollection`.

Closes #157.

> [!IMPORTANT]
> **Stacked on #155.** FlowGlyph reuses `cleopatra.styles.resolve_sizes` (added in #155) for line-width scaling, so this PR targets the **`feat/scatter-value-to-size`** branch. Merge #155 (PR #159) first, then this diff reduces to just the FlowGlyph files. Rebase onto `main` once #155 lands.

## What changed

- **`cleopatra/flow_glyph.py`** — `FlowGlyph(paths, *, values=None, widths=None, ...)` with `FLOW_DEFAULT_OPTIONS` (`width_limits=(1,5)`, `width_scale`, `size_legend`, plus shared colour options).
  - `plot()` builds a `LineCollection` from the vertex arrays; colours by `values` (inherited colorbar, like `VectorGlyph`); sets per-path `linewidth` from `widths` via `resolve_sizes`; returns `(fig, ax, LineCollection)`.
  - `values=None` → single-colour lines, no colorbar. `widths=None` → scalar `line_width`. Both mirror the other glyphs.
- **`cleopatra.styles.width_legend`** — the line-width counterpart to `size_legend` (varies `Line2D` linewidth), used for the optional width legend (the issue's `size_legend` option; `disjoint_legend`/`size_legend` can't represent line width).

## Dependency safety

Pure **numpy + matplotlib** — no new dependency. Geometry-agnostic: plain `(n_i, 2)` vertex arrays in; any great-circle interpolation is the caller's job.

## Tests

`tests/test_flow_glyph.py` (29 tests, **100% line+branch** on `flow_glyph.py`): `width_legend` (linewidth per entry, label round-trip, kwargs, length-mismatch); construction/validation (paths as float arrays, values/widths length mismatch); `_resolve_linewidths` (scalar fallback; per-path span of `width_limits`, monotonic; linear/log/sqrt scales); `_draw_width_legend` (default 3 quantile entries, explicit `size_legend_values`); and `plot` (returns `LineCollection`; `values=None` → single colour, no colorbar, `get_array() is None`; coloured → `get_array()` equals values + colorbar covers the value range; `get_linewidths()` monotonic in widths and spans `width_limits`; `add_colorbar=False`; discrete `levels` BoundaryNorm; title; supplied/constructed axes). `flow_glyph` registered in `tests/test_init.py`.

- Full suite green (802 passed); new docstring examples validated via doctest.