### PR TITLE
feat: geoplot upstream glyphs — classification scheme, value-to-size, KDEGlyph, FlowGlyph (#154–#157)

### DIFF
--- a/docs/diagrams/glyph-architecture.md
+++ b/docs/diagrams/glyph-architecture.md
@@ -1,0 +1,300 @@
+# Cleopatra glyph architecture
+
+Architecture and class diagrams for cleopatra's glyph subsystem and the shared
+colour / scale pipeline, including the geoplot-upstream additions
+(classification `scheme`, value→size scaling, `FlowGlyph`, `KDEGlyph`).
+
+All diagrams use [Mermaid](https://mermaid.js.org/) (rendered by
+`mkdocs-mermaid2` in the docs site and by GitHub).
+
+## Legend
+
+| Style | Meaning |
+|-------|---------|
+| **base** (blue) | `Glyph` base class — shared figure/axes, colour, colorbar, ticks |
+| **glyph** (green) | concrete user-facing glyph subclasses |
+| **standalone** (grey) | classes that do **not** subclass `Glyph` |
+| **helper** (amber) | `styles` functions / classes (no glyph instance needed) |
+
+---
+
+## 1. Class hierarchy
+
+`ArrayGlyph`, `MeshGlyph`, `ScatterGlyph`, `PolygonGlyph`, `VectorGlyph`,
+`FlowGlyph`, and `KDEGlyph` subclass `Glyph`. `StatisticalGlyph` is independent.
+
+```mermaid
+classDiagram
+    class Glyph {
+        +dict default_options
+        +Figure fig
+        +Axes ax
+        +vmin
+        +vmax
+        +option_keys() set
+        +filter_kwargs(kwargs) dict
+        +create_figure_axes()
+        +get_ticks() ndarray
+        #_resolve_limits(values)
+        #_prepare_scalar_mapping(values)
+        #_prepare_classified_mapping(values, scheme)
+        #_create_norm_and_cbar_kw(ticks)
+        #_levels_to_bounds(levels, vmin, vmax)
+        +create_color_bar(ax, im, cbar_kw)
+    }
+
+    class ArrayGlyph {
+        +plot()
+        +animate()
+        #_resolve_color_limits()
+    }
+    class MeshGlyph {
+        +plot()
+        #_render_mesh()
+    }
+    class ScatterGlyph {
+        +x
+        +y
+        +values
+        +sizes
+        +plot()
+        #_resolve_marker_area()
+        #_draw_size_legend()
+    }
+    class PolygonGlyph {
+        +polygons
+        +values
+        +plot(outline_only)
+    }
+    class VectorGlyph {
+        +x
+        +y
+        +u
+        +v
+        +magnitude
+        +plot(kind)
+        +add_key()
+    }
+    class FlowGlyph {
+        +paths
+        +values
+        +widths
+        +plot()
+        #_resolve_linewidths()
+        #_draw_width_legend()
+    }
+    class KDEGlyph {
+        +x
+        +y
+        +clip_path
+        +evaluate()
+        +plot()
+        #_bandwidth()
+        #_resolve_levels()
+        #_apply_clip()
+    }
+    class StatisticalGlyph {
+        +plot()
+    }
+
+    Glyph <|-- ArrayGlyph
+    Glyph <|-- MeshGlyph
+    Glyph <|-- ScatterGlyph
+    Glyph <|-- PolygonGlyph
+    Glyph <|-- VectorGlyph
+    Glyph <|-- FlowGlyph
+    Glyph <|-- KDEGlyph
+
+    note for StatisticalGlyph "Stands alone — 1-D/2-D histograms,\ndoes not subclass Glyph"
+
+    style Glyph fill:#cfe2ff,stroke:#3D59AB,color:#000
+    style ArrayGlyph fill:#d1e7dd,stroke:#0f5132,color:#000
+    style MeshGlyph fill:#d1e7dd,stroke:#0f5132,color:#000
+    style ScatterGlyph fill:#d1e7dd,stroke:#0f5132,color:#000
+    style PolygonGlyph fill:#d1e7dd,stroke:#0f5132,color:#000
+    style VectorGlyph fill:#d1e7dd,stroke:#0f5132,color:#000
+    style FlowGlyph fill:#d1e7dd,stroke:#0f5132,color:#000
+    style KDEGlyph fill:#d1e7dd,stroke:#0f5132,color:#000
+    style StatisticalGlyph fill:#e2e3e5,stroke:#41464b,color:#000
+```
+
+---
+
+## 2. Shared colour / scale pipeline
+
+Every colour-by-value glyph that routes through `_prepare_scalar_mapping`
+(`ScatterGlyph`, `PolygonGlyph`, `VectorGlyph`, `FlowGlyph`) shares one
+contract. Since the geoplot-upstream work, a `scheme` option short-circuits to
+classified (discrete) colouring; otherwise the continuous `color_scale` /
+`levels` path runs. `ArrayGlyph` / `MeshGlyph` build their norm directly via
+`_create_norm_and_cbar_kw` and therefore do **not** accept `scheme`.
+
+```mermaid
+flowchart TD
+    A["glyph.plot(values)"] --> B["_prepare_scalar_mapping(values)"]
+    B --> C["_resolve_limits(values)\nvmin / vmax / ticks_spacing"]
+    C --> D{"scheme set?"}
+
+    D -- "yes" --> E["_prepare_classified_mapping(values, scheme)"]
+    E --> F["styles.classify(values, scheme, k)"]
+    F --> G["bin_edges + BoundaryNorm\n(discrete classes)"]
+    E -. "warn if color_scale/levels\nalso set (ignored)" .-> G
+    G --> K["create_color_bar(ax, im, cbar_kw)\nstepped colorbar"]
+
+    D -- "no" --> H["get_ticks()"]
+    H --> I["_create_norm_and_cbar_kw(ticks)"]
+    I --> J["norm (linear / power / sym-log /\nboundary / midpoint) or None"]
+    J --> K
+
+    subgraph bypass["ArrayGlyph / MeshGlyph (bypass)"]
+        M["plot()"] --> N["_resolve_color_limits / get_ticks"]
+        N --> I
+    end
+
+    style B fill:#cfe2ff,stroke:#3D59AB,color:#000
+    style E fill:#cfe2ff,stroke:#3D59AB,color:#000
+    style I fill:#cfe2ff,stroke:#3D59AB,color:#000
+    style K fill:#cfe2ff,stroke:#3D59AB,color:#000
+    style F fill:#fff3cd,stroke:#997404,color:#000
+    style G fill:#fff3cd,stroke:#997404,color:#000
+```
+
+---
+
+## 3. `styles` helpers
+
+Stateless helpers used by the glyphs (and usable standalone). `scheme`/`k`
+live in `CLASSIFY_OPTIONS`, mixed only into the glyphs whose colouring is
+driven purely by the norm.
+
+```mermaid
+classDiagram
+    class classify {
+        <<function>>
+        +classify(values, scheme, k) tuple~edges,BoundaryNorm~
+    }
+    class resolve_sizes {
+        <<function>>
+        +resolve_sizes(values, out_min, out_max, scale) ndarray
+    }
+    class size_legend {
+        <<function>>
+        +size_legend(ax, marker_sizes, labels) Legend
+    }
+    class width_legend {
+        <<function>>
+        +width_legend(ax, linewidths, labels) Legend
+    }
+    class Scale {
+        +rescale(v, omin, omax, nmin, nmax)$
+        +log_scale(v)$
+        +power_scale(min_val)$
+        +identity_scale(min_val, max_val)$
+    }
+    class MidpointNormalize {
+        +midpoint
+        +__call__(value)
+    }
+    class ColorScale {
+        <<enum>>
+        LINEAR
+        POWER
+        SYM_LOGNORM
+        BOUNDARY_NORM
+        MIDPOINT
+    }
+    class CLASSIFY_OPTIONS {
+        <<dict>>
+        scheme = None
+        k = 5
+    }
+
+    Normalize <|-- MidpointNormalize
+    classify ..> BoundaryNorm : returns
+    resolve_sizes ..> Scale : uses rescale / log_scale
+    ScatterGlyph ..> resolve_sizes : marker area
+    ScatterGlyph ..> size_legend
+    FlowGlyph ..> resolve_sizes : line width
+    FlowGlyph ..> width_legend
+    Glyph ..> classify : via _prepare_classified_mapping
+
+    style classify fill:#fff3cd,stroke:#997404,color:#000
+    style resolve_sizes fill:#fff3cd,stroke:#997404,color:#000
+    style size_legend fill:#fff3cd,stroke:#997404,color:#000
+    style width_legend fill:#fff3cd,stroke:#997404,color:#000
+    style Scale fill:#fff3cd,stroke:#997404,color:#000
+    style MidpointNormalize fill:#fff3cd,stroke:#997404,color:#000
+```
+
+---
+
+## 4. Sequence — classified choropleth (`scheme`)
+
+A `PolygonGlyph(..., scheme="quantiles", k=5).plot()` call, end to end.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant PG as PolygonGlyph
+    participant G as Glyph (base)
+    participant ST as styles.classify
+    participant MPL as matplotlib
+
+    User->>PG: plot()
+    PG->>G: _prepare_scalar_mapping(values)
+    G->>G: _resolve_limits(values)
+    G->>G: scheme set -> _prepare_classified_mapping
+    G->>ST: classify(values, "quantiles", k=5)
+    ST-->>G: (bin_edges, BoundaryNorm)
+    G-->>PG: (norm, cbar_kw, edges)
+    PG->>MPL: PolyCollection(array=values, norm=BoundaryNorm)
+    PG->>G: create_color_bar(ax, pc, cbar_kw)
+    G->>MPL: fig.colorbar(...) (stepped)
+    PG-->>User: (fig, ax, PolyCollection)
+```
+
+---
+
+## 5. Sequence — value→size scatter
+
+A `ScatterGlyph(x, y, values=v, sizes=w, size_legend=True).plot()` call: colour
+and size are resolved independently.
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant SG as ScatterGlyph
+    participant G as Glyph (base)
+    participant RS as styles.resolve_sizes
+    participant SL as styles.size_legend
+    participant MPL as matplotlib
+
+    User->>SG: plot()
+    SG->>SG: _resolve_marker_area()
+    SG->>RS: resolve_sizes(sizes, *size_limits, scale)
+    RS-->>SG: per-point areas
+    SG->>G: _prepare_scalar_mapping(values)
+    G-->>SG: (norm, cbar_kw, ticks)
+    SG->>MPL: ax.scatter(c=values, s=areas, norm=norm)
+    SG->>G: create_color_bar(ax, paths, cbar_kw)
+    SG->>SL: size_legend(ax, repr_areas, labels)
+    SG-->>User: (fig, ax, PathCollection)
+```
+
+---
+
+## Notes / design patterns
+
+- **Template method** — `Glyph` owns the colour/colorbar/ticks contract; each
+  subclass implements only its `plot()` rendering and reuses
+  `_prepare_scalar_mapping` + `create_color_bar`.
+- **Strategy** — `color_scale` (`ColorScale`) and `scheme` select the
+  normalization strategy; `size_scale` / `width_scale` select the value→size
+  transform inside `resolve_sizes`.
+- **Shared-but-scoped options** — `scheme`/`k` are *not* in the shared
+  `DEFAULT_OPTIONS`; they live in `CLASSIFY_OPTIONS` and are mixed only into the
+  glyphs whose renderer is driven purely by the norm, so `ArrayGlyph` /
+  `MeshGlyph` / `KDEGlyph` reject `scheme` instead of silently ignoring it.
+- **No new hard dependency** — classification, KDE, and rescaling are pure
+  numpy + matplotlib; the Jenks-family schemes are the only thing behind an
+  optional, lazily-imported `cleopatra[classify]` extra.

--- a/docs/diagrams/glyph-architecture.md
+++ b/docs/diagrams/glyph-architecture.md
@@ -295,6 +295,5 @@ sequenceDiagram
   `DEFAULT_OPTIONS`; they live in `CLASSIFY_OPTIONS` and are mixed only into the
   glyphs whose renderer is driven purely by the norm, so `ArrayGlyph` /
   `MeshGlyph` / `KDEGlyph` reject `scheme` instead of silently ignoring it.
-- **No new hard dependency** — classification, KDE, and rescaling are pure
-  numpy + matplotlib; the Jenks-family schemes are the only thing behind an
-  optional, lazily-imported `cleopatra[classify]` extra.
+- **No new dependency at all** — classification (including the Fisher-Jenks
+  natural-breaks optimisation), KDE, and rescaling are pure numpy + matplotlib.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ tiles = [
     "pyproj>=3.7.2",
     "xyzservices>=2026.3.0",
 ]
+# Jenks-family classification schemes ("fisher_jenks" / "natural_breaks")
+# for cleopatra.styles.classify. The numpy-only schemes need nothing extra.
+classify = [
+    "mapclassify>=2.5.0",
+]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,6 @@ tiles = [
     "pyproj>=3.7.2",
     "xyzservices>=2026.3.0",
 ]
-# Jenks-family classification schemes ("fisher_jenks" / "natural_breaks")
-# for cleopatra.styles.classify. The numpy-only schemes need nothing extra.
-classify = [
-    "mapclassify>=2.5.0",
-]
 
 [dependency-groups]
 dev = [

--- a/src/cleopatra/flow_glyph.py
+++ b/src/cleopatra/flow_glyph.py
@@ -1,0 +1,326 @@
+"""Flow / Sankey-style line visualization.
+
+Provides `FlowGlyph` for drawing a collection of polylines whose **colour**
+encodes a per-path magnitude and whose **width** is scaled by a (possibly
+different) per-path magnitude — the rendering primitive behind a spatial
+Sankey / flow map. It mirrors `VectorGlyph` (which colours an artist by a
+per-item magnitude through the shared scalar-mapping pipeline) but draws a
+`matplotlib.collections.LineCollection` and adds value→width scaling via
+`cleopatra.styles.resolve_sizes` (shared with `ScatterGlyph`).
+
+The glyph is geometry-agnostic: it takes plain vertex arrays, so any
+great-circle interpolation or projection is the caller's job.
+
+Examples:
+    - Two flows coloured by value and scaled by width:
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.flow_glyph import FlowGlyph
+        >>> paths = [
+        ...     np.array([[0.0, 0.0], [1.0, 1.0]]),
+        ...     np.array([[0.0, 1.0], [1.0, 0.0]]),
+        ... ]
+        >>> glyph = FlowGlyph(
+        ...     paths, values=np.array([1.0, 5.0]), widths=np.array([2.0, 8.0])
+        ... )
+        >>> fig, ax, lc = glyph.plot()
+
+        ```
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import LineCollection
+from matplotlib.figure import Figure
+from matplotlib.legend import Legend
+
+from cleopatra.glyph import Glyph
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+from cleopatra.styles import resolve_sizes, width_legend
+
+#: Option keys for FlowGlyph. `ticks_spacing` is `None` so the shared
+#: `_prepare_scalar_mapping` helper auto-derives it from the values. The
+#: `width_*` / `size_legend*` keys drive value→width scaling and its legend;
+#: they are inert unless a `widths` array is supplied at construction.
+FLOW_DEFAULT_OPTIONS = {
+    "width_limits": (1, 5),
+    "width_scale": "linear",
+    "size_legend": False,
+    "size_legend_values": None,
+    "size_legend_kwargs": None,
+    "vmin": None,
+    "vmax": None,
+    "levels": None,
+    "ticks_spacing": None,
+    "add_colorbar": True,
+}
+FLOW_DEFAULT_OPTIONS = STYLE_DEFAULTS | FLOW_DEFAULT_OPTIONS
+
+
+class FlowGlyph(Glyph):
+    """Visualization class for magnitude-coloured, width-scaled flow paths.
+
+    Renders a sequence of polylines as a `LineCollection`. With a per-path
+    `values` array the lines are colour-mapped through the shared
+    scalar-mapping pipeline and a colorbar is attached (like `VectorGlyph`);
+    with a per-path `widths` array each line's width is scaled via
+    `cleopatra.styles.resolve_sizes` (like `ScatterGlyph`'s `sizes`). Colour
+    and width are independent, so a flow can encode two quantities at once.
+
+    Args:
+        paths: A sequence of `(n_i, 2)` arrays of `(x, y)` vertices, one
+            polyline per flow. Polylines may have different vertex counts.
+        values: Optional per-path magnitude (length = number of paths) used
+            for colour mapping. Default is None (single-colour lines, no
+            colorbar).
+        widths: Optional per-path magnitude (length = number of paths) used
+            for line-width scaling. When None, the scalar `line_width`
+            option is used for every line. Default is None.
+        ax: Pre-existing axes to draw on. Default is None.
+        fig: Pre-existing figure. Default is None.
+        **kwargs: Override any key in `FLOW_DEFAULT_OPTIONS`: `width_limits`
+            (min/max line width in points, default `(1, 5)`), `width_scale`
+            (`"linear"` / `"log"` / `"sqrt"`, default `"linear"`),
+            `size_legend` (bool, default False), `size_legend_values`,
+            `size_legend_kwargs`, plus the shared colour options (`cmap`,
+            `vmin`, `vmax`, `levels`, `color_scale`, `ticks_spacing`,
+            `cbar_label`, `figsize`, `title`). Set `add_colorbar=False` to
+            suppress the per-glyph colorbar (default True).
+
+    Raises:
+        ValueError: If `values` or `widths` lengths do not match the number
+            of paths.
+
+    Examples:
+        - Build flows and read back the width ordering:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.flow_glyph import FlowGlyph
+            >>> paths = [
+            ...     np.array([[0.0, 0.0], [1.0, 0.0]]),
+            ...     np.array([[0.0, 1.0], [1.0, 1.0]]),
+            ...     np.array([[0.0, 2.0], [1.0, 2.0]]),
+            ... ]
+            >>> glyph = FlowGlyph(
+            ...     paths,
+            ...     values=np.array([1.0, 2.0, 3.0]),
+            ...     widths=np.array([10.0, 1.0, 5.0]),
+            ...     width_limits=(1, 5),
+            ... )
+            >>> fig, ax, lc = glyph.plot()
+            >>> lw = lc.get_linewidths()
+            >>> bool(lw[0] == max(lw) and lw[1] == min(lw))
+            True
+
+            ```
+
+    See Also:
+        cleopatra.glyph.Glyph._prepare_scalar_mapping: Shared
+            norm/colorbar/ticks pipeline used to colour by `values`.
+        cleopatra.styles.resolve_sizes: The value→size helper used for line
+            width (shared with `ScatterGlyph`).
+        cleopatra.vector_glyph.VectorGlyph: Magnitude-coloured vector fields.
+    """
+
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = FLOW_DEFAULT_OPTIONS
+
+    def __init__(
+        self,
+        paths: Sequence[np.ndarray],
+        *,
+        values: np.ndarray | None = None,
+        widths: np.ndarray | None = None,
+        ax: Axes = None,
+        fig: Figure = None,
+        **kwargs,
+    ):
+        super().__init__(
+            default_options=FLOW_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
+        )
+        self.paths = [np.asarray(p, dtype=float) for p in paths]
+        n_paths = len(self.paths)
+        if values is not None:
+            values = np.asarray(values)
+            if values.shape != (n_paths,):
+                raise ValueError(
+                    f"values must have one entry per path ({n_paths}), got "
+                    f"shape {values.shape}."
+                )
+        if widths is not None:
+            widths = np.asarray(widths)
+            if widths.shape != (n_paths,):
+                raise ValueError(
+                    f"widths must have one entry per path ({n_paths}), got "
+                    f"shape {widths.shape}."
+                )
+        self.values = values
+        self.widths = widths
+        self.cbar = None
+        #: The width legend created by `plot` when `size_legend` is truthy
+        #: (None otherwise); built via `cleopatra.styles.width_legend`.
+        self.size_legend_artist = None
+
+    def _resolve_linewidths(self) -> float | np.ndarray:
+        """Resolve the per-path line widths for the collection.
+
+        Returns the per-path widths mapped from `widths` when a `widths`
+        array was supplied (via `cleopatra.styles.resolve_sizes`, honouring
+        the `width_limits` / `width_scale` options), or the scalar
+        `line_width` option when no `widths` were given.
+
+        Returns:
+            float or np.ndarray: A scalar width (no `widths`) or a per-path
+                width array spanning `width_limits` monotonically in
+                `widths`.
+        """
+        if self.widths is None:
+            return self.default_options["line_width"]
+        width_min, width_max = self.default_options["width_limits"]
+        return resolve_sizes(
+            self.widths,
+            width_min,
+            width_max,
+            scale=self.default_options["width_scale"],
+        )
+
+    def _draw_width_legend(self, ax: Axes, linewidths: np.ndarray) -> Legend:
+        """Draw a line-width legend for the resolved per-path widths.
+
+        Picks representative magnitudes (`size_legend_values`, or the min /
+        median / max of `widths` when unset), maps each to its plotted line
+        width by interpolating the already-computed `(widths -> linewidth)`
+        mapping, and hands them to `cleopatra.styles.width_legend`.
+
+        Args:
+            ax: The axes to attach the legend to.
+            linewidths: The per-path widths returned by
+                `_resolve_linewidths`.
+
+        Returns:
+            matplotlib.legend.Legend: The width legend added to `ax`.
+        """
+        widths = np.asarray(self.widths, dtype=float)
+        legend_values = self.default_options["size_legend_values"]
+        if legend_values is None:
+            legend_values = np.quantile(widths, [0.0, 0.5, 1.0])
+        legend_values = np.asarray(legend_values, dtype=float)
+        order = np.argsort(widths)
+        legend_widths = np.interp(
+            legend_values, widths[order], np.asarray(linewidths)[order]
+        )
+        labels = [f"{v:g}" for v in legend_values]
+        legend_kwargs = self.default_options["size_legend_kwargs"] or {}
+        return width_legend(ax, legend_widths, labels, **legend_kwargs)
+
+    def plot(
+        self,
+        ax: Axes = None,
+        title: str | None = None,
+        add_colorbar: bool | None = None,
+    ) -> tuple[Figure, Axes, LineCollection]:
+        """Draw the flow paths, colouring by value and scaling by width.
+
+        Builds a `LineCollection` from `paths`. When `values` was supplied,
+        the colour scale, norm, ticks, and colorbar are resolved through
+        `_prepare_scalar_mapping`; otherwise a single-colour collection is
+        drawn with no colorbar. Line widths come from `widths` via
+        `cleopatra.styles.resolve_sizes`, falling back to the scalar
+        `line_width` option. If `size_legend` is truthy and `widths` were
+        given, a width legend is drawn and stored on
+        `self.size_legend_artist`.
+
+        Args:
+            ax: Axes to draw on. Falls back to the axes supplied at
+                construction, otherwise a new figure/axes is created.
+            title: Plot title. Overrides `default_options["title"]` when
+                given.
+            add_colorbar: Override the `add_colorbar` option for this call
+                — True draws the colorbar, False suppresses it. Defaults to
+                None, which keeps the value set at construction.
+
+        Returns:
+            tuple[Figure, Axes, LineCollection]: The figure, the axes, and
+                the `LineCollection` (the mappable the colorbar attaches to
+                when coloured).
+
+        Raises:
+            ValueError: If the values have no finite entries (via
+                `_prepare_scalar_mapping`).
+
+        Examples:
+            - Uncoloured flows draw no colorbar:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.flow_glyph import FlowGlyph
+                >>> paths = [np.array([[0.0, 0.0], [1.0, 1.0]])]
+                >>> glyph = FlowGlyph(paths)
+                >>> fig, ax, lc = glyph.plot()
+                >>> glyph.cbar is None
+                True
+
+                ```
+            - Coloured flows expose the per-path values on the collection:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.flow_glyph import FlowGlyph
+                >>> paths = [
+                ...     np.array([[0.0, 0.0], [1.0, 1.0]]),
+                ...     np.array([[0.0, 1.0], [1.0, 0.0]]),
+                ... ]
+                >>> glyph = FlowGlyph(paths, values=np.array([3.0, 7.0]))
+                >>> fig, ax, lc = glyph.plot(add_colorbar=False)
+                >>> [float(v) for v in lc.get_array()]
+                [3.0, 7.0]
+
+                ```
+        """
+        if ax is not None:
+            self.ax = ax
+            self.fig = ax.get_figure()
+        elif self.ax is None:
+            self.fig, self.ax = self.create_figure_axes()
+        ax = self.ax
+        opts = self.default_options
+
+        if title is not None:
+            opts["title"] = title
+        draw_colorbar = (
+            opts["add_colorbar"] if add_colorbar is None else add_colorbar
+        )
+
+        linewidths = self._resolve_linewidths()
+
+        if self.values is None:
+            lc = LineCollection(
+                self.paths, colors=opts["color_1"], linewidths=linewidths
+            )
+            ax.add_collection(lc)
+        else:
+            norm, cbar_kw, ticks = self._prepare_scalar_mapping(self.values)
+            lc = LineCollection(
+                self.paths,
+                array=np.asarray(self.values),
+                cmap=opts["cmap"],
+                norm=norm,
+                linewidths=linewidths,
+            )
+            if norm is None:
+                lc.set_clim(ticks[0], ticks[-1])
+            ax.add_collection(lc)
+            if draw_colorbar:
+                self.cbar = self.create_color_bar(ax, lc, cbar_kw)
+
+        ax.autoscale_view()
+
+        if self.widths is not None and opts["size_legend"]:
+            self.size_legend_artist = self._draw_width_legend(ax, linewidths)
+
+        if opts["title"]:
+            ax.set_title(opts["title"], fontsize=opts["title_size"])
+
+        return self.fig, ax, lc

--- a/src/cleopatra/flow_glyph.py
+++ b/src/cleopatra/flow_glyph.py
@@ -39,6 +39,7 @@ from matplotlib.figure import Figure
 from matplotlib.legend import Legend
 
 from cleopatra.glyph import Glyph
+from cleopatra.styles import CLASSIFY_OPTIONS
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import resolve_sizes, width_legend
 
@@ -58,7 +59,7 @@ FLOW_DEFAULT_OPTIONS = {
     "ticks_spacing": None,
     "add_colorbar": True,
 }
-FLOW_DEFAULT_OPTIONS = STYLE_DEFAULTS | FLOW_DEFAULT_OPTIONS
+FLOW_DEFAULT_OPTIONS = STYLE_DEFAULTS | CLASSIFY_OPTIONS | FLOW_DEFAULT_OPTIONS
 
 
 class FlowGlyph(Glyph):

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -841,8 +841,6 @@ class Glyph:
         Raises:
             ValueError: Propagated from `classify` (unknown scheme,
                 degenerate data, or `k < 1`).
-            ModuleNotFoundError: Propagated from `classify` when a
-                Jenks-family scheme needs the optional `classify` extra.
 
         Examples:
             - A quantile scheme yields a `BoundaryNorm` and boundary ticks:

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -29,7 +29,7 @@ from matplotlib.ticker import LogFormatter
 from cleopatra.animation import SUPPORTED_VIDEO_FORMAT  # noqa: F401  (re-export)
 from cleopatra.animation import save_animation as _save_animation
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
-from cleopatra.styles import ColorScale, MidpointNormalize
+from cleopatra.styles import ColorScale, MidpointNormalize, classify
 
 #: Upper bound for an integer `levels` value (number of discrete colour
 #: levels / contour lines). A larger request is almost certainly a mistake
@@ -740,6 +740,11 @@ class Glyph:
         easy to get subtly wrong: `get_ticks()` does not read `self._vmin`,
         and `np.arange(None, None)` raises).
 
+        When the `scheme` option is set, the continuous steps above are
+        bypassed: control is handed to `_prepare_classified_mapping`, which
+        bins the data into discrete colour classes (a `BoundaryNorm`).
+        With `scheme` unset (the default) the behaviour is unchanged.
+
         Args:
             values: The scalar array to be colour-mapped (e.g. point
                 values, vector magnitudes, per-polygon values).
@@ -797,9 +802,79 @@ class Glyph:
             self.default_options["ticks_spacing"] = self.ticks_spacing
         self.default_options["vmin"] = self._vmin
         self.default_options["vmax"] = self._vmax
+        scheme = self.default_options.get("scheme")
+        if scheme is not None:
+            # Categorical (classified) colouring short-circuits the
+            # continuous `color_scale` / `levels` machinery: the bin edges
+            # fully determine the discrete `BoundaryNorm` and its ticks.
+            return self._prepare_classified_mapping(values, scheme)
         ticks = self.get_ticks()
         norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
         return norm, cbar_kw, ticks
+
+    def _prepare_classified_mapping(
+        self, values: np.ndarray, scheme: str | list | np.ndarray
+    ) -> tuple[colors.BoundaryNorm, dict, np.ndarray]:
+        """Build the `(norm, cbar_kw, ticks)` triple for classified colouring.
+
+        The discrete sibling of the continuous branch in
+        `_prepare_scalar_mapping`. When the `scheme` option is set, the
+        data is binned into classes by `cleopatra.styles.classify` (using
+        the `k` option for the count/width schemes), and the resulting bin
+        edges drive a `matplotlib.colors.BoundaryNorm` plus a colorbar
+        whose ticks sit on the class boundaries — so `create_color_bar`
+        renders a stepped colorbar. The `color_scale` / `levels` options
+        are intentionally bypassed here; classification owns the norm.
+
+        Args:
+            values: The scalar array to classify and colour-map.
+            scheme: A scheme name accepted by `classify` (e.g.
+                `"quantiles"`, `"equal_interval"`) or an explicit sequence
+                of bin edges.
+
+        Returns:
+            tuple[BoundaryNorm, dict, np.ndarray]: the discrete norm, the
+                colorbar keyword arguments (boundary `ticks` plus
+                `extend`), and the bin edges (returned in the `ticks`
+                slot of the shared contract).
+
+        Raises:
+            ValueError: Propagated from `classify` (unknown scheme,
+                degenerate data, or `k < 1`).
+            ModuleNotFoundError: Propagated from `classify` when a
+                Jenks-family scheme needs the optional `classify` extra.
+
+        Examples:
+            - A quantile scheme yields a `BoundaryNorm` and boundary ticks:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.glyph import Glyph
+                >>> from cleopatra.styles import DEFAULT_OPTIONS
+                >>> opts = DEFAULT_OPTIONS.copy()
+                >>> opts.update(
+                ...     {"vmin": None, "vmax": None, "scheme": "quantiles", "k": 4}
+                ... )
+                >>> g = Glyph(default_options=opts)
+                >>> norm, cbar_kw, edges = g._prepare_classified_mapping(
+                ...     np.arange(100.0), "quantiles"
+                ... )
+                >>> [float(b) for b in norm.boundaries]
+                [0.0, 24.75, 49.5, 74.25, 99.0]
+                >>> [float(t) for t in cbar_kw["ticks"]]
+                [0.0, 24.75, 49.5, 74.25, 99.0]
+                >>> cbar_kw["extend"]
+                'neither'
+
+                ```
+        """
+        k = self.default_options.get("k", 5)
+        bin_edges, norm = classify(values, scheme, k)
+        extend = self.default_options.get("extend")
+        cbar_kw = {
+            "ticks": bin_edges,
+            "extend": "neither" if extend is None else extend,
+        }
+        return norm, cbar_kw, bin_edges
 
     def create_color_bar(self, ax: Axes, im: Any, cbar_kw: dict) -> Colorbar:
         """Create a colorbar with full customization from default_options.

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -867,6 +867,22 @@ class Glyph:
 
                 ```
         """
+        # `scheme` owns the norm, so any continuous `color_scale` / `levels`
+        # the caller also set is ignored here. Warn rather than silently drop
+        # it, so a conflicting configuration is visible.
+        if self.default_options.get("color_scale", "linear") != "linear":
+            warnings.warn(
+                "`scheme` is set, so `color_scale="
+                f"{self.default_options['color_scale']!r}` is ignored "
+                "(classification builds its own discrete norm).",
+                stacklevel=3,
+            )
+        if self.default_options.get("levels") is not None:
+            warnings.warn(
+                "`scheme` is set, so `levels` is ignored (the classification "
+                "scheme determines the bins).",
+                stacklevel=3,
+            )
         k = self.default_options.get("k", 5)
         bin_edges, norm = classify(values, scheme, k)
         extend = self.default_options.get("extend")

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -873,13 +873,13 @@ class Glyph:
                 "`scheme` is set, so `color_scale="
                 f"{self.default_options['color_scale']!r}` is ignored "
                 "(classification builds its own discrete norm).",
-                stacklevel=3,
+                stacklevel=4,
             )
         if self.default_options.get("levels") is not None:
             warnings.warn(
                 "`scheme` is set, so `levels` is ignored (the classification "
                 "scheme determines the bins).",
-                stacklevel=3,
+                stacklevel=4,
             )
         k = self.default_options.get("k", 5)
         bin_edges, norm = classify(values, scheme, k)

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -261,10 +261,12 @@ class KDEGlyph(Glyph):
 
         A `Patch` clips through its own transform. A patch the caller just
         constructed (and has not added to an axes) carries an identity
-        transform, which would clip in display space rather than data space;
-        so when the patch is not attached to an axes its transform is set to
-        `ax.transData` first, matching what `Axes.add_patch` would do. A
-        patch already added to an axes keeps its own transform.
+        transform, which would clip in display space rather than data space.
+        Rather than mutate the caller's patch, an unattached patch is clipped
+        against its geometry directly — its `Path` under
+        `patch_transform + ax.transData` — which is what `Axes.add_patch`
+        would resolve to. A patch already added to an axes is used as-is
+        (its own transform is honoured).
 
         Args:
             contour_set: The `QuadContourSet` returned by
@@ -279,8 +281,11 @@ class KDEGlyph(Glyph):
             return
         if isinstance(clip, Patch):
             if clip.axes is None:
-                clip.set_transform(self.ax.transData)
-            contour_set.set_clip_path(clip)
+                # Clip in data coordinates without mutating the caller's patch.
+                transform = clip.get_patch_transform() + self.ax.transData
+                contour_set.set_clip_path(clip.get_path(), transform)
+            else:
+                contour_set.set_clip_path(clip)
         elif isinstance(clip, MplPath):
             contour_set.set_clip_path(clip, transform=self.ax.transData)
         else:

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -256,8 +256,15 @@ class KDEGlyph(Glyph):
     def _apply_clip(self, contour_set: Any) -> None:
         """Clip the drawn contour set to `self.clip_path`, if any.
 
-        A `Patch` clips directly; a `Path` is clipped in data coordinates
-        (`ax.transData`). No-op when no clip path was supplied.
+        A `Patch` clips in data coordinates; a `Path` is clipped in data
+        coordinates (`ax.transData`). No-op when no clip path was supplied.
+
+        A `Patch` clips through its own transform. A patch the caller just
+        constructed (and has not added to an axes) carries an identity
+        transform, which would clip in display space rather than data space;
+        so when the patch is not attached to an axes its transform is set to
+        `ax.transData` first, matching what `Axes.add_patch` would do. A
+        patch already added to an axes keeps its own transform.
 
         Args:
             contour_set: The `QuadContourSet` returned by
@@ -271,6 +278,8 @@ class KDEGlyph(Glyph):
         if clip is None:
             return
         if isinstance(clip, Patch):
+            if clip.axes is None:
+                clip.set_transform(self.ax.transData)
             contour_set.set_clip_path(clip)
         elif isinstance(clip, MplPath):
             contour_set.set_clip_path(clip, transform=self.ax.transData)

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -1,0 +1,371 @@
+"""2-D kernel-density (isochrone) visualization.
+
+Provides `KDEGlyph` for drawing a 2-D Gaussian kernel-density estimate of a
+point cloud as filled (`contourf`) or line (`contour`) density bands. The
+density is evaluated on a regular grid with a few lines of numpy — **no
+scipy** — and coloured through the shared `Glyph._prepare_scalar_mapping`
+pipeline, so `vmin` / `vmax`, `levels`, `ticks_spacing`, and `color_scale`
+behave exactly as they do for the other glyphs. The glyph is geometry- and
+CRS-agnostic: it takes plain `x` / `y` arrays plus an optional matplotlib
+clip path.
+
+The estimator uses an isotropic Gaussian kernel with Scott's-rule bandwidth
+(scaled by an optional `bw_method` multiplier). It is intended for typical
+scientific point clouds; it is **not** a drop-in for
+`scipy.stats.gaussian_kde` (no anisotropic/diagonal bandwidth, no weights).
+
+Examples:
+    - Filled density of a small cluster:
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.kde_glyph import KDEGlyph
+        >>> rng = np.random.default_rng(0)
+        >>> x = rng.normal(size=200)
+        >>> y = rng.normal(size=200)
+        >>> glyph = KDEGlyph(x, y, gridsize=40)
+        >>> fig, ax, cs = glyph.plot()
+
+        ```
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.patches import Patch
+from matplotlib.path import Path as MplPath
+
+from cleopatra.glyph import Glyph
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+
+#: Upper bound on the number of (grid-cell × data-point) products evaluated in
+#: a single numpy block. The density sum is chunked over the data points so a
+#: large `gridsize` / point count never materialises one giant array; this caps
+#: the temporary at ~`MAX_KDE_BLOCK` floats (a few tens of MB).
+MAX_KDE_BLOCK = 4_000_000
+
+#: Option keys for KDEGlyph. `ticks_spacing` is `None` so the shared
+#: `_prepare_scalar_mapping` helper auto-derives it from the density range.
+KDE_DEFAULT_OPTIONS = {
+    "levels": 10,
+    "shade": True,
+    "bw_method": None,
+    "gridsize": 100,
+    "vmin": None,
+    "vmax": None,
+    "ticks_spacing": None,
+    "add_colorbar": True,
+}
+KDE_DEFAULT_OPTIONS = STYLE_DEFAULTS | KDE_DEFAULT_OPTIONS
+
+
+class KDEGlyph(Glyph):
+    """Visualization class for 2-D kernel-density estimates.
+
+    Evaluates an isotropic Gaussian KDE of a `(x, y)` point cloud on a
+    regular grid (numpy only, no scipy) and draws it as filled or line
+    density contours, coloured through the shared scalar-mapping pipeline.
+
+    Args:
+        x: 1D array of point x-coordinates.
+        y: 1D array of point y-coordinates. Must match the length of `x`.
+        clip_path: Optional matplotlib `Path` or `Patch` that clips the
+            drawn contours (e.g. a country/basin outline supplied by the
+            caller). A `Patch` is used directly; a `Path` is interpreted in
+            data coordinates. Default is None (no clipping).
+        ax: Pre-existing axes to draw on. Default is None.
+        fig: Pre-existing figure. Default is None.
+        **kwargs: Override any key in `KDE_DEFAULT_OPTIONS`: `levels` (int
+            count or explicit sequence of density levels, default 10),
+            `shade` (filled `contourf` vs line `contour`, default True),
+            `bw_method` (None for Scott's rule, or a positive float
+            bandwidth multiplier), `gridsize` (density grid resolution,
+            default 100), plus the shared colour options (`cmap`, `vmin`,
+            `vmax`, `color_scale`, `ticks_spacing`, `cbar_label`,
+            `figsize`, `title`). Set `add_colorbar=False` to suppress the
+            per-glyph colorbar (default True).
+
+    Raises:
+        ValueError: If `x` and `y` have mismatched shapes, if fewer than
+            two points are given, if `bw_method` is non-positive, or if a
+            coordinate has zero spread (a degenerate kernel).
+
+    Examples:
+        - Evaluate the density grid directly (no rendering):
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.kde_glyph import KDEGlyph
+            >>> rng = np.random.default_rng(1)
+            >>> x = rng.normal(size=500)
+            >>> y = rng.normal(size=500)
+            >>> glyph = KDEGlyph(x, y, gridsize=50)
+            >>> gx, gy, density = glyph.evaluate()
+            >>> density.shape
+            (50, 50)
+            >>> bool(density.sum() > 0)
+            True
+
+            ```
+
+    See Also:
+        cleopatra.glyph.Glyph._prepare_scalar_mapping: Shared
+            norm/colorbar/ticks pipeline used to colour the density.
+        cleopatra.mesh_glyph.MeshGlyph: Contour rendering for unstructured
+            meshes.
+    """
+
+    #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = KDE_DEFAULT_OPTIONS
+
+    def __init__(
+        self,
+        x: np.ndarray,
+        y: np.ndarray,
+        *,
+        clip_path: MplPath | Patch | None = None,
+        ax: Axes = None,
+        fig: Figure = None,
+        **kwargs,
+    ):
+        super().__init__(
+            default_options=KDE_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
+        )
+        self.x = np.asarray(x, dtype=float)
+        self.y = np.asarray(y, dtype=float)
+        if self.x.shape != self.y.shape:
+            raise ValueError(
+                f"x and y must have the same shape, got {self.x.shape} "
+                f"and {self.y.shape}."
+            )
+        if self.x.size < 2:
+            raise ValueError(
+                f"KDE needs at least 2 points, got {self.x.size}."
+            )
+        bw_method = self.default_options["bw_method"]
+        if bw_method is not None and bw_method <= 0:
+            raise ValueError(
+                f"bw_method must be a positive float or None, got {bw_method}."
+            )
+        self.clip_path = clip_path
+        self.cbar = None
+
+    def _bandwidth(self) -> float:
+        """Return Scott's-rule bandwidth, scaled by the `bw_method` option.
+
+        Scott's rule in `d` dimensions is `n ** (-1 / (d + 4))`; for the 2-D
+        estimator here that is `n ** (-1 / 6)`. The optional `bw_method`
+        multiplier (default 1.0) widens (`> 1`) or narrows (`< 1`) the kernel.
+
+        Returns:
+            float: The bandwidth factor applied to each coordinate's
+                standard deviation.
+        """
+        n = self.x.size
+        multiplier = self.default_options["bw_method"] or 1.0
+        return multiplier * n ** (-1.0 / 6.0)
+
+    def evaluate(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Evaluate the KDE on a regular grid spanning the point bounds.
+
+        Builds a `gridsize × gridsize` grid over the `[x.min, x.max] ×
+        [y.min, y.max]` bounding box and sums an isotropic Gaussian kernel
+        (Scott's-rule bandwidth) over the points. The sum is chunked over
+        the data points so memory stays bounded (see `MAX_KDE_BLOCK`) even
+        for large `gridsize` or point counts.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray, np.ndarray]: The grid `gx`, `gy`
+                (each `gridsize × gridsize`) and the density evaluated on
+                that grid (same shape), normalised to integrate to ~1.
+
+        Raises:
+            ValueError: If either coordinate has zero spread (its standard
+                deviation is 0), which would give a degenerate kernel.
+
+        Examples:
+            - The density peaks near a tight synthetic cluster:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.kde_glyph import KDEGlyph
+                >>> rng = np.random.default_rng(2)
+                >>> pts = rng.normal(scale=0.1, size=300)
+                >>> x = np.concatenate([pts, pts + 5.0])
+                >>> y = np.concatenate([pts, pts + 5.0])
+                >>> gx, gy, d = KDEGlyph(x, y, gridsize=60).evaluate()
+                >>> peak = np.unravel_index(int(np.argmax(d)), d.shape)
+                >>> bool(min(abs(gx[peak] - 0.0), abs(gx[peak] - 5.0)) < 1.0)
+                True
+
+                ```
+        """
+        x, y = self.x, self.y
+        n = x.size
+        bw = self._bandwidth()
+        sx, sy = x.std() * bw, y.std() * bw
+        if sx == 0 or sy == 0:
+            raise ValueError(
+                "Cannot build a KDE: a coordinate has zero spread "
+                "(degenerate kernel). Provide points that vary in x and y."
+            )
+
+        gridsize = int(self.default_options["gridsize"])
+        gx, gy = np.meshgrid(
+            np.linspace(x.min(), x.max(), gridsize),
+            np.linspace(y.min(), y.max(), gridsize),
+        )
+        gx_flat = gx.ravel()[:, None]
+        gy_flat = gy.ravel()[:, None]
+
+        # Sum the kernel over the points in blocks so the temporary
+        # (grid-cells × block) array never exceeds ~MAX_KDE_BLOCK floats.
+        block = max(1, MAX_KDE_BLOCK // gx_flat.shape[0])
+        density_flat = np.zeros(gx_flat.shape[0], dtype=float)
+        for start in range(0, n, block):
+            xs = x[start:start + block]
+            ys = y[start:start + block]
+            dx = (gx_flat - xs) / sx
+            dy = (gy_flat - ys) / sy
+            density_flat += np.exp(-0.5 * (dx ** 2 + dy ** 2)).sum(axis=1)
+
+        density = density_flat.reshape(gx.shape) / (2.0 * np.pi * sx * sy * n)
+        return gx, gy, density
+
+    def _resolve_levels(self, density: np.ndarray) -> np.ndarray:
+        """Resolve the `levels` option to explicit, increasing density edges.
+
+        An integer becomes that many evenly-spaced edges across the density
+        range; an explicit sequence is sorted and used verbatim. Returning
+        explicit edges (rather than an int) keeps `contourf`/`contour` in
+        step with the `BoundaryNorm` the shared pipeline builds from the
+        same `levels` option.
+
+        Args:
+            density: The evaluated density grid (for its value range).
+
+        Returns:
+            np.ndarray: The sorted, increasing contour level edges.
+        """
+        levels = self.default_options["levels"]
+        if isinstance(levels, (int, np.integer)) and not isinstance(levels, bool):
+            return np.linspace(float(density.min()), float(density.max()), int(levels))
+        return np.sort(np.asarray(levels, dtype=float))
+
+    def _apply_clip(self, contour_set: Any) -> None:
+        """Clip the drawn contour set to `self.clip_path`, if any.
+
+        A `Patch` clips directly; a `Path` is clipped in data coordinates
+        (`ax.transData`). No-op when no clip path was supplied.
+
+        Args:
+            contour_set: The `QuadContourSet` returned by
+                `contourf`/`contour`.
+
+        Raises:
+            TypeError: If `clip_path` is neither a matplotlib `Path` nor a
+                `Patch`.
+        """
+        clip = self.clip_path
+        if clip is None:
+            return
+        if isinstance(clip, Patch):
+            contour_set.set_clip_path(clip)
+        elif isinstance(clip, MplPath):
+            contour_set.set_clip_path(clip, transform=self.ax.transData)
+        else:
+            raise TypeError(
+                "clip_path must be a matplotlib Path or Patch, got "
+                f"{type(clip).__name__}."
+            )
+
+    def plot(
+        self,
+        ax: Axes = None,
+        title: str | None = None,
+        add_colorbar: bool | None = None,
+    ):
+        """Render the 2-D density as filled or line contours.
+
+        Evaluates the KDE via `evaluate`, colours it through
+        `_prepare_scalar_mapping`, and draws `contourf` (when `shade`) or
+        `contour` (otherwise). An optional `clip_path` restricts the drawn
+        contours.
+
+        Args:
+            ax: Axes to draw on. Falls back to the axes supplied at
+                construction, otherwise a new figure/axes is created.
+            title: Plot title. Overrides `default_options["title"]` when
+                given.
+            add_colorbar: Override the `add_colorbar` option for this call
+                — True draws the colorbar, False suppresses it. Defaults to
+                None, which keeps the value set at construction.
+
+        Returns:
+            tuple[Figure, Axes, QuadContourSet]: The figure, the axes, and
+                the contour set (the mappable the colorbar attaches to).
+
+        Raises:
+            ValueError: If a coordinate has zero spread (via `evaluate`).
+            TypeError: If `clip_path` is an unsupported type (via the clip
+                step).
+
+        Examples:
+            - Filled contours add a colorbar by default:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.kde_glyph import KDEGlyph
+                >>> rng = np.random.default_rng(3)
+                >>> x, y = rng.normal(size=300), rng.normal(size=300)
+                >>> glyph = KDEGlyph(x, y, gridsize=40)
+                >>> fig, ax, cs = glyph.plot()
+                >>> glyph.cbar is not None
+                True
+
+                ```
+            - Line contours (`shade=False`) and no colorbar:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.kde_glyph import KDEGlyph
+                >>> rng = np.random.default_rng(4)
+                >>> x, y = rng.normal(size=300), rng.normal(size=300)
+                >>> glyph = KDEGlyph(x, y, gridsize=40, shade=False)
+                >>> fig, ax, cs = glyph.plot(add_colorbar=False)
+                >>> glyph.cbar is None
+                True
+
+                ```
+        """
+        if ax is not None:
+            self.ax = ax
+            self.fig = ax.get_figure()
+        elif self.ax is None:
+            self.fig, self.ax = self.create_figure_axes()
+        ax = self.ax
+        opts = self.default_options
+
+        if title is not None:
+            opts["title"] = title
+        draw_colorbar = (
+            opts["add_colorbar"] if add_colorbar is None else add_colorbar
+        )
+
+        gx, gy, density = self.evaluate()
+        level_edges = self._resolve_levels(density)
+        norm, cbar_kw, _ = self._prepare_scalar_mapping(density)
+
+        render = ax.contourf if opts["shade"] else ax.contour
+        contour_set = render(
+            gx, gy, density, levels=level_edges, cmap=opts["cmap"], norm=norm
+        )
+        self._apply_clip(contour_set)
+        self.im = contour_set
+
+        if draw_colorbar:
+            self.cbar = self.create_color_bar(ax, contour_set, cbar_kw)
+
+        if opts["title"]:
+            ax.set_title(opts["title"], fontsize=opts["title_size"])
+
+        return self.fig, ax, contour_set

--- a/src/cleopatra/polygon_glyph.py
+++ b/src/cleopatra/polygon_glyph.py
@@ -40,6 +40,7 @@ from matplotlib.collections import PolyCollection
 from matplotlib.figure import Figure
 
 from cleopatra.glyph import Glyph
+from cleopatra.styles import CLASSIFY_OPTIONS
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 
 #: Option keys for PolygonGlyph. `ticks_spacing` is `None` so the shared
@@ -53,7 +54,7 @@ POLYGON_DEFAULT_OPTIONS = {
     "ticks_spacing": None,
     "add_colorbar": True,
 }
-POLYGON_DEFAULT_OPTIONS = STYLE_DEFAULTS | POLYGON_DEFAULT_OPTIONS
+POLYGON_DEFAULT_OPTIONS = STYLE_DEFAULTS | CLASSIFY_OPTIONS | POLYGON_DEFAULT_OPTIONS
 
 
 class PolygonGlyph(Glyph):

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -42,6 +42,7 @@ from matplotlib.figure import Figure
 from matplotlib.legend import Legend
 
 from cleopatra.glyph import Glyph
+from cleopatra.styles import CLASSIFY_OPTIONS
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import resolve_sizes, size_legend
 
@@ -63,7 +64,7 @@ SCATTER_DEFAULT_OPTIONS = {
     "size_legend_values": None,
     "size_legend_kwargs": None,
 }
-SCATTER_DEFAULT_OPTIONS = STYLE_DEFAULTS | SCATTER_DEFAULT_OPTIONS
+SCATTER_DEFAULT_OPTIONS = STYLE_DEFAULTS | CLASSIFY_OPTIONS | SCATTER_DEFAULT_OPTIONS
 
 
 class ScatterGlyph(Glyph):

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -39,12 +39,16 @@ import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.collections import PathCollection
 from matplotlib.figure import Figure
+from matplotlib.legend import Legend
 
 from cleopatra.glyph import Glyph
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+from cleopatra.styles import resolve_sizes, size_legend
 
 #: Option keys for ScatterGlyph. `ticks_spacing` is `None` so the shared
 #: `_prepare_scalar_mapping` helper auto-derives it from the data range.
+#: The `size_*` keys drive value→size scaling and its legend (see `plot`);
+#: they are inert unless a `sizes` array is supplied at construction.
 SCATTER_DEFAULT_OPTIONS = {
     "marker": "o",
     "point_size": 20,
@@ -53,6 +57,11 @@ SCATTER_DEFAULT_OPTIONS = {
     "levels": None,
     "ticks_spacing": None,
     "add_colorbar": True,
+    "size_limits": (10, 200),
+    "size_scale": "linear",
+    "size_legend": False,
+    "size_legend_values": None,
+    "size_legend_kwargs": None,
 }
 SCATTER_DEFAULT_OPTIONS = STYLE_DEFAULTS | SCATTER_DEFAULT_OPTIONS
 
@@ -63,7 +72,9 @@ class ScatterGlyph(Glyph):
     Wraps `matplotlib.axes.Axes.scatter`. With no `values`, points are
     drawn in a single colour. With a per-point `values` array, points
     are colour-mapped through the shared scalar-mapping pipeline and a
-    matching colorbar is attached.
+    matching colorbar is attached. An independent per-point `sizes` array
+    scales the marker area (with an optional size legend), so colour and
+    size can encode two different quantities at once.
 
     Args:
         x: 1D array of point x-coordinates.
@@ -72,6 +83,11 @@ class ScatterGlyph(Glyph):
         values: Optional 1D array of per-point scalar values used for
             colour mapping. Must match the length of `x` when given.
             Default is None (uncoloured points).
+        sizes: Optional 1D array of per-point magnitudes used for *size*
+            mapping (kept separate from `values`, which drives colour, so a
+            point can encode both). Must match the length of `x` when
+            given. When None, the scalar `point_size` option is used for
+            every point (the original behaviour). Default is None.
         ax: Pre-existing axes to draw on. Default is None.
         fig: Pre-existing figure. Default is None.
         **kwargs: Override any key in `SCATTER_DEFAULT_OPTIONS`
@@ -79,11 +95,17 @@ class ScatterGlyph(Glyph):
             `levels`, `color_scale`, `ticks_spacing`, `cbar_label`,
             `figsize`, `title`). Set `add_colorbar=False` to suppress the
             per-glyph colorbar (default True) for shared-axes composition
-            where the host owns a single aggregated colorbar.
+            where the host owns a single aggregated colorbar. The
+            `size_limits` (min/max marker area in points², default
+            `(10, 200)`), `size_scale` (`"linear"` / `"log"` / `"sqrt"`,
+            default `"linear"`), `size_legend` (bool, default False),
+            `size_legend_values` (explicit representative magnitudes), and
+            `size_legend_kwargs` (forwarded to the legend) options control
+            the `sizes` mapping and its legend.
 
     Raises:
-        ValueError: If `x` and `y` (or `values`, when given) have
-            mismatched lengths.
+        ValueError: If `x` and `y` (or `values` / `sizes`, when given)
+            have mismatched lengths.
 
     Examples:
         - Colour points by value and read back the mapped array:
@@ -100,10 +122,29 @@ class ScatterGlyph(Glyph):
             [1.0, 5.0, 9.0]
 
             ```
+        - Size points by a magnitude; the areas span `size_limits`:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.scatter_glyph import ScatterGlyph
+            >>> glyph = ScatterGlyph(
+            ...     np.array([0.0, 1.0, 2.0]),
+            ...     np.array([0.0, 1.0, 0.0]),
+            ...     sizes=np.array([1.0, 5.0, 9.0]),
+            ...     size_limits=(10, 200),
+            ... )
+            >>> fig, ax, paths = glyph.plot()
+            >>> [float(s) for s in paths.get_sizes()]
+            [10.0, 105.0, 200.0]
+
+            ```
 
     See Also:
         cleopatra.glyph.Glyph._prepare_scalar_mapping: Shared
             norm/colorbar/ticks pipeline used for the coloured path.
+        cleopatra.styles.resolve_sizes: The value→size helper used for the
+            `sizes` mapping (reusable by other size-encoding glyphs).
+        cleopatra.styles.size_legend: Builds the size legend drawn when
+            `size_legend` is truthy.
     """
 
     #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
@@ -115,6 +156,7 @@ class ScatterGlyph(Glyph):
         y: np.ndarray,
         values: np.ndarray | None = None,
         *,
+        sizes: np.ndarray | None = None,
         ax: Axes = None,
         fig: Figure = None,
         **kwargs,
@@ -136,8 +178,19 @@ class ScatterGlyph(Glyph):
                     f"values must match x/y shape {self.x.shape}, got "
                     f"{values.shape}."
                 )
+        if sizes is not None:
+            sizes = np.asarray(sizes)
+            if sizes.shape != self.x.shape:
+                raise ValueError(
+                    f"sizes must match x/y shape {self.x.shape}, got "
+                    f"{sizes.shape}."
+                )
         self.values = values
+        self.sizes = sizes
         self.cbar = None
+        #: The size legend created by `plot` when `size_legend` is truthy
+        #: (None otherwise); built via `cleopatra.styles.size_legend`.
+        self.size_legend_artist = None
 
     def plot(
         self,
@@ -145,13 +198,21 @@ class ScatterGlyph(Glyph):
         title: str | None = None,
         add_colorbar: bool | None = None,
     ) -> tuple[Figure, Axes, PathCollection]:
-        """Draw the point cloud, colour-mapping by value when present.
+        """Draw the point cloud, colour- and/or size-mapping per point.
 
         When `values` was supplied at construction, the colour scale,
         norm, ticks, and colorbar are resolved through
         `_prepare_scalar_mapping`, so `vmin` / `vmax` / `levels` /
         `color_scale` behave as for the other glyphs. With no values,
         a single-colour scatter is drawn and no colorbar is added.
+
+        When `sizes` was supplied, each marker's area is resolved from
+        that magnitude via `cleopatra.styles.resolve_sizes` (honouring
+        `size_limits` / `size_scale`); otherwise the scalar `point_size`
+        option is used for every point. Colour and size are independent,
+        so a point can encode two quantities at once. If `size_legend` is
+        truthy, a size legend is drawn via `cleopatra.styles.size_legend`
+        and stored on `self.size_legend_artist`.
 
         Args:
             ax: Axes to draw on. Falls back to the axes supplied at
@@ -193,6 +254,24 @@ class ScatterGlyph(Glyph):
                 'Stations'
 
                 ```
+            - Combine colour and size, with a size legend:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.scatter_glyph import ScatterGlyph
+                >>> glyph = ScatterGlyph(
+                ...     np.array([0.0, 1.0, 2.0]),
+                ...     np.array([0.0, 1.0, 0.0]),
+                ...     values=np.array([1.0, 2.0, 3.0]),
+                ...     sizes=np.array([5.0, 10.0, 20.0]),
+                ...     size_legend=True,
+                ... )
+                >>> fig, ax, paths = glyph.plot()
+                >>> bool(paths.get_sizes()[0] < paths.get_sizes()[-1])
+                True
+                >>> glyph.size_legend_artist is not None
+                True
+
+                ```
         """
         if ax is not None:
             self.ax = ax
@@ -210,11 +289,13 @@ class ScatterGlyph(Glyph):
             opts["add_colorbar"] if add_colorbar is None else add_colorbar
         )
 
+        marker_area = self._resolve_marker_area()
+
         if self.values is None:
             paths = ax.scatter(
                 self.x,
                 self.y,
-                s=opts["point_size"],
+                s=marker_area,
                 marker=opts["marker"],
             )
         else:
@@ -223,7 +304,7 @@ class ScatterGlyph(Glyph):
                 self.x,
                 self.y,
                 c=np.asarray(self.values),
-                s=opts["point_size"],
+                s=marker_area,
                 marker=opts["marker"],
                 cmap=opts["cmap"],
                 norm=norm,
@@ -233,7 +314,62 @@ class ScatterGlyph(Glyph):
             if draw_colorbar:
                 self.cbar = self.create_color_bar(ax, paths, cbar_kw)
 
+        if self.sizes is not None and opts["size_legend"]:
+            self.size_legend_artist = self._draw_size_legend(ax, marker_area)
+
         if opts["title"]:
             ax.set_title(opts["title"], fontsize=opts["title_size"])
 
         return self.fig, ax, paths
+
+    def _resolve_marker_area(self) -> float | np.ndarray:
+        """Resolve the scatter `s` (marker area) for this glyph.
+
+        Returns the per-point areas mapped from `sizes` when a `sizes`
+        array was supplied (via `cleopatra.styles.resolve_sizes`, honouring
+        the `size_limits` / `size_scale` options), or the scalar
+        `point_size` option when no `sizes` were given.
+
+        Returns:
+            float or np.ndarray: A scalar area (no `sizes`) or a per-point
+                area array spanning `size_limits` monotonically in `sizes`.
+        """
+        if self.sizes is None:
+            return self.default_options["point_size"]
+        size_min, size_max = self.default_options["size_limits"]
+        return resolve_sizes(
+            self.sizes,
+            size_min,
+            size_max,
+            scale=self.default_options["size_scale"],
+        )
+
+    def _draw_size_legend(self, ax: Axes, marker_area: np.ndarray) -> Legend:
+        """Draw a size legend for the resolved per-point areas.
+
+        Picks representative magnitudes (`size_legend_values`, or the min /
+        median / max of `sizes` when unset), maps each to its plotted
+        marker area by interpolating the already-computed `(sizes ->
+        marker_area)` mapping (so the swatches match the points exactly),
+        and hands them to `cleopatra.styles.size_legend`.
+
+        Args:
+            ax: The axes to attach the legend to.
+            marker_area: The per-point marker areas returned by
+                `_resolve_marker_area`.
+
+        Returns:
+            matplotlib.legend.Legend: The size legend added to `ax`.
+        """
+        sizes = np.asarray(self.sizes, dtype=float)
+        legend_values = self.default_options["size_legend_values"]
+        if legend_values is None:
+            legend_values = np.quantile(sizes, [0.0, 0.5, 1.0])
+        legend_values = np.asarray(legend_values, dtype=float)
+        order = np.argsort(sizes)
+        legend_areas = np.interp(
+            legend_values, sizes[order], np.asarray(marker_area)[order]
+        )
+        labels = [f"{v:g}" for v in legend_values]
+        legend_kwargs = self.default_options["size_legend_kwargs"] or {}
+        return size_legend(ax, legend_areas, labels, **legend_kwargs)

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -15,6 +15,7 @@ from matplotlib.cm import ScalarMappable
 from matplotlib.colorbar import Colorbar
 from matplotlib.container import BarContainer
 from matplotlib.legend import Legend
+from matplotlib.lines import Line2D
 from matplotlib.patches import Patch
 
 
@@ -585,6 +586,119 @@ class Scale:
         return new_value
 
 
+#: Accepted values for the `size_scale` of `resolve_sizes` — the transform
+#: applied to the magnitudes before they are linearly rescaled into the output
+#: range. `"sqrt"` matches perceived marker *area*; `"log"` suits magnitudes
+#: that span orders of magnitude.
+SIZE_SCALES = ("linear", "log", "sqrt")
+
+
+def resolve_sizes(
+    values: np.ndarray | Sequence[float],
+    out_min: float,
+    out_max: float,
+    scale: str = "linear",
+) -> np.ndarray:
+    """Map per-item magnitudes to a visual size range.
+
+    The reusable value→size primitive shared by size-encoding glyphs: it
+    turns a per-item magnitude array into an array of visual sizes spanning
+    `[out_min, out_max]`, optionally pre-transforming the magnitudes
+    (`"log"` / `"sqrt"`) before the linear rescale. `ScatterGlyph` uses it
+    for marker area (`s`); a future `FlowGlyph` can reuse it for line width.
+    The linear rescale itself is delegated to `Scale.rescale`, so this never
+    re-implements the range mapping.
+
+    The mapping is monotonic in the input, so larger magnitudes always map
+    to larger sizes. When every (finite) magnitude is equal, there is no
+    spread to encode and the midpoint of the output range is returned for
+    each item.
+
+    Args:
+        values: The per-item magnitudes to map. Non-finite entries are kept
+            in place in the output (mapped from a domain that ignores them)
+            — callers that pre-filter their data will not hit this.
+        out_min: The smallest output size (maps to the minimum magnitude).
+        out_max: The largest output size (maps to the maximum magnitude).
+        scale: The pre-transform: `"linear"` (identity), `"log"`
+            (`log10`, requires strictly positive magnitudes), or `"sqrt"`
+            (requires non-negative magnitudes). Case-insensitive. Default
+            is `"linear"`.
+
+    Returns:
+        np.ndarray: The mapped sizes, the same shape as `values`, spanning
+            `[out_min, out_max]` for non-degenerate input.
+
+    Raises:
+        ValueError: If `values` has no finite entries, if `scale` is not one
+            of `SIZE_SCALES`, if `scale="log"` and any magnitude is
+            non-positive, or if `scale="sqrt"` and any magnitude is negative.
+
+    Examples:
+        - Linear mapping spans the output range, smallest→`out_min`:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import resolve_sizes
+            >>> sizes = resolve_sizes(np.array([0.0, 5.0, 10.0]), 10.0, 200.0)
+            >>> [float(s) for s in sizes]
+            [10.0, 105.0, 200.0]
+
+            ```
+        - The mapping is monotonic, so ranking is preserved:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import resolve_sizes
+            >>> sizes = resolve_sizes(np.array([3.0, 1.0, 2.0]), 0.0, 1.0)
+            >>> bool(sizes[1] < sizes[2] < sizes[0])
+            True
+
+            ```
+        - All-equal magnitudes map to the output midpoint:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import resolve_sizes
+            >>> [float(s) for s in resolve_sizes(np.full(3, 4.0), 10.0, 50.0)]
+            [30.0, 30.0, 30.0]
+
+            ```
+    """
+    values = np.asarray(values, dtype=float)
+    scale = str(scale).lower()
+    if scale not in SIZE_SCALES:
+        valid = ", ".join(repr(s) for s in SIZE_SCALES)
+        raise ValueError(
+            f"Invalid size_scale {scale!r}. Expected one of {valid}."
+        )
+    finite = values[np.isfinite(values)]
+    if finite.size == 0:
+        raise ValueError(
+            "Cannot resolve sizes: `values` has no finite entries."
+        )
+    if scale == "log":
+        if np.any(finite <= 0):
+            raise ValueError(
+                "size_scale='log' requires strictly positive magnitudes."
+            )
+        transformed = Scale.log_scale(values)
+        domain = Scale.log_scale(finite)
+    elif scale == "sqrt":
+        if np.any(finite < 0):
+            raise ValueError(
+                "size_scale='sqrt' requires non-negative magnitudes."
+            )
+        transformed = np.sqrt(values)
+        domain = np.sqrt(finite)
+    else:  # linear
+        transformed = values
+        domain = finite
+
+    lo, hi = float(domain.min()), float(domain.max())
+    if hi == lo:
+        midpoint = (out_min + out_max) / 2.0
+        return np.full(values.shape, midpoint, dtype=float)
+    return Scale.rescale(transformed, lo, hi, out_min, out_max)
+
+
 class MidpointNormalize(colors.Normalize):
     """A normalization class that scales data with a midpoint.
 
@@ -875,6 +989,92 @@ def disjoint_legend(
     handles = [
         Patch(facecolor=color, edgecolor=edgecolor, label=label)
         for color, label in zip(colors, labels)
+    ]
+    return ax.legend(handles=handles, **kwargs)
+
+
+def size_legend(
+    ax: Axes,
+    marker_sizes: Sequence[float],
+    labels: Sequence[str],
+    *,
+    color: str = "0.4",
+    marker: str = "o",
+    **kwargs,
+) -> Legend:
+    """Attach a legend whose marker *sizes* encode magnitude.
+
+    The size counterpart to `disjoint_legend`: where that varies the swatch
+    *colour*, this varies the marker *size*, so it is the right legend for a
+    bubble / size-scaled scatter (e.g. `ScatterGlyph(..., sizes=...)`). One
+    proxy marker is drawn per entry, sized to match the points it
+    represents.
+
+    `marker_sizes` are scatter-style **areas** (points², the same unit as a
+    glyph's resolved `s`); each is converted to the matplotlib `Line2D`
+    `markersize` (a diameter in points) via `sqrt`, so the swatches match
+    the plotted points visually.
+
+    Args:
+        ax: The axes the legend is attached to.
+        marker_sizes: The representative marker areas (points²), one per
+            legend entry. Must be the same length as `labels`.
+        labels: The text drawn next to each marker. Must be the same length
+            as `marker_sizes`.
+        color: Fill colour for every proxy marker. Defaults to a neutral
+            grey (`"0.4"`) because the legend encodes size, not colour.
+        marker: The marker style for the proxies. Defaults to `"o"`.
+        **kwargs: Forwarded verbatim to `Axes.legend` (e.g. `title`, `loc`,
+            `labelspacing`, `bbox_to_anchor`).
+
+    Returns:
+        Legend: The created legend artist, already added to `ax`.
+
+    Raises:
+        ValueError: If `marker_sizes` and `labels` have different lengths.
+
+    Examples:
+        - Build a three-entry size legend and read back its labels:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import size_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = size_legend(ax, [20.0, 100.0, 200.0], ["low", "mid", "high"])
+            >>> [t.get_text() for t in legend.get_texts()]
+            ['low', 'mid', 'high']
+
+            ```
+        - Larger areas produce larger proxy markers (diameters in points):
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import size_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = size_legend(ax, [16.0, 64.0], ["small", "big"])
+            >>> handles = legend.legend_handles
+            >>> round(handles[0].get_markersize(), 1), round(handles[1].get_markersize(), 1)
+            (4.0, 8.0)
+
+            ```
+    """
+    marker_sizes = list(marker_sizes)
+    labels = list(labels)
+    if len(marker_sizes) != len(labels):
+        raise ValueError(
+            "marker_sizes and labels must have the same length, got "
+            f"{len(marker_sizes)} and {len(labels)}."
+        )
+    handles = [
+        Line2D(
+            [],
+            [],
+            linestyle="none",
+            marker=marker,
+            markerfacecolor=color,
+            markeredgecolor=color,
+            markersize=np.sqrt(max(size, 0.0)),
+            label=label,
+        )
+        for size, label in zip(marker_sizes, labels)
     ]
     return ax.legend(handles=handles, **kwargs)
 

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -762,6 +762,7 @@ class MidpointNormalize(colors.Normalize):
     Create a normalization with a non-zero midpoint (5):
     ```python
     >>> norm = MidpointNormalize(vmin=0, vmax=10, midpoint=5)
+
     ```
     - Values below midpoint are mapped to [0, 0.5]
     ```python

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -111,6 +111,15 @@ DEFAULT_OPTIONS = {
     "bounds": None,
     "midpoint": 0,
     "grid_alpha": 0.75,
+}
+
+#: Classification options (`scheme` selects a `classify` scheme or explicit
+#: bin edges; `k` is the class count). Mixed into the option dicts of glyphs
+#: whose colour mapping routes through `Glyph._prepare_scalar_mapping` — kept
+#: out of the shared `DEFAULT_OPTIONS` so glyphs that bypass that pipeline
+#: (e.g. `ArrayGlyph` / `MeshGlyph`) reject `scheme` instead of silently
+#: ignoring it.
+CLASSIFY_OPTIONS = {
     "scheme": None,
     "k": 5,
 }
@@ -615,9 +624,9 @@ def resolve_sizes(
     each item.
 
     Args:
-        values: The per-item magnitudes to map. Non-finite entries are kept
-            in place in the output (mapped from a domain that ignores them)
-            — callers that pre-filter their data will not hit this.
+        values: The per-item magnitudes to map. Must be finite — a
+            non-finite entry (`NaN`/`inf`) would map to a `NaN` size, so it
+            is rejected rather than silently rendered as a broken marker.
         out_min: The smallest output size (maps to the minimum magnitude).
         out_max: The largest output size (maps to the maximum magnitude).
         scale: The pre-transform: `"linear"` (identity), `"log"`
@@ -630,9 +639,10 @@ def resolve_sizes(
             `[out_min, out_max]` for non-degenerate input.
 
     Raises:
-        ValueError: If `values` has no finite entries, if `scale` is not one
-            of `SIZE_SCALES`, if `scale="log"` and any magnitude is
-            non-positive, or if `scale="sqrt"` and any magnitude is negative.
+        ValueError: If `values` is empty or contains non-finite entries, if
+            `scale` is not one of `SIZE_SCALES`, if `scale="log"` and any
+            magnitude is non-positive, or if `scale="sqrt"` and any
+            magnitude is negative.
 
     Examples:
         - Linear mapping spans the output range, smallest→`out_min`:
@@ -669,30 +679,32 @@ def resolve_sizes(
         raise ValueError(
             f"Invalid size_scale {scale!r}. Expected one of {valid}."
         )
-    finite = values[np.isfinite(values)]
-    if finite.size == 0:
+    if values.size == 0:
+        raise ValueError("Cannot resolve sizes: `values` is empty.")
+    # Reject non-finite entries up front: a NaN/inf magnitude would map to a
+    # NaN size, which renders as an invisible or broken marker rather than
+    # failing loudly. Callers should clean their data first.
+    if not np.all(np.isfinite(values)):
         raise ValueError(
-            "Cannot resolve sizes: `values` has no finite entries."
+            "Cannot resolve sizes: `values` contains non-finite entries "
+            "(NaN/inf). Filter them before mapping to sizes."
         )
     if scale == "log":
-        if np.any(finite <= 0):
+        if np.any(values <= 0):
             raise ValueError(
                 "size_scale='log' requires strictly positive magnitudes."
             )
         transformed = Scale.log_scale(values)
-        domain = Scale.log_scale(finite)
     elif scale == "sqrt":
-        if np.any(finite < 0):
+        if np.any(values < 0):
             raise ValueError(
                 "size_scale='sqrt' requires non-negative magnitudes."
             )
         transformed = np.sqrt(values)
-        domain = np.sqrt(finite)
     else:  # linear
         transformed = values
-        domain = finite
 
-    lo, hi = float(domain.min()), float(domain.max())
+    lo, hi = float(transformed.min()), float(transformed.max())
     if hi == lo:
         midpoint = (out_min + out_max) / 2.0
         return np.full(values.shape, midpoint, dtype=float)

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -1079,6 +1079,75 @@ def size_legend(
     return ax.legend(handles=handles, **kwargs)
 
 
+def width_legend(
+    ax: Axes,
+    linewidths: Sequence[float],
+    labels: Sequence[str],
+    *,
+    color: str = "0.4",
+    **kwargs,
+) -> Legend:
+    """Attach a legend whose line *widths* encode magnitude.
+
+    The line-width counterpart to `size_legend` (which varies marker size):
+    each entry is a short line drawn at the given `linewidth`, so it is the
+    right legend for a width-scaled flow / Sankey map
+    (e.g. `FlowGlyph(..., widths=...)`).
+
+    Args:
+        ax: The axes the legend is attached to.
+        linewidths: The representative line widths (points), one per legend
+            entry. Must be the same length as `labels`.
+        labels: The text drawn next to each line. Must be the same length as
+            `linewidths`.
+        color: Colour for every proxy line. Defaults to a neutral grey
+            (`"0.4"`) because the legend encodes width, not colour.
+        **kwargs: Forwarded verbatim to `Axes.legend` (e.g. `title`, `loc`,
+            `labelspacing`, `bbox_to_anchor`).
+
+    Returns:
+        Legend: The created legend artist, already added to `ax`.
+
+    Raises:
+        ValueError: If `linewidths` and `labels` have different lengths.
+
+    Examples:
+        - Build a width legend and read back its labels:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import width_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = width_legend(ax, [1.0, 3.0, 5.0], ["low", "mid", "high"])
+            >>> [t.get_text() for t in legend.get_texts()]
+            ['low', 'mid', 'high']
+
+            ```
+        - Larger magnitudes give thicker proxy lines:
+            ```python
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styles import width_legend
+            >>> fig, ax = plt.subplots()
+            >>> legend = width_legend(ax, [1.0, 4.0], ["thin", "thick"])
+            >>> handles = legend.legend_handles
+            >>> handles[0].get_linewidth(), handles[1].get_linewidth()
+            (1.0, 4.0)
+
+            ```
+    """
+    linewidths = list(linewidths)
+    labels = list(labels)
+    if len(linewidths) != len(labels):
+        raise ValueError(
+            "linewidths and labels must have the same length, got "
+            f"{len(linewidths)} and {len(labels)}."
+        )
+    handles = [
+        Line2D([], [], color=color, linewidth=lw, label=label)
+        for lw, label in zip(linewidths, labels)
+    ]
+    return ax.legend(handles=handles, **kwargs)
+
+
 def colorbar_legend(mappable: ScalarMappable, ax: Axes = None, **kwargs) -> Colorbar:
     """Attach a continuous colorbar legend for a mappable.
 

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -1325,17 +1325,17 @@ def histogram_legend(
     return ax.barh(centers, counts, height=widths, color=bar_colors, **bar_kwargs)
 
 
-#: Classification schemes that need nothing beyond numpy. Anything outside
-#: this set (the Jenks-family `"fisher_jenks"` / `"natural_breaks"`) is routed
-#: to the optional, lazily-imported `cleopatra[classify]` extra (mapclassify)
-#: so the default install stays numpy + matplotlib only.
+#: Count/width/spread classification schemes (simple closed-form breaks).
 NUMPY_SCHEMES = ("quantiles", "equal_interval", "percentiles", "std_mean")
 
-#: Jenks-family schemes that require the optional `cleopatra[classify]` extra.
+#: Jenks-family schemes computed by the native Fisher-Jenks optimisation
+#: (`_fisher_jenks_edges`). `"natural_breaks"` is an alias of `"fisher_jenks"`:
+#: both minimise the within-class sum of squared deviations. No dependency
+#: beyond numpy — the whole package stays numpy + matplotlib only.
 JENKS_SCHEMES = ("fisher_jenks", "natural_breaks")
 
-#: Standard-deviation multiples used by the `"std_mean"` scheme (mean ± nσ).
-#: Matches mapclassify's `StdMean` default; `k` is ignored for this scheme.
+#: Standard-deviation multiples used by the `"std_mean"` scheme (mean ± nσ);
+#: `k` is ignored for this scheme.
 _STD_MEAN_MULTIPLES = (-2.0, -1.0, 0.0, 1.0, 2.0)
 
 
@@ -1367,8 +1367,9 @@ def classify(
       for this scheme (the number of classes follows from the multiples).
 
     The Jenks-family schemes `"fisher_jenks"` and `"natural_breaks"` are
-    routed to the optional `cleopatra[classify]` extra (`mapclassify`),
-    imported lazily so the default install never needs it.
+    computed by the native Fisher-Jenks optimisation — the exact dynamic
+    program that minimises the within-class sum of squared deviations. Both
+    names are aliases for the same algorithm. No dependency beyond numpy.
 
     A non-string `scheme` is treated as an explicit, already-chosen
     sequence of bin edges (sorted ascending); `k` is ignored.
@@ -1392,9 +1393,6 @@ def classify(
         ValueError: If `values` has no finite entries, if `k < 1`, if the
             (finite) data has no spread so fewer than two distinct edges
             result, or if `scheme` is an unrecognised name.
-        ModuleNotFoundError: If a Jenks-family scheme is requested but the
-            optional `cleopatra[classify]` extra (mapclassify) is not
-            installed.
 
     Examples:
         - Equal-interval edges on a 0–10 ramp:
@@ -1479,8 +1477,6 @@ def _scheme_edges(finite: np.ndarray, scheme: str, k: int) -> np.ndarray:
     Raises:
         ValueError: If `k < 1` (for the `k`-driven schemes) or `scheme`
             is not a recognised name.
-        ModuleNotFoundError: If a Jenks-family scheme is requested without
-            the optional `cleopatra[classify]` extra.
     """
     name = scheme.lower()
     if name in NUMPY_SCHEMES:
@@ -1500,7 +1496,9 @@ def _scheme_edges(finite: np.ndarray, scheme: str, k: int) -> np.ndarray:
         return np.linspace(float(finite.min()), float(finite.max()), k + 1)
 
     if name in JENKS_SCHEMES:
-        return _jenks_edges(finite, name, k)
+        if k < 1:
+            raise ValueError(f"`k` must be >= 1, got {k}.")
+        return _fisher_jenks_edges(finite, k)
 
     valid = ", ".join(repr(s) for s in (*NUMPY_SCHEMES, *JENKS_SCHEMES))
     raise ValueError(
@@ -1509,36 +1507,64 @@ def _scheme_edges(finite: np.ndarray, scheme: str, k: int) -> np.ndarray:
     )
 
 
-def _jenks_edges(finite: np.ndarray, name: str, k: int) -> np.ndarray:
-    """Compute Jenks-family bin edges via the optional mapclassify extra.
+def _fisher_jenks_edges(finite: np.ndarray, k: int) -> np.ndarray:
+    """Compute Fisher-Jenks (natural-breaks) bin edges in pure numpy.
 
-    `mapclassify` is a soft dependency (the `cleopatra[classify]` extra),
-    not a hard requirement, so it is imported lazily here and re-raised
-    with an actionable install hint when missing — the default install
-    stays numpy + matplotlib only.
+    Implements the exact Fisher-Jenks optimisation: the contiguous
+    partition of the sorted data into `k` classes that minimises the total
+    within-class sum of squared deviations about each class mean (the
+    objective that `"natural_breaks"` also targets). This is the classic
+    O(k·n²) dynamic program; segment costs are evaluated in O(1) from
+    prefix sums, and the inner search is vectorised over split points.
 
     Args:
-        finite: The finite-only data to classify.
-        name: Either `"fisher_jenks"` or `"natural_breaks"`.
-        k: The number of classes.
+        finite: The finite-only data to classify (any order; sorted here).
+        k: The number of classes (`>= 1`, validated by the caller).
 
     Returns:
-        np.ndarray: Bin edges `[min, *upper_bounds]` from the classifier.
+        np.ndarray: Bin edges `[min, *class_upper_bounds]` (length `k + 1`),
+            i.e. the data minimum followed by the maximum value of each
+            class — matching the `[min, *bins]` convention of the other
+            schemes. When `k` meets or exceeds the number of distinct
+            points, every point becomes its own break.
 
-    Raises:
-        ValueError: If `k < 1`.
-        ModuleNotFoundError: If `mapclassify` is not installed.
+    Notes:
+        Runtime is O(k·n²); for very large point counts pre-aggregate or use
+        `"quantiles"` instead.
     """
-    if k < 1:
-        raise ValueError(f"`k` must be >= 1, got {k}.")
-    try:
-        import mapclassify
-    except ModuleNotFoundError as exc:  # pragma: no cover - extra not installed
-        raise ModuleNotFoundError(
-            f"The {name!r} classification scheme requires the optional "
-            "'classify' extra. Install it with: "
-            "pip install 'cleopatra[classify]'."
-        ) from exc
-    classifier_name = "FisherJenks" if name == "fisher_jenks" else "NaturalBreaks"
-    classifier = getattr(mapclassify, classifier_name)(finite, k=k)
-    return np.concatenate([[float(finite.min())], np.asarray(classifier.bins)])
+    data = np.sort(np.asarray(finite, dtype=float))
+    n = data.size
+    if k >= n:
+        # More classes than points: each value is its own class bound.
+        return np.concatenate([[data[0]], data])
+
+    # Prefix sums of values and squares for O(1) segment SSE:
+    # SSE[a, b) = sum(x^2) - sum(x)^2 / count  over data[a:b].
+    s1 = np.concatenate([[0.0], np.cumsum(data)])
+    s2 = np.concatenate([[0.0], np.cumsum(data * data)])
+
+    inf = np.inf
+    # dp[m, j] = min total SSE splitting the first j points into m classes.
+    dp = np.full((k + 1, n + 1), inf)
+    back = np.zeros((k + 1, n + 1), dtype=int)
+    dp[0, 0] = 0.0
+    for m in range(1, k + 1):
+        for j in range(m, n + 1):
+            # The m-th class spans points [i, j); i ranges over valid splits.
+            i = np.arange(m - 1, j)
+            count = j - i
+            seg_sum = s1[j] - s1[i]
+            seg_sse = (s2[j] - s2[i]) - seg_sum * seg_sum / count
+            total = dp[m - 1, i] + seg_sse
+            best = int(np.argmin(total))
+            dp[m, j] = total[best]
+            back[m, j] = i[best]
+
+    # Reconstruct class upper bounds from the split pointers.
+    bounds = []
+    j = n
+    for m in range(k, 0, -1):
+        bounds.append(data[j - 1])
+        j = int(back[m, j])
+    bounds.reverse()
+    return np.concatenate([[data[0]], bounds])

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -110,6 +110,8 @@ DEFAULT_OPTIONS = {
     "bounds": None,
     "midpoint": 0,
     "grid_alpha": 0.75,
+    "scheme": None,
+    "k": 5,
 }
 
 
@@ -1039,3 +1041,222 @@ def histogram_legend(
     if orientation == "vertical":
         return ax.bar(centers, counts, width=widths, color=bar_colors, **bar_kwargs)
     return ax.barh(centers, counts, height=widths, color=bar_colors, **bar_kwargs)
+
+
+#: Classification schemes that need nothing beyond numpy. Anything outside
+#: this set (the Jenks-family `"fisher_jenks"` / `"natural_breaks"`) is routed
+#: to the optional, lazily-imported `cleopatra[classify]` extra (mapclassify)
+#: so the default install stays numpy + matplotlib only.
+NUMPY_SCHEMES = ("quantiles", "equal_interval", "percentiles", "std_mean")
+
+#: Jenks-family schemes that require the optional `cleopatra[classify]` extra.
+JENKS_SCHEMES = ("fisher_jenks", "natural_breaks")
+
+#: Standard-deviation multiples used by the `"std_mean"` scheme (mean ± nσ).
+#: Matches mapclassify's `StdMean` default; `k` is ignored for this scheme.
+_STD_MEAN_MULTIPLES = (-2.0, -1.0, 0.0, 1.0, 2.0)
+
+
+def classify(
+    values: np.ndarray | Sequence[float],
+    scheme: str | Sequence[float],
+    k: int = 5,
+) -> tuple[np.ndarray, colors.BoundaryNorm]:
+    """Bin a continuous array into discrete colour classes.
+
+    The shared building block behind categorical (classified) colouring:
+    it turns a continuous data column into an array of bin edges plus a
+    matching `matplotlib.colors.BoundaryNorm`, so any colour-by-value glyph
+    can render a stepped colorbar / class legend instead of a continuous
+    ramp. It is the classification counterpart to `Scale` and
+    `MidpointNormalize`.
+
+    The numpy-only schemes (no dependency beyond numpy) are:
+
+    * `"quantiles"` — `k` equal-count classes via
+      `np.quantile(values, np.linspace(0, 1, k + 1))`.
+    * `"equal_interval"` — `k` equal-width classes spanning the data range.
+    * `"percentiles"` — `k` equal-count classes via `np.percentile` on the
+      same evenly-spaced probabilities; numerically equivalent to
+      `"quantiles"` (it differs only in the `[0, 100]` vs `[0, 1]`
+      convention) and is kept as a familiar alias.
+    * `"std_mean"` — fixed breaks at `mean + nσ` for `n` in
+      `(-2, -1, 0, 1, 2)`, clipped to the data range. `k` is **ignored**
+      for this scheme (the number of classes follows from the multiples).
+
+    The Jenks-family schemes `"fisher_jenks"` and `"natural_breaks"` are
+    routed to the optional `cleopatra[classify]` extra (`mapclassify`),
+    imported lazily so the default install never needs it.
+
+    A non-string `scheme` is treated as an explicit, already-chosen
+    sequence of bin edges (sorted ascending); `k` is ignored.
+
+    Args:
+        values: The data to classify. Non-finite entries (`NaN` / `inf`)
+            are ignored when computing the edges. Can be any array-like.
+        scheme: A scheme name (see above, case-insensitive) **or** an
+            explicit sequence of bin edges to use verbatim.
+        k: The number of classes for the count/width schemes. Must be
+            `>= 1`. Default is 5. Ignored for `"std_mean"` and for an
+            explicit edge sequence.
+
+    Returns:
+        tuple[np.ndarray, matplotlib.colors.BoundaryNorm]: The sorted,
+            de-duplicated bin edges (length = classes + 1) and a
+            `BoundaryNorm` built from them (with `ncolors=256`, matching
+            the package's other boundary norms).
+
+    Raises:
+        ValueError: If `values` has no finite entries, if `k < 1`, if the
+            (finite) data has no spread so fewer than two distinct edges
+            result, or if `scheme` is an unrecognised name.
+        ModuleNotFoundError: If a Jenks-family scheme is requested but the
+            optional `cleopatra[classify]` extra (mapclassify) is not
+            installed.
+
+    Examples:
+        - Equal-interval edges on a 0–10 ramp:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import classify
+            >>> edges, norm = classify(np.arange(11.0), "equal_interval", k=5)
+            >>> [float(e) for e in edges]
+            [0.0, 2.0, 4.0, 6.0, 8.0, 10.0]
+            >>> [float(b) for b in norm.boundaries]
+            [0.0, 2.0, 4.0, 6.0, 8.0, 10.0]
+
+            ```
+        - Quantile edges put equal counts in each class:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import classify
+            >>> edges, _ = classify(np.arange(100.0), "quantiles", k=4)
+            >>> [float(e) for e in edges]
+            [0.0, 24.75, 49.5, 74.25, 99.0]
+
+            ```
+        - An explicit edge sequence is used verbatim (sorted):
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import classify
+            >>> edges, _ = classify(np.arange(11.0), [10.0, 0.0, 5.0])
+            >>> [float(e) for e in edges]
+            [0.0, 5.0, 10.0]
+
+            ```
+        - An unknown scheme name is rejected:
+            ```python
+            >>> from cleopatra.styles import classify
+            >>> classify([1.0, 2.0, 3.0], "rainbow")
+            Traceback (most recent call last):
+                ...
+            ValueError: Unknown classification scheme 'rainbow'. ...
+
+            ```
+    """
+    finite = np.asarray(values, dtype=float)
+    finite = finite[np.isfinite(finite)]
+    if finite.size == 0:
+        raise ValueError(
+            "Cannot classify: `values` has no finite entries to bin."
+        )
+
+    if isinstance(scheme, str):
+        edges = _scheme_edges(finite, scheme, k)
+    else:
+        # An explicit sequence of bin edges supplied by the caller.
+        edges = np.sort(np.asarray(scheme, dtype=float))
+
+    # BoundaryNorm needs strictly increasing edges; quantiles on skewed or
+    # discrete data can repeat, so collapse duplicates and require spread.
+    edges = np.unique(edges)
+    if edges.size < 2:
+        raise ValueError(
+            "Cannot classify: the data has no spread (fewer than two "
+            "distinct bin edges). Pin explicit edges or widen the data."
+        )
+    norm = colors.BoundaryNorm(boundaries=edges, ncolors=256)
+    return edges, norm
+
+
+def _scheme_edges(finite: np.ndarray, scheme: str, k: int) -> np.ndarray:
+    """Compute bin edges for a named classification `scheme`.
+
+    Helper for `classify`: `finite` is already the finite-only data and
+    `scheme` is a (case-insensitive) scheme name. Returns the raw edges
+    before de-duplication, which `classify` performs.
+
+    Args:
+        finite: The finite-only data to derive edges from.
+        scheme: The scheme name (see `classify`).
+        k: The number of classes for the count/width schemes.
+
+    Returns:
+        np.ndarray: The (possibly non-unique) bin edges.
+
+    Raises:
+        ValueError: If `k < 1` (for the `k`-driven schemes) or `scheme`
+            is not a recognised name.
+        ModuleNotFoundError: If a Jenks-family scheme is requested without
+            the optional `cleopatra[classify]` extra.
+    """
+    name = scheme.lower()
+    if name in NUMPY_SCHEMES:
+        if name == "std_mean":
+            mean, std = float(finite.mean()), float(finite.std())
+            breaks = [mean + mult * std for mult in _STD_MEAN_MULTIPLES]
+            lo, hi = float(finite.min()), float(finite.max())
+            inner = [b for b in breaks if lo < b < hi]
+            return np.array([lo, *inner, hi], dtype=float)
+        if k < 1:
+            raise ValueError(f"`k` must be >= 1, got {k}.")
+        if name == "quantiles":
+            return np.quantile(finite, np.linspace(0.0, 1.0, k + 1))
+        if name == "percentiles":
+            return np.percentile(finite, np.linspace(0.0, 100.0, k + 1))
+        # name == "equal_interval"
+        return np.linspace(float(finite.min()), float(finite.max()), k + 1)
+
+    if name in JENKS_SCHEMES:
+        return _jenks_edges(finite, name, k)
+
+    valid = ", ".join(repr(s) for s in (*NUMPY_SCHEMES, *JENKS_SCHEMES))
+    raise ValueError(
+        f"Unknown classification scheme {scheme!r}. Expected one of "
+        f"{valid}, or an explicit sequence of bin edges."
+    )
+
+
+def _jenks_edges(finite: np.ndarray, name: str, k: int) -> np.ndarray:
+    """Compute Jenks-family bin edges via the optional mapclassify extra.
+
+    `mapclassify` is a soft dependency (the `cleopatra[classify]` extra),
+    not a hard requirement, so it is imported lazily here and re-raised
+    with an actionable install hint when missing — the default install
+    stays numpy + matplotlib only.
+
+    Args:
+        finite: The finite-only data to classify.
+        name: Either `"fisher_jenks"` or `"natural_breaks"`.
+        k: The number of classes.
+
+    Returns:
+        np.ndarray: Bin edges `[min, *upper_bounds]` from the classifier.
+
+    Raises:
+        ValueError: If `k < 1`.
+        ModuleNotFoundError: If `mapclassify` is not installed.
+    """
+    if k < 1:
+        raise ValueError(f"`k` must be >= 1, got {k}.")
+    try:
+        import mapclassify
+    except ModuleNotFoundError as exc:  # pragma: no cover - extra not installed
+        raise ModuleNotFoundError(
+            f"The {name!r} classification scheme requires the optional "
+            "'classify' extra. Install it with: "
+            "pip install 'cleopatra[classify]'."
+        ) from exc
+    classifier_name = "FisherJenks" if name == "fisher_jenks" else "NaturalBreaks"
+    classifier = getattr(mapclassify, classifier_name)(finite, k=k)
+    return np.concatenate([[float(finite.min())], np.asarray(classifier.bins)])

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import warnings
 from collections import OrderedDict
 from enum import StrEnum
 from typing import Callable, Sequence
@@ -1338,6 +1339,13 @@ JENKS_SCHEMES = ("fisher_jenks", "natural_breaks")
 #: `k` is ignored for this scheme.
 _STD_MEAN_MULTIPLES = (-2.0, -1.0, 0.0, 1.0, 2.0)
 
+#: Point-count above which the Fisher-Jenks optimisation classifies a
+#: representative quantile sample instead of the full data. The exact DP is
+#: O(k·n²); beyond this size it would block for seconds, so a sample of this
+#: many points is used (and a warning is emitted). The class breaks it yields
+#: still apply to the full data.
+MAX_JENKS_N = 5_000
+
 
 def classify(
     values: np.ndarray | Sequence[float],
@@ -1387,7 +1395,10 @@ def classify(
         tuple[np.ndarray, matplotlib.colors.BoundaryNorm]: The sorted,
             de-duplicated bin edges (length = classes + 1) and a
             `BoundaryNorm` built from them (with `ncolors=256`, matching
-            the package's other boundary norms).
+            the package's other boundary norms). The realised class count
+            can be **fewer than `k`** when the data has too few distinct
+            values to support `k` classes — coincident edges are collapsed,
+            so the returned edges are always strictly increasing.
 
     Raises:
         ValueError: If `values` has no finite entries, if `k < 1`, if the
@@ -1529,8 +1540,9 @@ def _fisher_jenks_edges(finite: np.ndarray, k: int) -> np.ndarray:
             points, every point becomes its own break.
 
     Notes:
-        Runtime is O(k·n²); for very large point counts pre-aggregate or use
-        `"quantiles"` instead.
+        Runtime is O(k·n²). Above `MAX_JENKS_N` points the optimisation runs
+        on a representative quantile sample of that size (a `UserWarning` is
+        emitted); the resulting breaks still apply to the full data.
     """
     data = np.sort(np.asarray(finite, dtype=float))
     n = data.size
@@ -1538,10 +1550,27 @@ def _fisher_jenks_edges(finite: np.ndarray, k: int) -> np.ndarray:
         # More classes than points: each value is its own class bound.
         return np.concatenate([[data[0]], data])
 
-    # Prefix sums of values and squares for O(1) segment SSE:
+    if n > MAX_JENKS_N:
+        # The exact DP is O(k·n²); on large inputs classify a quantile
+        # thumbprint of the distribution instead. The sample spans the full
+        # range (its ends are the data min/max), so the breaks remain valid.
+        warnings.warn(
+            f"Fisher-Jenks on {n} points is O(k·n^2); classifying a "
+            f"{MAX_JENKS_N}-point quantile sample instead. Pass fewer points "
+            "or use scheme='quantiles' for an exact result.",
+            stacklevel=2,
+        )
+        data = np.quantile(data, np.linspace(0.0, 1.0, MAX_JENKS_N))
+        n = data.size
+
+    # Centre the data before forming prefix sums: the partition is
+    # shift-invariant, and centring keeps `sum(x)^2 / count` from cancelling
+    # against `sum(x^2)` when the values are large relative to their spread.
+    centered = data - data.mean()
+    # Prefix sums of (centred) values and squares for O(1) segment SSE:
     # SSE[a, b) = sum(x^2) - sum(x)^2 / count  over data[a:b].
-    s1 = np.concatenate([[0.0], np.cumsum(data)])
-    s2 = np.concatenate([[0.0], np.cumsum(data * data)])
+    s1 = np.concatenate([[0.0], np.cumsum(centered)])
+    s2 = np.concatenate([[0.0], np.cumsum(centered * centered)])
 
     inf = np.inf
     # dp[m, j] = min total SSE splitting the first j points into m classes.
@@ -1560,7 +1589,7 @@ def _fisher_jenks_edges(finite: np.ndarray, k: int) -> np.ndarray:
             dp[m, j] = total[best]
             back[m, j] = i[best]
 
-    # Reconstruct class upper bounds from the split pointers.
+    # Reconstruct class upper bounds from the split pointers (original units).
     bounds = []
     j = n
     for m in range(k, 0, -1):

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -34,6 +34,7 @@ from matplotlib.figure import Figure
 from matplotlib.quiver import QuiverKey
 
 from cleopatra.glyph import Glyph
+from cleopatra.styles import CLASSIFY_OPTIONS
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 
 #: Vector kinds dispatched by `VectorGlyph.plot`.
@@ -50,7 +51,7 @@ VECTOR_DEFAULT_OPTIONS = {
     "ticks_spacing": None,
     "add_colorbar": True,
 }
-VECTOR_DEFAULT_OPTIONS = STYLE_DEFAULTS | VECTOR_DEFAULT_OPTIONS
+VECTOR_DEFAULT_OPTIONS = STYLE_DEFAULTS | CLASSIFY_OPTIONS | VECTOR_DEFAULT_OPTIONS
 
 
 class VectorGlyph(Glyph):

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -418,6 +418,69 @@ class TestFisherJenksEdges:
         with pytest.raises(ValueError, match="`k` must be >= 1"):
             classify(np.arange(20.0), scheme, k=bad_k)
 
+    def test_centering_preserves_optimum_and_shift_invariance(self):
+        """Mean-centring keeps the breaks optimal and shift-invariant (L1).
+
+        Test scenario:
+            The same data offset by a large constant (1e9) yields the same
+            partition — the breaks differ only by that constant — proving the
+            centred SSE does not lose precision for extreme magnitudes.
+        """
+        data = np.array([0.0, 1, 2, 3, 4, 50, 51, 52, 200, 201])
+        base, _ = classify(data, "fisher_jenks", k=3)
+        shifted, _ = classify(data + 1e9, "fisher_jenks", k=3)
+        assert np.allclose(shifted - 1e9, base), (
+            f"Breaks should be shift-invariant; {shifted - 1e9} != {base}"
+        )
+
+    def test_large_input_samples_and_warns(self, monkeypatch):
+        """Above `MAX_JENKS_N` the DP runs on a quantile sample and warns (M1).
+
+        Args:
+            monkeypatch: Lowers the cap so the sampling path is exercised
+                without generating a huge array.
+
+        Test scenario:
+            Classifying more points than the cap emits a UserWarning and still
+            returns `k + 1` strictly-increasing edges spanning the data range.
+        """
+        monkeypatch.setattr(styles_mod, "MAX_JENKS_N", 100)
+        rng = np.random.default_rng(5)
+        data = rng.normal(size=400)
+        with pytest.warns(UserWarning, match="quantile sample"):
+            edges, _ = classify(data, "fisher_jenks", k=5)
+        assert len(edges) == 6, f"k=5 should give 6 edges, got {len(edges)}"
+        assert np.all(np.diff(edges) > 0), f"Edges must be increasing: {edges}"
+        assert np.isclose(edges[0], data.min()) and np.isclose(edges[-1], data.max()), (
+            "Sampled breaks should still span the full data range"
+        )
+
+    def test_below_cap_does_not_warn(self, monkeypatch, recwarn):
+        """At or below `MAX_JENKS_N` no sampling warning is emitted (M1).
+
+        Args:
+            monkeypatch: Sets a cap above the input size.
+            recwarn: Captures any warnings raised.
+
+        Test scenario:
+            A modest input classified exactly (no sampling) warns nothing.
+        """
+        monkeypatch.setattr(styles_mod, "MAX_JENKS_N", 5000)
+        classify(np.arange(50.0), "fisher_jenks", k=4)
+        sampling = [w for w in recwarn.list if "quantile sample" in str(w.message)]
+        assert not sampling, f"No sampling warning expected, got {sampling}"
+
+    def test_ties_yield_fewer_classes(self):
+        """Insufficient distinct values yield fewer than `k` classes (N1).
+
+        Test scenario:
+            Data with only two distinct values and k=4 collapses coincident
+            breaks, returning strictly-increasing edges with < k + 1 entries.
+        """
+        edges, _ = classify(np.array([1.0, 1, 1, 2, 2]), "fisher_jenks", k=4)
+        assert len(edges) < 5, f"Tied data should give < k+1 edges, got {len(edges)}"
+        assert np.all(np.diff(edges) > 0), f"Edges must stay increasing: {edges}"
+
 
 class TestGlyphPrepareClassifiedMapping:
     """Tests for ``Glyph._prepare_classified_mapping`` and the routing."""

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -2,9 +2,9 @@
 
 Covers:
 
-* `cleopatra.styles.classify` and its helpers `_scheme_edges` / `_jenks_edges`
-  (the numpy-only schemes, explicit edges, the `BoundaryNorm` output, and the
-  error / optional-extra paths).
+* `cleopatra.styles.classify` and its helpers `_scheme_edges` /
+  `_fisher_jenks_edges` (the numpy-only schemes incl. native Fisher-Jenks,
+  explicit edges, the `BoundaryNorm` output, and the error paths).
 * `Glyph._prepare_classified_mapping` and the `scheme` / `k` short-circuit
   added to `Glyph._prepare_scalar_mapping`.
 * Integration through `ScatterGlyph` and `PolygonGlyph` (discrete classes,
@@ -37,7 +37,7 @@ from cleopatra.styles import (
     NUMPY_SCHEMES,
     classify,
 )
-from cleopatra.styles import _jenks_edges, _scheme_edges
+from cleopatra.styles import _fisher_jenks_edges, _scheme_edges
 
 
 @pytest.fixture(autouse=True)
@@ -96,7 +96,7 @@ class TestModuleConstants:
         """The Jenks tuple names the two optional-extra schemes.
 
         Test scenario:
-            ``JENKS_SCHEMES`` is exactly the mapclassify-backed names.
+            ``JENKS_SCHEMES`` is exactly the native Fisher-Jenks names.
         """
         assert set(JENKS_SCHEMES) == {
             "fisher_jenks",
@@ -290,15 +290,16 @@ class TestClassify:
 class TestSchemeEdges:
     """Tests for the private ``_scheme_edges`` helper."""
 
-    def test_routes_jenks_to_extra(self):
-        """A Jenks name is routed to the optional-extra path.
+    def test_routes_jenks_to_native_fisher_jenks(self):
+        """A Jenks name is routed to the native Fisher-Jenks implementation.
 
         Test scenario:
-            With mapclassify absent, requesting fisher_jenks surfaces the
-            install hint (proving the routing, not the computation).
+            `fisher_jenks` returns `k + 1` edges computed in-process (no
+            optional dependency), spanning the data range.
         """
-        with pytest.raises(ModuleNotFoundError, match="cleopatra\\[classify\\]"):
-            _scheme_edges(np.arange(10.0), "fisher_jenks", k=3)
+        edges = _scheme_edges(np.arange(10.0), "fisher_jenks", k=3)
+        assert len(edges) == 4, f"k=3 should give 4 edges, got {len(edges)}"
+        assert edges[0] == 0.0 and edges[-1] == 9.0, f"Edges should span data: {edges}"
 
     def test_std_mean_k_ignored_branch(self):
         """``_scheme_edges`` does not validate ``k`` for ``std_mean``.
@@ -311,49 +312,96 @@ class TestSchemeEdges:
         assert edges[0] == 0.0 and edges[-1] == 99.0, f"Unexpected std_mean edges: {edges}"
 
 
-class TestJenksEdges:
-    """Tests for the private ``_jenks_edges`` helper."""
+class TestFisherJenksEdges:
+    """Tests for the native ``_fisher_jenks_edges`` helper (no dependency)."""
 
-    def test_missing_mapclassify_raises_with_hint(self):
-        """A missing optional extra raises ``ModuleNotFoundError`` with a hint.
+    @staticmethod
+    def _partition_sse(data, edges):
+        """Sum of within-class squared deviations for the given bin edges."""
+        data = np.sort(np.asarray(data, dtype=float))
+        cls = np.searchsorted(edges[1:-1], data, side="left")
+        return sum(
+            ((data[cls == c] - data[cls == c].mean()) ** 2).sum()
+            for c in np.unique(cls)
+        )
+
+    def test_matches_brute_force_optimum(self):
+        """The DP finds the globally optimal (minimum-SSE) partition.
 
         Test scenario:
-            mapclassify is not installed in the test environment, so the
-            helper re-raises with an actionable ``pip install`` hint.
+            For small samples, the within-class SSE achieved by the
+            Fisher-Jenks edges equals the brute-force optimum over all
+            contiguous k-partitions.
         """
-        with pytest.raises(ModuleNotFoundError, match="pip install 'cleopatra\\[classify\\]'"):
-            _jenks_edges(np.arange(10.0), "natural_breaks", k=3)
+        import itertools
 
-    def test_k_below_one_raises(self):
-        """``_jenks_edges`` validates ``k`` before importing the extra.
+        rng = np.random.default_rng(0)
+        for _ in range(5):
+            data = np.sort(rng.normal(size=11))
+            for k in (2, 3, 4):
+                best = min(
+                    sum(
+                        ((seg - seg.mean()) ** 2).sum()
+                        for seg in np.split(data, list(cuts))
+                        if seg.size
+                    )
+                    for cuts in itertools.combinations(range(1, data.size), k - 1)
+                )
+                edges = _fisher_jenks_edges(data, k)
+                got = self._partition_sse(data, edges)
+                assert np.isclose(got, best), f"k={k}: DP SSE {got} != optimum {best}"
+
+    def test_classic_break(self):
+        """A clear outlier is split into its own class.
 
         Test scenario:
-            ``k < 1`` raises ``ValueError`` regardless of mapclassify.
+            [1, 2, 3, 4, 5, 100] with k=2 breaks between 5 and 100.
         """
-        with pytest.raises(ValueError, match="`k` must be >= 1"):
-            _jenks_edges(np.arange(10.0), "fisher_jenks", k=0)
+        edges = _fisher_jenks_edges(np.array([1.0, 2, 3, 4, 5, 100]), k=2)
+        assert np.allclose(edges, [1.0, 5.0, 100.0]), f"Unexpected edges: {edges}"
 
-    def test_uses_mapclassify_when_available(self, monkeypatch):
-        """When mapclassify is importable, edges are ``[min, *bins]``.
+    def test_edges_count_and_span(self):
+        """`k` classes yield `k + 1` increasing edges spanning the data.
 
         Test scenario:
-            A fake ``mapclassify`` module with a ``FisherJenks`` classifier is
-            injected; the helper prepends the data minimum to the classifier
-            bins.
+            k=5 on a ramp gives six strictly increasing edges from min to max.
+        """
+        edges = _fisher_jenks_edges(np.arange(50.0), k=5)
+        assert len(edges) == 6, f"Expected 6 edges, got {len(edges)}"
+        assert edges[0] == 0.0 and edges[-1] == 49.0, "Edges should span the data"
+        assert np.all(np.diff(edges) > 0), f"Edges must be increasing: {edges}"
+
+    def test_k_at_least_n_one_class_per_point(self):
+        """When k >= number of points, every value becomes its own break.
+
+        Test scenario:
+            Three points with k=10 return the sorted values as edges.
+        """
+        edges = _fisher_jenks_edges(np.array([3.0, 1.0, 2.0]), k=10)
+        assert np.allclose(edges, [1.0, 1.0, 2.0, 3.0]), f"Unexpected edges: {edges}"
+
+    def test_natural_breaks_is_fisher_jenks_alias(self):
+        """`natural_breaks` produces identical edges to `fisher_jenks`.
+
+        Test scenario:
+            Both scheme names route to the same exact optimisation.
+        """
+        data = np.arange(40.0)
+        fisher, _ = classify(data, "fisher_jenks", k=4)
+        natural, _ = classify(data, "natural_breaks", k=4)
+        assert np.allclose(fisher, natural), "natural_breaks should equal fisher_jenks"
+
+    def test_no_mapclassify_import(self):
+        """Classifying with a Jenks scheme imports no optional dependency.
+
+        Test scenario:
+            After a fisher_jenks classification, `mapclassify` is absent from
+            `sys.modules` — the algorithm is pure numpy.
         """
         import sys
-        import types
 
-        fake = types.ModuleType("mapclassify")
-
-        class _FisherJenks:
-            def __init__(self, data, k):
-                self.bins = np.array([3.0, 6.0, 9.0])
-
-        fake.FisherJenks = _FisherJenks
-        monkeypatch.setitem(sys.modules, "mapclassify", fake)
-        edges = _jenks_edges(np.arange(10.0), "fisher_jenks", k=3)
-        assert np.allclose(edges, [0.0, 3.0, 6.0, 9.0]), f"Unexpected jenks edges: {edges}"
+        classify(np.arange(20.0), "fisher_jenks", k=4)
+        assert "mapclassify" not in sys.modules, "Jenks must not import mapclassify"
 
 
 class TestGlyphPrepareClassifiedMapping:

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -22,10 +22,16 @@ import numpy as np
 import pytest
 
 import cleopatra.styles as styles_mod
+from cleopatra.array_glyph import ArrayGlyph
+from cleopatra.flow_glyph import FlowGlyph
 from cleopatra.glyph import Glyph
+from cleopatra.kde_glyph import KDEGlyph
+from cleopatra.mesh_glyph import MeshGlyph
 from cleopatra.polygon_glyph import PolygonGlyph
 from cleopatra.scatter_glyph import ScatterGlyph
+from cleopatra.vector_glyph import VectorGlyph
 from cleopatra.styles import (
+    CLASSIFY_OPTIONS,
     DEFAULT_OPTIONS as STYLE_DEFAULTS,
     JENKS_SCHEMES,
     NUMPY_SCHEMES,
@@ -97,15 +103,19 @@ class TestModuleConstants:
             "natural_breaks",
         }, f"Unexpected Jenks schemes: {JENKS_SCHEMES}"
 
-    def test_scheme_and_k_defaults_present(self):
-        """``scheme`` / ``k`` are part of the shared option defaults.
+    def test_scheme_and_k_in_classify_options_not_shared_defaults(self):
+        """``scheme`` / ``k`` live in CLASSIFY_OPTIONS, not the shared defaults.
 
         Test scenario:
-            They default to ``None`` and ``5`` so every glyph inherits the
-            continuous-by-default behaviour with five classes when enabled.
+            They default to ``None`` and ``5`` in CLASSIFY_OPTIONS, and are
+            deliberately kept out of the shared DEFAULT_OPTIONS so glyphs that
+            bypass the scalar-mapping pipeline reject `scheme` instead of
+            silently ignoring it.
         """
-        assert STYLE_DEFAULTS["scheme"] is None, "scheme should default to None"
-        assert STYLE_DEFAULTS["k"] == 5, "k should default to 5"
+        assert CLASSIFY_OPTIONS["scheme"] is None, "scheme should default to None"
+        assert CLASSIFY_OPTIONS["k"] == 5, "k should default to 5"
+        assert "scheme" not in STYLE_DEFAULTS, "scheme must not be in shared defaults"
+        assert "k" not in STYLE_DEFAULTS, "k must not be in shared defaults"
 
 
 class TestClassify:
@@ -549,3 +559,113 @@ class TestPolygonGlyphScheme:
         glyph = PolygonGlyph(polys, values=values)
         _, _, pc = glyph.plot()
         assert not isinstance(pc.norm, mcolors.BoundaryNorm), "No scheme -> no BoundaryNorm"
+
+
+class TestSchemeGlyphScope:
+    """Tests for which glyphs accept `scheme` (the M1 fix).
+
+    `scheme`/`k` live in `CLASSIFY_OPTIONS` and are mixed only into glyphs
+    whose colour mapping routes through `Glyph._prepare_scalar_mapping` and
+    is driven purely by the norm. Glyphs that bypass that pipeline
+    (`ArrayGlyph`, `MeshGlyph`) — and `KDEGlyph`, whose `contourf` has its
+    own `levels` discretisation — must reject `scheme` rather than silently
+    ignore it.
+    """
+
+    @pytest.mark.parametrize("glyph_cls", [ScatterGlyph, PolygonGlyph, VectorGlyph, FlowGlyph])
+    def test_pipeline_glyphs_accept_scheme(self, glyph_cls):
+        """Pipeline glyphs expose `scheme`/`k` as accepted options.
+
+        Args:
+            glyph_cls: A glyph class that colours through the shared pipeline.
+
+        Test scenario:
+            `scheme` and `k` are in the class's option keys.
+        """
+        keys = glyph_cls.option_keys()
+        assert "scheme" in keys and "k" in keys, (
+            f"{glyph_cls.__name__} should accept scheme/k"
+        )
+
+    def test_array_glyph_rejects_scheme(self):
+        """`ArrayGlyph` rejects `scheme` instead of silently ignoring it.
+
+        Test scenario:
+            ArrayGlyph bypasses `_prepare_scalar_mapping`, so `scheme` is not
+            an accepted option and construction raises.
+        """
+        with pytest.raises(ValueError, match="not correct"):
+            ArrayGlyph(np.arange(9).reshape(3, 3).astype(float), scheme="quantiles")
+
+    def test_mesh_glyph_rejects_scheme(self):
+        """`MeshGlyph` rejects `scheme` instead of silently ignoring it.
+
+        Test scenario:
+            MeshGlyph bypasses `_prepare_scalar_mapping`, so `scheme` is
+            rejected at construction.
+        """
+        with pytest.raises(ValueError, match="not correct"):
+            MeshGlyph(
+                np.array([0.0, 1.0, 0.0]),
+                np.array([0.0, 0.0, 1.0]),
+                np.array([[0, 1, 2]]),
+                scheme="quantiles",
+            )
+
+    def test_kde_glyph_rejects_scheme(self):
+        """`KDEGlyph` rejects `scheme` (its `levels` owns discretisation).
+
+        Test scenario:
+            KDEGlyph is excluded from the classification options, so `scheme`
+            is rejected at construction.
+        """
+        rng = np.random.default_rng(0)
+        with pytest.raises(ValueError, match="not correct"):
+            KDEGlyph(rng.normal(size=20), rng.normal(size=20), scheme="quantiles")
+
+
+class TestSchemeConflictWarnings:
+    """Tests for the L2 conflict warnings when `scheme` overrides options."""
+
+    def test_warns_on_conflicting_color_scale(self):
+        """Setting `scheme` with a non-linear `color_scale` warns.
+
+        Test scenario:
+            `scheme` owns the norm, so `color_scale="midpoint"` is ignored —
+            and a warning says so.
+        """
+        glyph = ScatterGlyph(
+            np.arange(5.0), np.zeros(5), values=np.arange(5.0),
+            scheme="quantiles", color_scale="midpoint",
+        )
+        with pytest.warns(UserWarning, match="color_scale"):
+            glyph.plot()
+
+    def test_warns_on_conflicting_levels(self):
+        """Setting `scheme` together with `levels` warns.
+
+        Test scenario:
+            The classification scheme determines the bins, so `levels` is
+            ignored — and a warning says so.
+        """
+        glyph = ScatterGlyph(
+            np.arange(5.0), np.zeros(5), values=np.arange(5.0),
+            scheme="quantiles", levels=4,
+        )
+        with pytest.warns(UserWarning, match="levels"):
+            glyph.plot()
+
+    def test_no_warning_without_conflict(self):
+        """A plain `scheme` (default color_scale, no levels) does not warn.
+
+        Test scenario:
+            `scheme="quantiles"` alone produces no conflict warning.
+        """
+        import warnings as _warnings
+
+        glyph = ScatterGlyph(
+            np.arange(5.0), np.zeros(5), values=np.arange(5.0), scheme="quantiles",
+        )
+        with _warnings.catch_warnings():
+            _warnings.simplefilter("error")
+            glyph.plot()

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -799,6 +799,24 @@ class TestVectorGlyphScheme:
         assert glyph.cbar is not None, "A colorbar should be drawn"
         assert isinstance(glyph.cbar.norm, mcolors.BoundaryNorm), "Colorbar norm should be discrete"
 
+    def test_streamplot_scheme_uses_boundary_norm(self):
+        """A classified streamplot colours its lines via a BoundaryNorm.
+
+        Test scenario:
+            On a regular grid with a magnitude gradient, `scheme="quantiles"`
+            makes the streamplot's `LineCollection` use a discrete
+            BoundaryNorm and draws a discrete colorbar.
+        """
+        y, x = np.mgrid[0:6, 0:6].astype(float)
+        u = x + 1.0
+        v = y + 1.0
+        glyph = VectorGlyph(x, y, u, v, scheme="quantiles", k=4)
+        _, _, im = glyph.plot(kind="streamplot")
+        assert isinstance(im.norm, mcolors.BoundaryNorm), "scheme should set a BoundaryNorm"
+        assert len(im.norm.boundaries) == 5, "k=4 should give 5 boundaries"
+        assert glyph.cbar is not None, "A discrete colorbar should be drawn"
+        assert isinstance(glyph.cbar.norm, mcolors.BoundaryNorm), "Colorbar norm should be discrete"
+
     def test_scheme_none_regression(self, field):
         """`scheme=None` keeps the continuous vector colouring.
 

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -403,6 +403,21 @@ class TestFisherJenksEdges:
         classify(np.arange(20.0), "fisher_jenks", k=4)
         assert "mapclassify" not in sys.modules, "Jenks must not import mapclassify"
 
+    @pytest.mark.parametrize("scheme", ["fisher_jenks", "natural_breaks"])
+    @pytest.mark.parametrize("bad_k", [0, -1])
+    def test_jenks_k_below_one_raises(self, scheme, bad_k):
+        """`k < 1` raises for the Jenks-family schemes too.
+
+        Args:
+            scheme: The Jenks scheme name under test.
+            bad_k: An invalid class count.
+
+        Test scenario:
+            Fewer than one class is rejected before running the optimisation.
+        """
+        with pytest.raises(ValueError, match="`k` must be >= 1"):
+            classify(np.arange(20.0), scheme, k=bad_k)
+
 
 class TestGlyphPrepareClassifiedMapping:
     """Tests for ``Glyph._prepare_classified_mapping`` and the routing."""

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -669,3 +669,95 @@ class TestSchemeConflictWarnings:
         with _warnings.catch_warnings():
             _warnings.simplefilter("error")
             glyph.plot()
+
+
+class TestClassifyTwoDimensional:
+    """Tests for `classify` on a 2-D values array (raster-shaped input)."""
+
+    def test_2d_values_flattened_for_edges(self):
+        """A 2-D values array is classified on its flattened finite values.
+
+        Test scenario:
+            A 10x10 grid of 0..99 yields the same quantile edges as the
+            equivalent 1-D ramp.
+        """
+        grid = np.arange(100.0).reshape(10, 10)
+        edges_2d, _ = classify(grid, "quantiles", k=4)
+        edges_1d, _ = classify(np.arange(100.0), "quantiles", k=4)
+        assert np.allclose(edges_2d, edges_1d), (
+            f"2-D edges {edges_2d} should match 1-D edges {edges_1d}"
+        )
+
+    def test_2d_values_with_non_finite(self):
+        """Non-finite cells in a 2-D array are ignored when binning.
+
+        Test scenario:
+            A grid with a NaN cell produces the same edges as the clean grid.
+        """
+        clean = np.arange(1.0, 101.0).reshape(10, 10)
+        dirty = clean.copy()
+        dirty[0, 0] = np.nan
+        edges_clean, _ = classify(clean, "equal_interval", k=5)
+        edges_dirty, _ = classify(dirty, "equal_interval", k=5)
+        # equal_interval depends on min/max; the NaN cell was the min (1.0),
+        # so removing it shifts the lower edge — assert the upper edge holds
+        # and edges remain strictly increasing.
+        assert np.isclose(edges_clean[-1], edges_dirty[-1]), "Upper edge should match"
+        assert np.all(np.diff(edges_dirty) > 0), "Edges must stay strictly increasing"
+
+
+class TestVectorGlyphScheme:
+    """Integration tests for `scheme` through VectorGlyph."""
+
+    @pytest.fixture()
+    def field(self):
+        """A small vector field with a spread of magnitudes.
+
+        Returns:
+            tuple[np.ndarray, ...]: x, y, u, v arrays on a 4x4 grid.
+        """
+        x, y = np.meshgrid(np.arange(4.0), np.arange(4.0))
+        rng = np.random.default_rng(3)
+        u = rng.uniform(0.1, 5.0, size=x.shape)
+        v = rng.uniform(0.1, 5.0, size=x.shape)
+        return x, y, u, v
+
+    def test_quiver_scheme_uses_boundary_norm(self, field):
+        """A classified quiver colours via a discrete BoundaryNorm.
+
+        Test scenario:
+            `scheme="quantiles"` makes the Quiver mappable use a BoundaryNorm
+            with k+1 boundaries while still carrying the raw magnitude array.
+        """
+        x, y, u, v = field
+        glyph = VectorGlyph(x, y, u, v, scheme="quantiles", k=5)
+        _, _, im = glyph.plot(kind="quiver")
+        assert isinstance(im.norm, mcolors.BoundaryNorm), "scheme should set a BoundaryNorm"
+        assert len(im.norm.boundaries) == 6, "k=5 should give 6 boundaries"
+        assert np.allclose(im.get_array(), np.hypot(u, v).ravel()), (
+            "Quiver should carry the raw magnitude array"
+        )
+
+    def test_barbs_scheme_discrete_colorbar(self, field):
+        """A classified barbs plot draws a discrete colorbar.
+
+        Test scenario:
+            The colorbar norm is the discrete BoundaryNorm built from the
+            magnitude classification.
+        """
+        x, y, u, v = field
+        glyph = VectorGlyph(x, y, u, v, scheme="equal_interval", k=4)
+        glyph.plot(kind="barbs")
+        assert glyph.cbar is not None, "A colorbar should be drawn"
+        assert isinstance(glyph.cbar.norm, mcolors.BoundaryNorm), "Colorbar norm should be discrete"
+
+    def test_scheme_none_regression(self, field):
+        """`scheme=None` keeps the continuous vector colouring.
+
+        Test scenario:
+            Without a scheme the quiver is not BoundaryNorm-normalised.
+        """
+        x, y, u, v = field
+        glyph = VectorGlyph(x, y, u, v)
+        _, _, im = glyph.plot(kind="quiver")
+        assert not isinstance(im.norm, mcolors.BoundaryNorm), "No scheme -> no BoundaryNorm"

--- a/tests/test_classify.py
+++ b/tests/test_classify.py
@@ -1,0 +1,551 @@
+"""Tests for categorical (classified) colouring — issue #154.
+
+Covers:
+
+* `cleopatra.styles.classify` and its helpers `_scheme_edges` / `_jenks_edges`
+  (the numpy-only schemes, explicit edges, the `BoundaryNorm` output, and the
+  error / optional-extra paths).
+* `Glyph._prepare_classified_mapping` and the `scheme` / `k` short-circuit
+  added to `Glyph._prepare_scalar_mapping`.
+* Integration through `ScatterGlyph` and `PolygonGlyph` (discrete classes,
+  stepped colorbar, raw value preservation, and the `scheme=None` regression).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import cleopatra.styles as styles_mod
+from cleopatra.glyph import Glyph
+from cleopatra.polygon_glyph import PolygonGlyph
+from cleopatra.scatter_glyph import ScatterGlyph
+from cleopatra.styles import (
+    DEFAULT_OPTIONS as STYLE_DEFAULTS,
+    JENKS_SCHEMES,
+    NUMPY_SCHEMES,
+    classify,
+)
+from cleopatra.styles import _jenks_edges, _scheme_edges
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def ramp():
+    """A 0..99 linear ramp of 100 values.
+
+    Returns:
+        np.ndarray: ``np.arange(100.0)``, convenient because quantile and
+            equal-interval edges coincide on a uniform ramp.
+    """
+    return np.arange(100.0)
+
+
+def _make_options(**overrides) -> dict:
+    """Build a Glyph ``default_options`` dict with auto colour limits.
+
+    Args:
+        **overrides: Option keys to override on top of the shared defaults.
+
+    Returns:
+        dict: A copy of ``STYLE_DEFAULTS`` with ``vmin`` / ``vmax`` unset
+            (so limits resolve from the data) plus any overrides applied.
+    """
+    opts = STYLE_DEFAULTS.copy()
+    opts["vmin"] = None
+    opts["vmax"] = None
+    opts.update(overrides)
+    return opts
+
+
+class TestModuleConstants:
+    """Tests for the scheme-name constants and the shared option defaults."""
+
+    def test_numpy_schemes_membership(self):
+        """The numpy-only scheme tuple lists exactly the no-dependency schemes.
+
+        Test scenario:
+            The four numpy schemes are present and the Jenks names are not.
+        """
+        assert set(NUMPY_SCHEMES) == {
+            "quantiles",
+            "equal_interval",
+            "percentiles",
+            "std_mean",
+        }, f"Unexpected numpy schemes: {NUMPY_SCHEMES}"
+        assert "fisher_jenks" not in NUMPY_SCHEMES, "Jenks must not be numpy-only"
+
+    def test_jenks_schemes_membership(self):
+        """The Jenks tuple names the two optional-extra schemes.
+
+        Test scenario:
+            ``JENKS_SCHEMES`` is exactly the mapclassify-backed names.
+        """
+        assert set(JENKS_SCHEMES) == {
+            "fisher_jenks",
+            "natural_breaks",
+        }, f"Unexpected Jenks schemes: {JENKS_SCHEMES}"
+
+    def test_scheme_and_k_defaults_present(self):
+        """``scheme`` / ``k`` are part of the shared option defaults.
+
+        Test scenario:
+            They default to ``None`` and ``5`` so every glyph inherits the
+            continuous-by-default behaviour with five classes when enabled.
+        """
+        assert STYLE_DEFAULTS["scheme"] is None, "scheme should default to None"
+        assert STYLE_DEFAULTS["k"] == 5, "k should default to 5"
+
+
+class TestClassify:
+    """Tests for the public ``cleopatra.styles.classify`` function."""
+
+    @pytest.mark.parametrize(
+        "scheme, expected",
+        [
+            ("equal_interval", [0.0, 19.8, 39.6, 59.4, 79.2, 99.0]),
+            ("quantiles", [0.0, 19.8, 39.6, 59.4, 79.2, 99.0]),
+            ("percentiles", [0.0, 19.8, 39.6, 59.4, 79.2, 99.0]),
+        ],
+    )
+    def test_uniform_ramp_edges(self, ramp, scheme, expected):
+        """Count/width schemes give known edges on a uniform ramp.
+
+        Args:
+            ramp: The 0..99 ramp fixture.
+            scheme: The scheme name under test.
+            expected: The expected bin edges (k=5).
+
+        Test scenario:
+            On a uniform ramp, equal-interval and equal-count schemes all
+            coincide on the same six edges.
+        """
+        edges, _ = classify(ramp, scheme, k=5)
+        assert np.allclose(edges, expected), f"{scheme} edges {edges} != {expected}"
+
+    def test_quantiles_equal_counts(self):
+        """Quantile classes hold (near) equal counts of points.
+
+        Test scenario:
+            With 100 points and k=4, each of the four classes holds ~25
+            points (digitize on the interior edges).
+        """
+        data = np.arange(100.0)
+        edges, _ = classify(data, "quantiles", k=4)
+        counts = np.bincount(np.clip(np.digitize(data, edges[1:-1]), 0, 3), minlength=4)
+        assert set(counts) <= {24, 25, 26}, f"Quantile counts not balanced: {counts}"
+
+    def test_equal_interval_equal_widths(self, ramp):
+        """Equal-interval classes have uniform width.
+
+        Test scenario:
+            The differences between successive edges are all equal.
+        """
+        edges, _ = classify(ramp, "equal_interval", k=5)
+        widths = np.diff(edges)
+        assert np.allclose(widths, widths[0]), f"Widths not uniform: {widths}"
+
+    def test_std_mean_breaks_and_ignores_k(self):
+        """``std_mean`` builds mean±nσ breaks regardless of ``k``.
+
+        Test scenario:
+            Edges are [min, mean-σ, mean, mean+σ, max] for a symmetric ramp
+            (the ±2σ breaks fall outside the data range and are dropped), and
+            passing a different ``k`` does not change the result.
+        """
+        data = np.arange(100.0)
+        edges_k5, _ = classify(data, "std_mean", k=5)
+        edges_k9, _ = classify(data, "std_mean", k=9)
+        assert np.allclose(edges_k5, edges_k9), "std_mean must ignore k"
+        mean, std = data.mean(), data.std()
+        assert np.isclose(edges_k5[0], data.min()), "first edge should be data min"
+        assert np.isclose(edges_k5[-1], data.max()), "last edge should be data max"
+        assert any(
+            np.isclose(edges_k5, mean)
+        ), f"mean break {mean} missing from {edges_k5}"
+        assert any(
+            np.isclose(edges_k5, mean - std)
+        ), "mean-σ break missing"
+
+    def test_explicit_edges_used_verbatim_sorted(self, ramp):
+        """A non-string ``scheme`` is treated as explicit, sorted edges.
+
+        Test scenario:
+            An unsorted edge sequence is sorted ascending and used as-is;
+            ``k`` is ignored.
+        """
+        edges, _ = classify(ramp, [50.0, 0.0, 99.0], k=5)
+        assert np.allclose(edges, [0.0, 50.0, 99.0]), f"Edges not sorted: {edges}"
+
+    def test_returns_boundary_norm_matching_edges(self, ramp):
+        """The returned norm is a ``BoundaryNorm`` over the same edges.
+
+        Test scenario:
+            ``classify`` returns a ``(edges, BoundaryNorm)`` pair whose
+            boundaries equal the edges.
+        """
+        edges, norm = classify(ramp, "equal_interval", k=5)
+        assert isinstance(norm, mcolors.BoundaryNorm), f"Expected BoundaryNorm, got {type(norm)}"
+        assert np.allclose(norm.boundaries, edges), "norm boundaries must equal edges"
+
+    def test_case_insensitive_scheme_name(self, ramp):
+        """Scheme names are matched case-insensitively.
+
+        Test scenario:
+            "Equal_Interval" resolves to the same edges as "equal_interval".
+        """
+        upper, _ = classify(ramp, "Equal_Interval", k=5)
+        lower, _ = classify(ramp, "equal_interval", k=5)
+        assert np.allclose(upper, lower), "Scheme lookup should be case-insensitive"
+
+    def test_non_finite_values_ignored(self):
+        """Non-finite entries do not influence the edges.
+
+        Test scenario:
+            A ramp with NaN/inf appended yields the same edges as the clean
+            ramp, because non-finite values are filtered out first.
+        """
+        clean = np.arange(100.0)
+        dirty = np.concatenate([clean, [np.nan, np.inf, -np.inf]])
+        edges_clean, _ = classify(clean, "equal_interval", k=5)
+        edges_dirty, _ = classify(dirty, "equal_interval", k=5)
+        assert np.allclose(edges_clean, edges_dirty), "Non-finite values must be ignored"
+
+    def test_duplicate_edges_collapsed(self):
+        """Repeated quantile edges are de-duplicated to keep edges increasing.
+
+        Test scenario:
+            Heavily tied data makes interior quantiles coincide; the result
+            still has strictly increasing edges (a valid BoundaryNorm).
+        """
+        data = np.array([0.0] * 90 + [1.0] * 10)
+        edges, norm = classify(data, "quantiles", k=5)
+        assert np.all(np.diff(edges) > 0), f"Edges must strictly increase: {edges}"
+        assert isinstance(norm, mcolors.BoundaryNorm), "Should still build a BoundaryNorm"
+
+    def test_no_finite_values_raises(self):
+        """All-non-finite input raises a clear ``ValueError``.
+
+        Test scenario:
+            An all-NaN array cannot be classified.
+        """
+        with pytest.raises(ValueError, match="no finite entries"):
+            classify(np.array([np.nan, np.inf]), "quantiles", k=5)
+
+    def test_degenerate_no_spread_raises(self):
+        """Constant data (no spread) raises a clear ``ValueError``.
+
+        Test scenario:
+            All-equal values collapse to a single edge, which cannot form a
+            BoundaryNorm.
+        """
+        with pytest.raises(ValueError, match="no spread"):
+            classify(np.full(10, 3.0), "quantiles", k=5)
+
+    def test_unknown_scheme_name_raises(self, ramp):
+        """An unrecognised scheme name raises ``ValueError`` listing valid ones.
+
+        Test scenario:
+            "rainbow" is not a scheme; the message names the valid schemes.
+        """
+        with pytest.raises(ValueError, match="Unknown classification scheme"):
+            classify(ramp, "rainbow", k=5)
+
+    @pytest.mark.parametrize("bad_k", [0, -1])
+    def test_k_below_one_raises(self, ramp, bad_k):
+        """``k < 1`` raises ``ValueError`` for the count/width schemes.
+
+        Args:
+            ramp: The ramp fixture.
+            bad_k: An invalid class count.
+
+        Test scenario:
+            Fewer than one class is meaningless and rejected.
+        """
+        with pytest.raises(ValueError, match="`k` must be >= 1"):
+            classify(ramp, "quantiles", k=bad_k)
+
+
+class TestSchemeEdges:
+    """Tests for the private ``_scheme_edges`` helper."""
+
+    def test_routes_jenks_to_extra(self):
+        """A Jenks name is routed to the optional-extra path.
+
+        Test scenario:
+            With mapclassify absent, requesting fisher_jenks surfaces the
+            install hint (proving the routing, not the computation).
+        """
+        with pytest.raises(ModuleNotFoundError, match="cleopatra\\[classify\\]"):
+            _scheme_edges(np.arange(10.0), "fisher_jenks", k=3)
+
+    def test_std_mean_k_ignored_branch(self):
+        """``_scheme_edges`` does not validate ``k`` for ``std_mean``.
+
+        Test scenario:
+            ``k=0`` would raise for quantiles, but std_mean ignores k and
+            returns edges without error.
+        """
+        edges = _scheme_edges(np.arange(100.0), "std_mean", k=0)
+        assert edges[0] == 0.0 and edges[-1] == 99.0, f"Unexpected std_mean edges: {edges}"
+
+
+class TestJenksEdges:
+    """Tests for the private ``_jenks_edges`` helper."""
+
+    def test_missing_mapclassify_raises_with_hint(self):
+        """A missing optional extra raises ``ModuleNotFoundError`` with a hint.
+
+        Test scenario:
+            mapclassify is not installed in the test environment, so the
+            helper re-raises with an actionable ``pip install`` hint.
+        """
+        with pytest.raises(ModuleNotFoundError, match="pip install 'cleopatra\\[classify\\]'"):
+            _jenks_edges(np.arange(10.0), "natural_breaks", k=3)
+
+    def test_k_below_one_raises(self):
+        """``_jenks_edges`` validates ``k`` before importing the extra.
+
+        Test scenario:
+            ``k < 1`` raises ``ValueError`` regardless of mapclassify.
+        """
+        with pytest.raises(ValueError, match="`k` must be >= 1"):
+            _jenks_edges(np.arange(10.0), "fisher_jenks", k=0)
+
+    def test_uses_mapclassify_when_available(self, monkeypatch):
+        """When mapclassify is importable, edges are ``[min, *bins]``.
+
+        Test scenario:
+            A fake ``mapclassify`` module with a ``FisherJenks`` classifier is
+            injected; the helper prepends the data minimum to the classifier
+            bins.
+        """
+        import sys
+        import types
+
+        fake = types.ModuleType("mapclassify")
+
+        class _FisherJenks:
+            def __init__(self, data, k):
+                self.bins = np.array([3.0, 6.0, 9.0])
+
+        fake.FisherJenks = _FisherJenks
+        monkeypatch.setitem(sys.modules, "mapclassify", fake)
+        edges = _jenks_edges(np.arange(10.0), "fisher_jenks", k=3)
+        assert np.allclose(edges, [0.0, 3.0, 6.0, 9.0]), f"Unexpected jenks edges: {edges}"
+
+
+class TestGlyphPrepareClassifiedMapping:
+    """Tests for ``Glyph._prepare_classified_mapping`` and the routing."""
+
+    def test_returns_norm_cbar_edges_triple(self):
+        """The helper returns the ``(norm, cbar_kw, edges)`` contract.
+
+        Test scenario:
+            A quantile scheme yields a BoundaryNorm, boundary ticks, and the
+            bin edges in the ticks slot.
+        """
+        g = Glyph(default_options=_make_options(scheme="quantiles", k=4))
+        norm, cbar_kw, edges = g._prepare_classified_mapping(np.arange(100.0), "quantiles")
+        assert isinstance(norm, mcolors.BoundaryNorm), "norm must be a BoundaryNorm"
+        assert np.allclose(cbar_kw["ticks"], edges), "cbar ticks must be the edges"
+        assert len(edges) == 5, f"k=4 should give 5 edges, got {len(edges)}"
+
+    def test_extend_defaults_to_neither(self):
+        """``extend`` defaults to ``'neither'`` when unset.
+
+        Test scenario:
+            No ``extend`` option present -> the colorbar does not extend.
+        """
+        g = Glyph(default_options=_make_options(scheme="quantiles", k=4))
+        _, cbar_kw, _ = g._prepare_classified_mapping(np.arange(100.0), "quantiles")
+        assert cbar_kw["extend"] == "neither", f"extend should be 'neither', got {cbar_kw['extend']}"
+
+    def test_explicit_extend_is_honoured(self):
+        """An explicit ``extend`` option is forwarded unchanged.
+
+        Test scenario:
+            ``extend='both'`` survives into the colorbar kwargs.
+        """
+        opts = _make_options(scheme="quantiles", k=4)
+        opts["extend"] = "both"
+        g = Glyph(default_options=opts)
+        _, cbar_kw, _ = g._prepare_classified_mapping(np.arange(100.0), "quantiles")
+        assert cbar_kw["extend"] == "both", "Explicit extend must be honoured"
+
+    def test_prepare_scalar_mapping_routes_to_classified(self):
+        """``_prepare_scalar_mapping`` short-circuits when ``scheme`` is set.
+
+        Test scenario:
+            With a scheme configured, the shared entry point returns a
+            BoundaryNorm rather than the continuous (None) linear norm.
+        """
+        g = Glyph(default_options=_make_options(scheme="equal_interval", k=5))
+        norm, _, edges = g._prepare_scalar_mapping(np.arange(100.0))
+        assert isinstance(norm, mcolors.BoundaryNorm), "scheme must route to BoundaryNorm"
+        assert len(edges) == 6, f"k=5 should give 6 edges, got {len(edges)}"
+
+    def test_prepare_scalar_mapping_unchanged_without_scheme(self):
+        """Without a scheme, the continuous linear path is unchanged.
+
+        Test scenario:
+            ``scheme=None`` keeps the default linear norm (``None``).
+        """
+        g = Glyph(default_options=_make_options())
+        norm, _, _ = g._prepare_scalar_mapping(np.arange(100.0))
+        assert norm is None, "Linear default should yield norm=None when no scheme"
+
+    def test_k_option_controls_class_count(self):
+        """The ``k`` option drives the number of classes.
+
+        Test scenario:
+            k=3 yields four edges (three classes).
+        """
+        g = Glyph(default_options=_make_options(scheme="quantiles", k=3))
+        _, _, edges = g._prepare_scalar_mapping(np.arange(100.0))
+        assert len(edges) == 4, f"k=3 should give 4 edges, got {len(edges)}"
+
+
+class TestScatterGlyphScheme:
+    """Integration tests for ``scheme`` through ScatterGlyph."""
+
+    @pytest.fixture()
+    def xy_values(self):
+        """Ten points on a line with a 0..9 value ramp.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray, np.ndarray]: x, y, and values.
+        """
+        x = np.arange(10.0)
+        return x, np.zeros_like(x), x.copy()
+
+    def test_scheme_produces_boundary_norm(self, xy_values):
+        """A scheme colours the scatter through a BoundaryNorm.
+
+        Test scenario:
+            ``scheme='quantiles'`` makes the PathCollection use a discrete
+            BoundaryNorm with k+1 boundaries.
+        """
+        x, y, v = xy_values
+        glyph = ScatterGlyph(x, y, values=v, scheme="quantiles", k=5)
+        _, _, paths = glyph.plot()
+        assert isinstance(paths.norm, mcolors.BoundaryNorm), "scheme should set a BoundaryNorm"
+        assert len(paths.norm.boundaries) == 6, "k=5 should give 6 boundaries"
+
+    def test_raw_values_preserved(self, xy_values):
+        """Classification does not alter the underlying value array.
+
+        Test scenario:
+            ``get_array`` still returns the raw per-point values.
+        """
+        x, y, v = xy_values
+        glyph = ScatterGlyph(x, y, values=v, scheme="equal_interval", k=4)
+        _, _, paths = glyph.plot()
+        assert np.array_equal(paths.get_array(), v), "Raw values must be preserved"
+
+    def test_colorbar_drawn_by_default(self, xy_values):
+        """A classified scatter draws a (stepped) colorbar by default.
+
+        Test scenario:
+            ``add_colorbar`` defaults to True, so a colorbar is created.
+        """
+        x, y, v = xy_values
+        glyph = ScatterGlyph(x, y, values=v, scheme="quantiles", k=5)
+        glyph.plot()
+        assert glyph.cbar is not None, "A colorbar should be drawn by default"
+
+    def test_add_colorbar_false_suppresses(self, xy_values):
+        """``add_colorbar=False`` suppresses the colorbar with a scheme set.
+
+        Test scenario:
+            The plot-time override wins and no colorbar is created.
+        """
+        x, y, v = xy_values
+        glyph = ScatterGlyph(x, y, values=v, scheme="quantiles", k=5)
+        glyph.plot(add_colorbar=False)
+        assert glyph.cbar is None, "add_colorbar=False should suppress the colorbar"
+
+    def test_scheme_none_regression(self, xy_values):
+        """``scheme=None`` keeps the continuous (non-BoundaryNorm) behaviour.
+
+        Test scenario:
+            Without a scheme the scatter is not normalised by a BoundaryNorm.
+        """
+        x, y, v = xy_values
+        glyph = ScatterGlyph(x, y, values=v)
+        _, _, paths = glyph.plot()
+        assert not isinstance(paths.norm, mcolors.BoundaryNorm), "No scheme -> no BoundaryNorm"
+
+
+class TestPolygonGlyphScheme:
+    """Integration tests for ``scheme`` through PolygonGlyph (choropleth)."""
+
+    @pytest.fixture()
+    def polys_values(self):
+        """Ten triangles with a 0..9 value ramp.
+
+        Returns:
+            tuple[list[np.ndarray], np.ndarray]: polygon vertices and values.
+        """
+        polys = [
+            np.array([[i, 0.0], [i + 1, 0.0], [i + 0.5, 1.0]]) for i in range(10)
+        ]
+        return polys, np.arange(10.0)
+
+    def test_five_discrete_classes(self, polys_values):
+        """A k=5 quantile choropleth yields five discrete classes.
+
+        Test scenario:
+            The PolyCollection uses a BoundaryNorm whose six boundaries
+            delimit five fill classes.
+        """
+        polys, values = polys_values
+        glyph = PolygonGlyph(polys, values=values, scheme="quantiles", k=5)
+        _, _, pc = glyph.plot()
+        assert isinstance(pc.norm, mcolors.BoundaryNorm), "choropleth should use a BoundaryNorm"
+        assert len(pc.norm.boundaries) - 1 == 5, "Six boundaries delimit five classes"
+
+    def test_raw_values_preserved(self, polys_values):
+        """The polygon array still carries the raw values.
+
+        Test scenario:
+            ``get_array`` returns the unbinned per-polygon values.
+        """
+        polys, values = polys_values
+        glyph = PolygonGlyph(polys, values=values, scheme="quantiles", k=5)
+        _, _, pc = glyph.plot()
+        assert np.array_equal(pc.get_array(), values), "Raw values must be preserved"
+
+    def test_discrete_colorbar_drawn(self, polys_values):
+        """A discrete colorbar is attached for a classified choropleth.
+
+        Test scenario:
+            The colorbar exists and its norm is the discrete BoundaryNorm.
+        """
+        polys, values = polys_values
+        glyph = PolygonGlyph(polys, values=values, scheme="quantiles", k=5)
+        glyph.plot()
+        assert glyph.cbar is not None, "A discrete colorbar should be drawn"
+        assert isinstance(glyph.cbar.norm, mcolors.BoundaryNorm), "Colorbar norm should be discrete"
+
+    def test_scheme_none_regression(self, polys_values):
+        """``scheme=None`` keeps the continuous choropleth behaviour.
+
+        Test scenario:
+            Without a scheme the PolyCollection is not BoundaryNorm-normalised.
+        """
+        polys, values = polys_values
+        glyph = PolygonGlyph(polys, values=values)
+        _, _, pc = glyph.plot()
+        assert not isinstance(pc.norm, mcolors.BoundaryNorm), "No scheme -> no BoundaryNorm"

--- a/tests/test_flow_glyph.py
+++ b/tests/test_flow_glyph.py
@@ -1,0 +1,366 @@
+"""Tests for cleopatra.flow_glyph.FlowGlyph and styles.width_legend — issue #157.
+
+Covers the width legend helper, FlowGlyph construction/validation, the
+value→width resolution, the width-legend drawing helper, and the `plot`
+rendering contract (colour by value, width by magnitude, colorbar toggle).
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.collections import LineCollection
+from matplotlib.legend import Legend
+
+from cleopatra.flow_glyph import FLOW_DEFAULT_OPTIONS, FlowGlyph
+from cleopatra.styles import width_legend
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def paths():
+    """Five horizontal polylines stacked vertically.
+
+    Returns:
+        list[np.ndarray]: Five `(2, 2)` vertex arrays.
+    """
+    return [np.array([[0.0, float(i)], [1.0, float(i)]]) for i in range(5)]
+
+
+@pytest.fixture()
+def values():
+    """A per-path colour magnitude aligned with the `paths` fixture.
+
+    Returns:
+        np.ndarray: Five ascending values.
+    """
+    return np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+
+@pytest.fixture()
+def widths():
+    """A per-path width magnitude (deliberately unsorted).
+
+    Returns:
+        np.ndarray: Five magnitudes whose ranking differs from `values`.
+    """
+    return np.array([2.0, 1.0, 5.0, 3.0, 9.0])
+
+
+class TestWidthLegend:
+    """Tests for the styles.width_legend helper."""
+
+    def test_labels_round_trip(self):
+        """The legend exposes its labels in order.
+
+        Test scenario:
+            Three labels come back unchanged from the legend texts.
+        """
+        fig, ax = plt.subplots()
+        legend = width_legend(ax, [1.0, 3.0, 5.0], ["low", "mid", "high"])
+        texts = [t.get_text() for t in legend.get_texts()]
+        assert texts == ["low", "mid", "high"], f"Unexpected labels: {texts}"
+
+    def test_linewidth_matches_input(self):
+        """Each proxy line uses the supplied linewidth.
+
+        Test scenario:
+            Inputs 1 and 4 become handle linewidths 1 and 4.
+        """
+        fig, ax = plt.subplots()
+        legend = width_legend(ax, [1.0, 4.0], ["thin", "thick"])
+        handles = legend.legend_handles
+        assert handles[0].get_linewidth() == 1.0, "First handle should be 1.0 wide"
+        assert handles[1].get_linewidth() == 4.0, "Second handle should be 4.0 wide"
+
+    def test_forwards_legend_kwargs(self):
+        """`Axes.legend` kwargs such as `title` are forwarded.
+
+        Test scenario:
+            A title passed through reaches the legend title text.
+        """
+        fig, ax = plt.subplots()
+        legend = width_legend(ax, [1.0, 2.0], ["a", "b"], title="Flow")
+        assert legend.get_title().get_text() == "Flow", "title kwarg should be forwarded"
+
+    def test_length_mismatch_raises(self):
+        """Mismatched lengths raise ValueError.
+
+        Test scenario:
+            Two widths but one label is rejected.
+        """
+        fig, ax = plt.subplots()
+        with pytest.raises(ValueError, match="same length"):
+            width_legend(ax, [1.0, 2.0], ["only-one"])
+
+
+class TestFlowGlyphInit:
+    """Tests for FlowGlyph.__init__."""
+
+    def test_paths_stored_as_float_arrays(self, paths):
+        """Path vertices are stored as float ndarrays.
+
+        Test scenario:
+            Integer-typed vertex lists are converted to float arrays.
+        """
+        glyph = FlowGlyph([[[0, 0], [1, 1]]])
+        assert glyph.paths[0].dtype == float, "Paths should be stored as float arrays"
+        assert glyph.values is None and glyph.widths is None, "values/widths default to None"
+
+    def test_defaults_present(self, paths):
+        """Flow-specific option defaults are exposed.
+
+        Test scenario:
+            width_limits/width_scale defaults and None ticks_spacing.
+        """
+        glyph = FlowGlyph(paths)
+        assert glyph.default_options["width_limits"] == (1, 5), "Default width_limits should be (1, 5)"
+        assert glyph.default_options["width_scale"] == "linear", "Default width_scale should be linear"
+        assert glyph.default_options["ticks_spacing"] is None, "ticks_spacing should auto-derive"
+
+    def test_mismatched_values_raises(self, paths):
+        """A values array not matching the path count raises ValueError.
+
+        Test scenario:
+            len(values) != len(paths) is rejected.
+        """
+        with pytest.raises(ValueError, match="values must have one entry per path"):
+            FlowGlyph(paths, values=np.array([1.0, 2.0]))
+
+    def test_mismatched_widths_raises(self, paths):
+        """A widths array not matching the path count raises ValueError.
+
+        Test scenario:
+            len(widths) != len(paths) is rejected.
+        """
+        with pytest.raises(ValueError, match="widths must have one entry per path"):
+            FlowGlyph(paths, widths=np.array([1.0, 2.0]))
+
+    def test_invalid_kwarg_raises(self, paths):
+        """An unknown kwarg is rejected by the strict merge.
+
+        Test scenario:
+            A key absent from FLOW_DEFAULT_OPTIONS raises ValueError.
+        """
+        with pytest.raises(ValueError, match="not correct"):
+            FlowGlyph(paths, not_an_option=1)
+
+
+class TestFlowGlyphResolveLinewidths:
+    """Tests for FlowGlyph._resolve_linewidths."""
+
+    def test_scalar_when_no_widths(self, paths):
+        """Without widths the scalar `line_width` option is returned.
+
+        Test scenario:
+            A FlowGlyph with no widths resolves to the scalar line_width.
+        """
+        glyph = FlowGlyph(paths, line_width=2.5)
+        assert glyph._resolve_linewidths() == 2.5, "Should return scalar line_width"
+
+    def test_array_spans_width_limits(self, paths, widths):
+        """With widths the result spans width_limits monotonically.
+
+        Test scenario:
+            The per-path widths run from width_limits[0] to width_limits[1]
+            in the order of the input magnitudes.
+        """
+        glyph = FlowGlyph(paths, widths=widths, width_limits=(1, 5))
+        out = np.asarray(glyph._resolve_linewidths())
+        assert np.isclose(out.min(), 1.0), f"min width should be 1.0, got {out.min()}"
+        assert np.isclose(out.max(), 5.0), f"max width should be 5.0, got {out.max()}"
+        assert np.array_equal(np.argsort(out), np.argsort(widths)), "Widths not monotonic in input"
+
+    @pytest.mark.parametrize("scale", ["linear", "log", "sqrt"])
+    def test_width_scale_modes(self, paths, scale):
+        """Each width_scale yields a monotonic per-path width array.
+
+        Args:
+            paths: The polyline fixture.
+            scale: The width scale under test.
+
+        Test scenario:
+            For positive magnitudes every scale preserves the ranking.
+        """
+        widths = np.array([1.0, 2.0, 4.0, 8.0, 16.0])
+        glyph = FlowGlyph(paths, widths=widths, width_scale=scale, width_limits=(1, 5))
+        out = np.asarray(glyph._resolve_linewidths())
+        assert np.array_equal(np.argsort(out), np.argsort(widths)), f"{scale} not monotonic"
+
+
+class TestFlowGlyphDrawWidthLegend:
+    """Tests for FlowGlyph._draw_width_legend (via plot)."""
+
+    def test_default_three_quantile_entries(self, paths, widths):
+        """The default width legend has three (min/median/max) entries.
+
+        Test scenario:
+            size_legend=True with no explicit values draws three entries.
+        """
+        glyph = FlowGlyph(paths, widths=widths, size_legend=True)
+        glyph.plot()
+        assert isinstance(glyph.size_legend_artist, Legend), "A width legend should be drawn"
+        texts = [t.get_text() for t in glyph.size_legend_artist.get_texts()]
+        assert len(texts) == 3, f"Default legend should have 3 entries, got {texts}"
+
+    def test_explicit_legend_values(self, paths, widths):
+        """Explicit size_legend_values control the legend entries.
+
+        Test scenario:
+            Two representative magnitudes give two labelled entries.
+        """
+        glyph = FlowGlyph(paths, widths=widths, size_legend=True,
+                          size_legend_values=[2.0, 8.0])
+        glyph.plot()
+        texts = [t.get_text() for t in glyph.size_legend_artist.get_texts()]
+        assert texts == ["2", "8"], f"Legend should honour explicit values, got {texts}"
+
+    def test_no_legend_without_widths(self, paths, values):
+        """No legend is drawn when there are no widths, even if requested.
+
+        Test scenario:
+            size_legend=True but widths None leaves the legend unset.
+        """
+        glyph = FlowGlyph(paths, values=values, size_legend=True)
+        glyph.plot()
+        assert glyph.size_legend_artist is None, "No width legend without widths"
+
+
+class TestFlowGlyphPlot:
+    """Tests for FlowGlyph.plot."""
+
+    def test_returns_line_collection(self, paths):
+        """plot returns a LineCollection added to the axes.
+
+        Test scenario:
+            The third return value is a LineCollection.
+        """
+        glyph = FlowGlyph(paths)
+        fig, ax, lc = glyph.plot()
+        assert isinstance(lc, LineCollection), f"Expected LineCollection, got {type(lc)}"
+
+    def test_uncoloured_single_colour_no_colorbar(self, paths):
+        """Without values the lines are single-colour with no colorbar.
+
+        Test scenario:
+            values None -> no colour array and no colorbar.
+        """
+        glyph = FlowGlyph(paths)
+        _, _, lc = glyph.plot()
+        assert lc.get_array() is None, "Uncoloured collection should carry no array"
+        assert glyph.cbar is None, "No colorbar without values"
+
+    def test_coloured_carries_values_and_colorbar(self, paths, values):
+        """With values the collection carries them and gains a colorbar.
+
+        Test scenario:
+            get_array equals the input values and a colorbar is attached.
+        """
+        glyph = FlowGlyph(paths, values=values)
+        _, _, lc = glyph.plot()
+        assert np.array_equal(lc.get_array(), values), "Colour array should equal values"
+        assert glyph.cbar is not None, "A colorbar should be drawn by default"
+
+    def test_colorbar_reflects_value_range(self, paths, values):
+        """The colorbar spans the value range.
+
+        Test scenario:
+            The colorbar starts at the value minimum and covers the maximum
+            (its upper limit may round slightly past `vmax` via the shared
+            tick spacing, exactly as for the other glyphs).
+        """
+        glyph = FlowGlyph(paths, values=values)
+        glyph.plot()
+        lo, hi = glyph.cbar.mappable.get_clim()
+        assert np.isclose(lo, values.min()), f"Colorbar should start at {values.min()}, got {lo}"
+        assert hi >= values.max(), f"Colorbar should cover {values.max()}, got {hi}"
+
+    def test_colorbar_with_discrete_levels(self, paths, values):
+        """An integer `levels` colours via a discrete BoundaryNorm.
+
+        Test scenario:
+            With levels set, the collection's norm carries discrete
+            boundaries (and `set_clim` is bypassed).
+        """
+        glyph = FlowGlyph(paths, values=values, levels=4)
+        _, _, lc = glyph.plot()
+        assert lc.norm.boundaries is not None, "levels should yield a BoundaryNorm"
+        assert glyph.cbar is not None, "A colorbar should still be drawn"
+
+    def test_linewidths_monotonic_and_span_limits(self, paths, widths):
+        """get_linewidths runs monotonically with widths and spans limits.
+
+        Test scenario:
+            The drawn linewidths order matches the widths order and the
+            extremes equal width_limits.
+        """
+        glyph = FlowGlyph(paths, widths=widths, width_limits=(1, 5))
+        _, _, lc = glyph.plot()
+        lw = np.asarray(lc.get_linewidths())
+        assert np.array_equal(np.argsort(lw), np.argsort(widths)), "Linewidths not monotonic in widths"
+        assert np.isclose(lw.min(), 1.0) and np.isclose(lw.max(), 5.0), (
+            f"Linewidths should span (1, 5), got [{lw.min()}, {lw.max()}]"
+        )
+
+    def test_add_colorbar_false_suppresses(self, paths, values):
+        """add_colorbar=False suppresses the colorbar.
+
+        Test scenario:
+            The plot-time override wins and no colorbar is created.
+        """
+        glyph = FlowGlyph(paths, values=values)
+        glyph.plot(add_colorbar=False)
+        assert glyph.cbar is None, "add_colorbar=False should suppress the colorbar"
+
+    def test_widths_none_uses_scalar_line_width(self, paths, values):
+        """Without widths every line uses the scalar line_width.
+
+        Test scenario:
+            All linewidths equal the line_width option.
+        """
+        glyph = FlowGlyph(paths, values=values, line_width=2.0)
+        _, _, lc = glyph.plot()
+        lw = np.asarray(lc.get_linewidths())
+        assert np.all(lw == 2.0), f"All linewidths should be 2.0, got {set(lw.tolist())}"
+
+    def test_title_override(self, paths):
+        """A title passed to plot overrides the default.
+
+        Test scenario:
+            plot(title=...) sets the axes title.
+        """
+        glyph = FlowGlyph(paths)
+        _, ax, _ = glyph.plot(title="Flows")
+        assert ax.get_title() == "Flows", f"Title should be 'Flows', got {ax.get_title()!r}"
+
+    def test_plot_on_supplied_axes(self, paths):
+        """plot(ax=...) draws on the supplied axes.
+
+        Test scenario:
+            A pre-existing axes is used and its figure adopted.
+        """
+        fig, host_ax = plt.subplots()
+        glyph = FlowGlyph(paths)
+        _, out_ax, _ = glyph.plot(ax=host_ax)
+        assert out_ax is host_ax, "plot should draw on the supplied axes"
+
+    def test_plot_uses_axes_from_construction(self, paths):
+        """plot() reuses an axes supplied at construction.
+
+        Test scenario:
+            With an axes passed to __init__, a no-arg plot() reuses it.
+        """
+        fig, host_ax = plt.subplots()
+        glyph = FlowGlyph(paths, ax=host_ax)
+        _, out_ax, _ = glyph.plot()
+        assert out_ax is host_ax, "plot() should reuse the construction axes"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,6 +21,7 @@ _SUBMODULES = [
     "array_glyph",
     "colors",
     "config",
+    "flow_glyph",
     "glyph",
     "line_glyph",
     "mesh_glyph",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -23,6 +23,7 @@ _SUBMODULES = [
     "config",
     "flow_glyph",
     "glyph",
+    "kde_glyph",
     "line_glyph",
     "mesh_glyph",
     "polygon_glyph",

--- a/tests/test_kde_glyph.py
+++ b/tests/test_kde_glyph.py
@@ -1,0 +1,434 @@
+"""Tests for cleopatra.kde_glyph.KDEGlyph — issue #156.
+
+Covers construction/validation, the bandwidth rule, grid evaluation (including
+the memory-chunking path), level resolution, contour clipping, and the
+`plot` rendering contract. The estimator is numpy-only; one test asserts scipy
+is never imported.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.contour import QuadContourSet
+from matplotlib.patches import Circle
+from matplotlib.path import Path as MplPath
+
+import cleopatra.kde_glyph as kde_mod
+from cleopatra.kde_glyph import KDE_DEFAULT_OPTIONS, KDEGlyph
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def cloud():
+    """A reproducible 2-D Gaussian point cloud.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: 400 x and y coordinates from a fixed
+            seed.
+    """
+    rng = np.random.default_rng(1234)
+    return rng.normal(size=400), rng.normal(size=400)
+
+
+@pytest.fixture()
+def bimodal():
+    """Two tight, well-separated clusters at (0, 0) and (5, 5).
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: x and y coordinates of the clusters.
+    """
+    rng = np.random.default_rng(7)
+    a = rng.normal(scale=0.1, size=300)
+    b = rng.normal(scale=0.1, size=300)
+    x = np.concatenate([a, a + 5.0])
+    y = np.concatenate([b, b + 5.0])
+    return x, y
+
+
+class TestKDEGlyphInit:
+    """Tests for KDEGlyph.__init__."""
+
+    def test_stores_coordinates_and_defaults(self, cloud):
+        """Coordinates are stored as float arrays and defaults are present.
+
+        Test scenario:
+            x/y become float ndarrays; clip_path defaults to None and cbar
+            is unset until plot.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y)
+        assert glyph.x.dtype == float, "x should be stored as float"
+        assert glyph.clip_path is None, "clip_path should default to None"
+        assert glyph.cbar is None, "cbar should be None before plotting"
+        assert glyph.default_options["gridsize"] == 100, "default gridsize should be 100"
+
+    def test_clip_path_stored(self, cloud):
+        """A supplied clip_path is stored on the glyph.
+
+        Test scenario:
+            A Circle patch passed at construction is kept for plot time.
+        """
+        x, y = cloud
+        patch = Circle((0, 0), 1.0)
+        glyph = KDEGlyph(x, y, clip_path=patch)
+        assert glyph.clip_path is patch, "clip_path should be stored verbatim"
+
+    def test_mismatched_xy_raises(self):
+        """x and y of different lengths raise ValueError.
+
+        Test scenario:
+            len(x) != len(y) is rejected at construction.
+        """
+        with pytest.raises(ValueError, match="same shape"):
+            KDEGlyph(np.arange(5.0), np.arange(4.0))
+
+    def test_too_few_points_raises(self):
+        """Fewer than two points raise ValueError.
+
+        Test scenario:
+            A single point cannot define a KDE.
+        """
+        with pytest.raises(ValueError, match="at least 2 points"):
+            KDEGlyph(np.array([1.0]), np.array([2.0]))
+
+    @pytest.mark.parametrize("bad_bw", [0.0, -1.0])
+    def test_non_positive_bw_method_raises(self, cloud, bad_bw):
+        """A non-positive ``bw_method`` raises ValueError.
+
+        Args:
+            cloud: The point-cloud fixture.
+            bad_bw: An invalid bandwidth multiplier.
+
+        Test scenario:
+            Zero or negative bandwidth multipliers are rejected.
+        """
+        x, y = cloud
+        with pytest.raises(ValueError, match="positive float or None"):
+            KDEGlyph(x, y, bw_method=bad_bw)
+
+    def test_invalid_kwarg_raises(self, cloud):
+        """An unknown kwarg is rejected by the strict merge.
+
+        Test scenario:
+            A key absent from KDE_DEFAULT_OPTIONS raises ValueError.
+        """
+        x, y = cloud
+        with pytest.raises(ValueError, match="not correct"):
+            KDEGlyph(x, y, not_an_option=1)
+
+
+class TestKDEGlyphBandwidth:
+    """Tests for KDEGlyph._bandwidth."""
+
+    def test_scotts_rule_default(self, cloud):
+        """The default bandwidth is Scott's rule ``n ** (-1/6)``.
+
+        Test scenario:
+            With no bw_method, the factor is n**(-1/6).
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y)
+        expected = x.size ** (-1.0 / 6.0)
+        assert np.isclose(glyph._bandwidth(), expected), (
+            f"Expected Scott's factor {expected}, got {glyph._bandwidth()}"
+        )
+
+    def test_bw_method_multiplier(self, cloud):
+        """``bw_method`` scales Scott's rule linearly.
+
+        Test scenario:
+            bw_method=2 doubles the Scott's-rule factor.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, bw_method=2.0)
+        expected = 2.0 * x.size ** (-1.0 / 6.0)
+        assert np.isclose(glyph._bandwidth(), expected), (
+            f"Expected {expected}, got {glyph._bandwidth()}"
+        )
+
+
+class TestKDEGlyphEvaluate:
+    """Tests for KDEGlyph.evaluate."""
+
+    def test_grid_shape(self, cloud):
+        """The grid and density share the ``gridsize × gridsize`` shape.
+
+        Test scenario:
+            gridsize=50 yields 50×50 gx, gy, and density arrays.
+        """
+        x, y = cloud
+        gx, gy, density = KDEGlyph(x, y, gridsize=50).evaluate()
+        assert gx.shape == (50, 50), f"gx shape should be (50, 50), got {gx.shape}"
+        assert density.shape == (50, 50), f"density shape should be (50, 50), got {density.shape}"
+
+    def test_density_positive(self, cloud):
+        """The density grid is strictly positive everywhere.
+
+        Test scenario:
+            A Gaussian kernel sum is positive across the whole grid.
+        """
+        x, y = cloud
+        _, _, density = KDEGlyph(x, y, gridsize=40).evaluate()
+        assert np.all(density > 0), "Density should be positive everywhere"
+
+    def test_density_integrates_to_about_one(self, cloud):
+        """The density integrates to approximately 1 over the grid.
+
+        Test scenario:
+            A trapezoidal integral of the normalised density is near 1 for a
+            grid that comfortably spans the cloud.
+        """
+        x, y = cloud
+        gx, gy, density = KDEGlyph(x, y, gridsize=200).evaluate()
+        dx = gx[0, 1] - gx[0, 0]
+        dy = gy[1, 0] - gy[0, 0]
+        integral = density.sum() * dx * dy
+        assert 0.8 < integral < 1.2, f"Density integral should be ~1, got {integral}"
+
+    def test_density_peaks_near_cluster(self, bimodal):
+        """The global density peak sits near a cluster centre.
+
+        Test scenario:
+            For clusters at (0,0)/(5,5) the argmax cell is within 1.0 of one
+            centre in each axis.
+        """
+        x, y = bimodal
+        gx, gy, density = KDEGlyph(x, y, gridsize=60).evaluate()
+        peak = np.unravel_index(int(np.argmax(density)), density.shape)
+        near_x = min(abs(gx[peak] - 0.0), abs(gx[peak] - 5.0))
+        near_y = min(abs(gy[peak] - 0.0), abs(gy[peak] - 5.0))
+        assert near_x < 1.0 and near_y < 1.0, (
+            f"Peak {(gx[peak], gy[peak])} not near a cluster centre"
+        )
+
+    @pytest.mark.parametrize("x, y", [
+        (np.zeros(10), np.arange(10.0)),
+        (np.arange(10.0), np.full(10, 3.0)),
+    ])
+    def test_zero_spread_raises(self, x, y):
+        """A zero-spread coordinate raises ValueError.
+
+        Args:
+            x: x-coordinates (constant in one parametrisation).
+            y: y-coordinates (constant in the other).
+
+        Test scenario:
+            A degenerate kernel (std 0 in x or y) is rejected.
+        """
+        with pytest.raises(ValueError, match="zero spread"):
+            KDEGlyph(x, y).evaluate()
+
+    def test_chunking_matches_unchunked(self, cloud, monkeypatch):
+        """Chunked evaluation equals the single-block result.
+
+        Test scenario:
+            Forcing a tiny MAX_KDE_BLOCK (so the point loop runs in many
+            blocks) yields a density identical to the default single block.
+        """
+        x, y = cloud
+        reference = KDEGlyph(x, y, gridsize=30).evaluate()[2]
+        monkeypatch.setattr(kde_mod, "MAX_KDE_BLOCK", 5000)
+        chunked = KDEGlyph(x, y, gridsize=30).evaluate()[2]
+        assert np.allclose(reference, chunked), "Chunked result must match unchunked"
+
+
+class TestKDEGlyphResolveLevels:
+    """Tests for KDEGlyph._resolve_levels."""
+
+    def test_int_levels_evenly_spaced(self, cloud):
+        """An integer ``levels`` gives that many evenly-spaced edges.
+
+        Test scenario:
+            levels=6 yields 6 edges from density.min to density.max.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30, levels=6)
+        _, _, density = glyph.evaluate()
+        edges = glyph._resolve_levels(density)
+        assert edges.size == 6, f"Expected 6 edges, got {edges.size}"
+        assert np.isclose(edges[0], density.min()), "First edge should be density min"
+        assert np.isclose(edges[-1], density.max()), "Last edge should be density max"
+        assert np.allclose(np.diff(edges), np.diff(edges)[0]), "Edges should be evenly spaced"
+
+    def test_sequence_levels_sorted(self, cloud):
+        """An explicit ``levels`` sequence is sorted ascending.
+
+        Test scenario:
+            An unsorted list of edges is returned sorted.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30, levels=[0.3, 0.1, 0.2])
+        edges = glyph._resolve_levels(np.zeros((3, 3)))
+        assert np.allclose(edges, [0.1, 0.2, 0.3]), f"Edges should be sorted, got {edges}"
+
+
+class TestKDEGlyphApplyClip:
+    """Tests for KDEGlyph._apply_clip."""
+
+    def test_none_is_noop(self, cloud):
+        """No clip path leaves the contour set unclipped.
+
+        Test scenario:
+            With clip_path None, the drawn set has the default axes clip
+            (not a custom one).
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30)
+        _, _, cs = glyph.plot()
+        assert glyph.clip_path is None, "clip_path should be None"
+
+    def test_patch_clip_applied(self, cloud):
+        """A Patch clip path is applied to the contour set.
+
+        Test scenario:
+            A Circle patch produces a non-None clip path on the drawn set.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30, clip_path=Circle((0, 0), 1.0))
+        _, _, cs = glyph.plot()
+        assert cs.get_clip_path() is not None, "Patch clip should be applied"
+
+    def test_path_clip_applied(self, cloud):
+        """A Path clip path is applied in data coordinates.
+
+        Test scenario:
+            A square Path produces a non-None clip path on the drawn set.
+        """
+        x, y = cloud
+        square = MplPath([(-1, -1), (1, -1), (1, 1), (-1, 1), (-1, -1)])
+        glyph = KDEGlyph(x, y, gridsize=30, clip_path=square)
+        _, _, cs = glyph.plot()
+        assert cs.get_clip_path() is not None, "Path clip should be applied"
+
+    def test_unsupported_clip_type_raises(self, cloud):
+        """An unsupported clip_path type raises TypeError.
+
+        Test scenario:
+            A string clip path is rejected at plot time.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30, clip_path="not-a-path")
+        with pytest.raises(TypeError, match="clip_path must be a matplotlib Path or Patch"):
+            glyph.plot()
+
+
+class TestKDEGlyphPlot:
+    """Tests for KDEGlyph.plot."""
+
+    def test_returns_quadcontourset_with_colorbar(self, cloud):
+        """Filled plot returns a QuadContourSet and adds a colorbar.
+
+        Test scenario:
+            Default shade=True draws filled contours with a colorbar.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=40)
+        fig, ax, cs = glyph.plot()
+        assert isinstance(cs, QuadContourSet), f"Expected QuadContourSet, got {type(cs)}"
+        assert cs.filled, "shade=True should produce filled contours"
+        assert glyph.cbar is not None, "A colorbar should be drawn by default"
+
+    def test_shade_false_line_contours(self, cloud):
+        """``shade=False`` draws line contours.
+
+        Test scenario:
+            The returned contour set is not filled.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=40, shade=False)
+        _, _, cs = glyph.plot()
+        assert not cs.filled, "shade=False should produce line contours"
+
+    def test_add_colorbar_false_suppresses(self, cloud):
+        """``add_colorbar=False`` suppresses the colorbar.
+
+        Test scenario:
+            The plot-time override wins and no colorbar is created.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=40)
+        glyph.plot(add_colorbar=False)
+        assert glyph.cbar is None, "add_colorbar=False should suppress the colorbar"
+
+    def test_title_override(self, cloud):
+        """A title passed to plot overrides the default.
+
+        Test scenario:
+            plot(title=...) sets the axes title.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30)
+        _, ax, _ = glyph.plot(title="Density")
+        assert ax.get_title() == "Density", f"Title should be 'Density', got {ax.get_title()!r}"
+
+    def test_levels_option_controls_contour_count(self, cloud):
+        """The ``levels`` option drives the number of contour levels.
+
+        Test scenario:
+            levels=5 yields five contour levels on the drawn set.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=40, levels=5)
+        _, _, cs = glyph.plot()
+        assert len(cs.levels) == 5, f"Expected 5 levels, got {len(cs.levels)}"
+
+    def test_exposes_im_attribute(self, cloud):
+        """The drawn contour set is exposed as ``glyph.im``.
+
+        Test scenario:
+            ``im`` is the same object the plot returns.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30)
+        _, _, cs = glyph.plot()
+        assert glyph.im is cs, "glyph.im should be the returned contour set"
+
+    def test_plot_on_supplied_axes(self, cloud):
+        """``plot(ax=...)`` draws on the given axes and binds its figure.
+
+        Test scenario:
+            A pre-existing axes is used as-is and its parent figure is
+            adopted by the glyph.
+        """
+        x, y = cloud
+        fig, host_ax = plt.subplots()
+        glyph = KDEGlyph(x, y, gridsize=30)
+        out_fig, out_ax, _ = glyph.plot(ax=host_ax)
+        assert out_ax is host_ax, "plot should draw on the supplied axes"
+        assert glyph.fig is host_ax.get_figure(), "glyph.fig should be the axes' figure"
+
+    def test_plot_uses_axes_from_construction(self, cloud):
+        """``plot()`` reuses an axes supplied at construction.
+
+        Test scenario:
+            With an axes passed to __init__, a no-argument plot() draws on
+            that same axes (the `ax is None`/`self.ax` set branch).
+        """
+        x, y = cloud
+        fig, host_ax = plt.subplots()
+        glyph = KDEGlyph(x, y, gridsize=30, ax=host_ax)
+        _, out_ax, _ = glyph.plot()
+        assert out_ax is host_ax, "plot() should reuse the construction axes"
+
+    def test_no_scipy_imported(self, cloud):
+        """The estimator never imports scipy.
+
+        Test scenario:
+            A full plot leaves scipy absent from sys.modules.
+        """
+        x, y = cloud
+        KDEGlyph(x, y, gridsize=30).plot()
+        assert "scipy" not in sys.modules, "KDEGlyph must not import scipy"

--- a/tests/test_kde_glyph.py
+++ b/tests/test_kde_glyph.py
@@ -301,6 +301,40 @@ class TestKDEGlyphApplyClip:
         _, _, cs = glyph.plot()
         assert cs.get_clip_path() is not None, "Patch clip should be applied"
 
+    def test_standalone_patch_clips_in_data_coordinates(self, cloud):
+        """A freshly-constructed Patch clips in data space, not display space.
+
+        Test scenario:
+            A standalone Circle carries an identity transform; the glyph must
+            give it ``ax.transData`` so the clip maps the data boundary
+            point (1, 0) to the same display location as the data transform
+            (otherwise it would clip a tiny region near the display origin).
+        """
+        x, y = cloud
+        patch = Circle((0, 0), 1.0)
+        glyph = KDEGlyph(x, y, gridsize=30, clip_path=patch)
+        _, ax, cs = glyph.plot()
+        mapped = patch.get_transform().transform((1.0, 0.0))
+        expected = ax.transData.transform((1.0, 0.0))
+        assert np.allclose(mapped, expected), (
+            f"Patch clip should map data (1, 0) to {expected} (data space), got {mapped}"
+        )
+
+    def test_attached_patch_transform_preserved(self, cloud):
+        """A Patch already added to an axes keeps its own transform.
+
+        Test scenario:
+            When the caller has added the patch to the axes, the glyph must
+            not overwrite its transform (clip.axes is not None).
+        """
+        x, y = cloud
+        fig, host_ax = plt.subplots()
+        patch = Circle((0, 0), 1.0)
+        host_ax.add_patch(patch)
+        glyph = KDEGlyph(x, y, gridsize=20, clip_path=patch, ax=host_ax)
+        glyph.plot()
+        assert patch.axes is host_ax, "Attached patch should remain bound to its axes"
+
     def test_path_clip_applied(self, cloud):
         """A Path clip path is applied in data coordinates.
 

--- a/tests/test_kde_glyph.py
+++ b/tests/test_kde_glyph.py
@@ -305,35 +305,55 @@ class TestKDEGlyphApplyClip:
         """A freshly-constructed Patch clips in data space, not display space.
 
         Test scenario:
-            A standalone Circle carries an identity transform; the glyph must
-            give it ``ax.transData`` so the clip maps the data boundary
-            point (1, 0) to the same display location as the data transform
-            (otherwise it would clip a tiny region near the display origin).
+            A standalone Circle of radius 1 at the origin must clip the
+            contours to that circle in *data* coordinates: a point inside the
+            circle (0, 0) is kept and a far point (5, 5) is excluded. A
+            display-space clip (the bug) would instead clip a tiny region near
+            the axes origin.
+        """
+        x, y = cloud
+        glyph = KDEGlyph(x, y, gridsize=30, clip_path=Circle((0, 0), 1.0))
+        _, ax, cs = glyph.plot()
+        path = cs.get_clip_path().get_fully_transformed_path()
+        assert path.contains_point(ax.transData.transform((0.0, 0.0))), (
+            "Clip should keep data point (0, 0) inside the circle"
+        )
+        assert not path.contains_point(ax.transData.transform((5.0, 5.0))), (
+            "Clip should exclude data point (5, 5) outside the circle"
+        )
+
+    def test_standalone_patch_not_mutated(self, cloud):
+        """The glyph clips without mutating the caller's patch.
+
+        Test scenario:
+            A standalone Circle passed as clip_path keeps its original
+            transform and stays unattached after plotting, so it can be
+            reused on another axes.
         """
         x, y = cloud
         patch = Circle((0, 0), 1.0)
-        glyph = KDEGlyph(x, y, gridsize=30, clip_path=patch)
-        _, ax, cs = glyph.plot()
-        mapped = patch.get_transform().transform((1.0, 0.0))
-        expected = ax.transData.transform((1.0, 0.0))
-        assert np.allclose(mapped, expected), (
-            f"Patch clip should map data (1, 0) to {expected} (data space), got {mapped}"
+        before = patch.get_transform().get_matrix().copy()
+        KDEGlyph(x, y, gridsize=20, clip_path=patch).plot()
+        assert patch.axes is None, "clip patch should not be attached to the glyph axes"
+        assert np.allclose(patch.get_transform().get_matrix(), before), (
+            "clip patch transform should be left unchanged"
         )
 
-    def test_attached_patch_transform_preserved(self, cloud):
-        """A Patch already added to an axes keeps its own transform.
+    def test_attached_patch_used_as_is(self, cloud):
+        """A Patch already added to an axes is used with its own transform.
 
         Test scenario:
-            When the caller has added the patch to the axes, the glyph must
-            not overwrite its transform (clip.axes is not None).
+            When the caller has added the patch to the axes, the glyph uses it
+            directly (clip.axes is not None) and leaves it attached.
         """
         x, y = cloud
         fig, host_ax = plt.subplots()
         patch = Circle((0, 0), 1.0)
         host_ax.add_patch(patch)
         glyph = KDEGlyph(x, y, gridsize=20, clip_path=patch, ax=host_ax)
-        glyph.plot()
+        _, _, cs = glyph.plot()
         assert patch.axes is host_ax, "Attached patch should remain bound to its axes"
+        assert cs.get_clip_path() is not None, "Clip should be applied"
 
     def test_path_clip_applied(self, cloud):
         """A Path clip path is applied in data coordinates.

--- a/tests/test_styles_doctests.py
+++ b/tests/test_styles_doctests.py
@@ -1,0 +1,50 @@
+"""Doctest runner for `cleopatra.styles`.
+
+Pytest is not configured with ``--doctest-modules``, so the docstring examples
+in ``src/cleopatra/styles.py`` (ColorScale, Scale, MidpointNormalize, classify,
+resolve_sizes, the legend helpers, ...) would otherwise never run. This module
+executes them in-band so example drift fails CI — mirroring the existing
+``test_projection`` / ``test_statistical_glyph`` doctest runners.
+"""
+
+import doctest
+
+import matplotlib
+
+matplotlib.use("agg")
+import matplotlib.pyplot as plt
+import pytest
+
+import cleopatra.styles as styles_module
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+def test_module_doctests_execute():
+    """Run every `cleopatra.styles` docstring example in-band.
+
+    Test scenario:
+        All collected doctest examples in the module execute with zero
+        failures, and at least one example is collected (so the coverage is
+        not silently dropped if examples are moved or removed).
+
+    Note:
+        ``ELLIPSIS`` is enabled to match pytest's ``--doctest-modules``
+        behavior, since some examples use ``...`` in expected tracebacks.
+    """
+    try:
+        results = doctest.testmod(
+            styles_module, verbose=False, optionflags=doctest.ELLIPSIS
+        )
+    finally:
+        plt.close("all")
+    assert results.failed == 0, f"{results.failed} doctest example(s) failed in styles"
+    assert results.attempted > 0, (
+        "no doctest examples were collected from styles; the module's docstring "
+        "examples may have been moved or removed, silently dropping this coverage"
+    )

--- a/tests/test_value_to_size.py
+++ b/tests/test_value_to_size.py
@@ -1,0 +1,379 @@
+"""Tests for value-to-size scaling and the size legend — issue #155.
+
+Covers:
+
+* `cleopatra.styles.resolve_sizes` (each `size_scale`, monotonicity, range
+  spanning, degenerate input, and error paths) and the `SIZE_SCALES` constant.
+* `cleopatra.styles.size_legend` (area→markersize mapping, label round-trip,
+  and the length-mismatch guard).
+* `ScatterGlyph`'s `sizes` parameter and `size_*` options, including the
+  `_resolve_marker_area` / `_draw_size_legend` helpers and the `sizes=None`
+  regression.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.collections import PathCollection
+from matplotlib.legend import Legend
+
+from cleopatra.scatter_glyph import ScatterGlyph
+from cleopatra.styles import SIZE_SCALES, resolve_sizes, size_legend
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture()
+def xy():
+    """Five points on a horizontal line.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: x (0..4) and y (zeros) arrays.
+    """
+    x = np.arange(5.0)
+    return x, np.zeros_like(x)
+
+
+class TestResolveSizes:
+    """Tests for the ``resolve_sizes`` value→size helper."""
+
+    def test_size_scales_constant(self):
+        """``SIZE_SCALES`` enumerates exactly the supported transforms.
+
+        Test scenario:
+            The accepted scales are linear, log, and sqrt.
+        """
+        assert set(SIZE_SCALES) == {"linear", "log", "sqrt"}, (
+            f"Unexpected SIZE_SCALES: {SIZE_SCALES}"
+        )
+
+    def test_linear_spans_output_range(self):
+        """Linear scaling maps min→out_min and max→out_max.
+
+        Test scenario:
+            A 0..10 ramp maps onto [10, 200] with the midpoint centred.
+        """
+        sizes = resolve_sizes(np.array([0.0, 5.0, 10.0]), 10.0, 200.0)
+        assert np.allclose(sizes, [10.0, 105.0, 200.0]), f"Unexpected sizes: {sizes}"
+
+    @pytest.mark.parametrize("scale", ["linear", "log", "sqrt"])
+    def test_monotonic_in_input(self, scale):
+        """Every scale preserves the ranking of the input magnitudes.
+
+        Args:
+            scale: The size scale under test.
+
+        Test scenario:
+            The argsort of the output equals the argsort of the input, so
+            larger magnitudes always map to larger sizes.
+        """
+        values = np.array([3.0, 1.0, 2.0, 8.0, 5.0])
+        sizes = resolve_sizes(values, 10.0, 200.0, scale=scale)
+        assert np.array_equal(np.argsort(sizes), np.argsort(values)), (
+            f"{scale} mapping is not monotonic: {sizes}"
+        )
+
+    @pytest.mark.parametrize("scale", ["linear", "log", "sqrt"])
+    def test_spans_exactly_the_limits(self, scale):
+        """The smallest/largest outputs equal out_min/out_max for each scale.
+
+        Args:
+            scale: The size scale under test.
+
+        Test scenario:
+            With positive, non-degenerate input the output min and max are
+            exactly the requested limits.
+        """
+        values = np.array([1.0, 2.0, 4.0, 8.0])
+        sizes = resolve_sizes(values, 5.0, 50.0, scale=scale)
+        assert np.isclose(sizes.min(), 5.0), f"min should be 5.0, got {sizes.min()}"
+        assert np.isclose(sizes.max(), 50.0), f"max should be 50.0, got {sizes.max()}"
+
+    def test_log_compresses_orders_of_magnitude(self):
+        """Log scaling makes evenly-spaced decades evenly-spaced sizes.
+
+        Test scenario:
+            [1, 10, 100] over [0, 1] maps to [0, 0.5, 1] (log10 is linear in
+            decades).
+        """
+        sizes = resolve_sizes(np.array([1.0, 10.0, 100.0]), 0.0, 1.0, scale="log")
+        assert np.allclose(sizes, [0.0, 0.5, 1.0]), f"Unexpected log sizes: {sizes}"
+
+    def test_sqrt_uses_area_perception(self):
+        """Sqrt scaling places 4 at the midpoint of [0, 4]→sizes.
+
+        Test scenario:
+            sqrt([0, 1, 4]) = [0, 1, 2] maps onto [0, 1] as [0, 0.5, 1].
+        """
+        sizes = resolve_sizes(np.array([0.0, 1.0, 4.0]), 0.0, 1.0, scale="sqrt")
+        assert np.allclose(sizes, [0.0, 0.5, 1.0]), f"Unexpected sqrt sizes: {sizes}"
+
+    def test_all_equal_maps_to_midpoint(self):
+        """Constant input maps every item to the output midpoint.
+
+        Test scenario:
+            No spread to encode -> each size is (out_min + out_max) / 2.
+        """
+        sizes = resolve_sizes(np.full(4, 7.0), 10.0, 50.0)
+        assert np.allclose(sizes, 30.0), f"Constant input should map to 30.0, got {sizes}"
+
+    def test_preserves_input_shape(self):
+        """The output has the same shape as the input array.
+
+        Test scenario:
+            A length-5 input yields a length-5 output.
+        """
+        sizes = resolve_sizes(np.arange(5.0), 1.0, 2.0)
+        assert sizes.shape == (5,), f"Expected shape (5,), got {sizes.shape}"
+
+    def test_unknown_scale_raises(self):
+        """An unrecognised ``scale`` raises ``ValueError`` listing valid ones.
+
+        Test scenario:
+            "cubic" is not a supported size scale.
+        """
+        with pytest.raises(ValueError, match="Invalid size_scale"):
+            resolve_sizes(np.arange(5.0), 1.0, 2.0, scale="cubic")
+
+    def test_log_non_positive_raises(self):
+        """``scale='log'`` with a non-positive magnitude raises ``ValueError``.
+
+        Test scenario:
+            A zero magnitude cannot be log-scaled.
+        """
+        with pytest.raises(ValueError, match="strictly positive"):
+            resolve_sizes(np.array([0.0, 1.0, 2.0]), 1.0, 2.0, scale="log")
+
+    def test_sqrt_negative_raises(self):
+        """``scale='sqrt'`` with a negative magnitude raises ``ValueError``.
+
+        Test scenario:
+            A negative magnitude cannot be sqrt-scaled.
+        """
+        with pytest.raises(ValueError, match="non-negative"):
+            resolve_sizes(np.array([-1.0, 1.0, 2.0]), 1.0, 2.0, scale="sqrt")
+
+    def test_all_non_finite_raises(self):
+        """All-non-finite input raises a clear ``ValueError``.
+
+        Test scenario:
+            No finite magnitude is available to define the domain.
+        """
+        with pytest.raises(ValueError, match="no finite entries"):
+            resolve_sizes(np.array([np.nan, np.inf]), 1.0, 2.0)
+
+
+class TestSizeLegend:
+    """Tests for the ``size_legend`` helper."""
+
+    def test_labels_round_trip(self):
+        """The legend exposes the labels it was given, in order.
+
+        Test scenario:
+            Three labels come back unchanged from the legend texts.
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [20.0, 100.0, 200.0], ["low", "mid", "high"])
+        texts = [t.get_text() for t in legend.get_texts()]
+        assert texts == ["low", "mid", "high"], f"Unexpected legend labels: {texts}"
+
+    def test_marker_size_is_sqrt_of_area(self):
+        """Proxy ``markersize`` is the square root of the supplied area.
+
+        Test scenario:
+            Areas 16 and 64 (points²) become markersizes 4 and 8 (points).
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [16.0, 64.0], ["small", "big"])
+        handles = legend.legend_handles
+        assert np.isclose(handles[0].get_markersize(), 4.0), "16 -> markersize 4"
+        assert np.isclose(handles[1].get_markersize(), 8.0), "64 -> markersize 8"
+
+    def test_returns_legend_attached_to_axes(self):
+        """The returned legend is the one registered on the axes.
+
+        Test scenario:
+            ``ax.get_legend()`` is the object returned by ``size_legend``.
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [10.0, 20.0], ["a", "b"])
+        assert ax.get_legend() is legend, "Legend should be attached to the axes"
+
+    def test_forwards_legend_kwargs(self):
+        """``Axes.legend`` kwargs such as ``title`` are forwarded.
+
+        Test scenario:
+            A ``title`` passed through reaches the legend title text.
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [10.0, 20.0], ["a", "b"], title="Population")
+        assert legend.get_title().get_text() == "Population", "title kwarg should be forwarded"
+
+    def test_negative_area_clamped(self):
+        """A negative area is clamped to zero markersize (no math error).
+
+        Test scenario:
+            ``sqrt`` of a clamped negative area is 0, not NaN.
+        """
+        fig, ax = plt.subplots()
+        legend = size_legend(ax, [-4.0, 16.0], ["neg", "pos"])
+        handles = legend.legend_handles
+        assert handles[0].get_markersize() == 0.0, "Negative area should clamp to 0"
+
+    def test_length_mismatch_raises(self):
+        """Mismatched ``marker_sizes`` / ``labels`` lengths raise ``ValueError``.
+
+        Test scenario:
+            Two sizes but one label is rejected.
+        """
+        fig, ax = plt.subplots()
+        with pytest.raises(ValueError, match="same length"):
+            size_legend(ax, [10.0, 20.0], ["only-one"])
+
+
+class TestScatterGlyphSizes:
+    """Integration tests for the ``sizes`` parameter and ``size_*`` options."""
+
+    def test_sizes_span_limits_monotonically(self, xy):
+        """A ``sizes`` array yields per-point areas spanning ``size_limits``.
+
+        Test scenario:
+            ``get_sizes`` runs monotonically with the input and its extremes
+            equal the configured ``size_limits``.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.array([2.0, 1.0, 5.0, 3.0, 9.0]),
+                             size_limits=(10, 200))
+        _, _, paths = glyph.plot()
+        out = paths.get_sizes()
+        assert np.isclose(out.min(), 10.0), f"min area should be 10, got {out.min()}"
+        assert np.isclose(out.max(), 200.0), f"max area should be 200, got {out.max()}"
+        assert np.array_equal(
+            np.argsort(out), np.argsort([2.0, 1.0, 5.0, 3.0, 9.0])
+        ), f"Areas not monotonic in input: {out}"
+
+    def test_size_scale_option_applied(self, xy):
+        """The ``size_scale`` option drives the transform used.
+
+        Test scenario:
+            With ``size_scale='log'`` and decade-spaced input, the middle
+            point sits at the midpoint of the limits.
+        """
+        x, y = xy[0][:3], xy[1][:3]
+        glyph = ScatterGlyph(x, y, sizes=np.array([1.0, 10.0, 100.0]),
+                             size_limits=(0, 100), size_scale="log")
+        _, _, paths = glyph.plot()
+        out = paths.get_sizes()
+        assert np.isclose(out[1], 50.0), f"log midpoint should be 50, got {out[1]}"
+
+    def test_size_legend_renders_default_entries(self, xy):
+        """``size_legend=True`` draws a three-entry legend by default.
+
+        Test scenario:
+            With no explicit values, the min/median/max quantiles give three
+            legend entries stored on ``size_legend_artist``.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.arange(1.0, 6.0), size_legend=True)
+        glyph.plot()
+        assert isinstance(glyph.size_legend_artist, Legend), "A size legend should be drawn"
+        texts = [t.get_text() for t in glyph.size_legend_artist.get_texts()]
+        assert len(texts) == 3, f"Default legend should have 3 entries, got {texts}"
+
+    def test_size_legend_values_honoured(self, xy):
+        """Explicit ``size_legend_values`` control the legend entries.
+
+        Test scenario:
+            Two representative magnitudes give two labelled legend entries.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.arange(1.0, 6.0), size_legend=True,
+                             size_legend_values=[2.0, 4.0])
+        glyph.plot()
+        texts = [t.get_text() for t in glyph.size_legend_artist.get_texts()]
+        assert texts == ["2", "4"], f"Legend should honour explicit values, got {texts}"
+
+    def test_no_legend_when_disabled(self, xy):
+        """No size legend is drawn when ``size_legend`` is False.
+
+        Test scenario:
+            Sizes given but ``size_legend`` left at its default False.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.arange(1.0, 6.0))
+        glyph.plot()
+        assert glyph.size_legend_artist is None, "No legend should be drawn when disabled"
+
+    def test_color_and_size_independent(self, xy):
+        """Colour (``values``) and size (``sizes``) combine independently.
+
+        Test scenario:
+            The scatter carries the raw colour array AND size-scaled areas at
+            once.
+        """
+        x, y = xy
+        values = np.array([5.0, 4.0, 3.0, 2.0, 1.0])
+        sizes = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        glyph = ScatterGlyph(x, y, values=values, sizes=sizes, size_limits=(10, 100))
+        _, _, paths = glyph.plot()
+        assert np.array_equal(paths.get_array(), values), "Colour array must be the raw values"
+        out = paths.get_sizes()
+        assert np.array_equal(np.argsort(out), np.argsort(sizes)), "Sizes must follow sizes array"
+
+    def test_sizes_none_regression(self, xy):
+        """``sizes=None`` keeps the original scalar-size behaviour.
+
+        Test scenario:
+            Every marker uses the scalar ``point_size`` and no legend is made.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, point_size=42)
+        _, _, paths = glyph.plot()
+        out = paths.get_sizes()
+        assert np.all(out == 42), f"All markers should use point_size 42, got {set(out)}"
+        assert glyph.size_legend_artist is None, "No legend without sizes"
+
+    def test_resolve_marker_area_scalar_without_sizes(self, xy):
+        """``_resolve_marker_area`` returns the scalar ``point_size``.
+
+        Test scenario:
+            With no ``sizes`` the helper returns the scalar option, not an
+            array.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, point_size=33)
+        assert glyph._resolve_marker_area() == 33, "Should return scalar point_size"
+
+    def test_resolve_marker_area_array_with_sizes(self, xy):
+        """``_resolve_marker_area`` returns a per-point area array with sizes.
+
+        Test scenario:
+            With ``sizes`` the helper returns an array spanning ``size_limits``.
+        """
+        x, y = xy
+        glyph = ScatterGlyph(x, y, sizes=np.arange(1.0, 6.0), size_limits=(10, 200))
+        areas = glyph._resolve_marker_area()
+        assert isinstance(areas, np.ndarray), "Should return a per-point array"
+        assert np.isclose(areas.min(), 10.0) and np.isclose(areas.max(), 200.0), (
+            f"Areas should span size_limits, got [{areas.min()}, {areas.max()}]"
+        )
+
+    def test_mismatched_sizes_raises(self, xy):
+        """A ``sizes`` array not matching x/y length raises ``ValueError``.
+
+        Test scenario:
+            len(sizes) != len(x) is rejected at construction.
+        """
+        x, y = xy
+        with pytest.raises(ValueError, match="sizes must match"):
+            ScatterGlyph(x, y, sizes=np.array([1.0, 2.0]))

--- a/tests/test_value_to_size.py
+++ b/tests/test_value_to_size.py
@@ -163,14 +163,33 @@ class TestResolveSizes:
         with pytest.raises(ValueError, match="non-negative"):
             resolve_sizes(np.array([-1.0, 1.0, 2.0]), 1.0, 2.0, scale="sqrt")
 
-    def test_all_non_finite_raises(self):
-        """All-non-finite input raises a clear ``ValueError``.
+    def test_non_finite_raises(self):
+        """Any non-finite entry raises a clear ``ValueError``.
 
         Test scenario:
-            No finite magnitude is available to define the domain.
+            A NaN/inf magnitude would map to a NaN size, so it is rejected
+            up front rather than rendered as a broken marker.
         """
-        with pytest.raises(ValueError, match="no finite entries"):
+        with pytest.raises(ValueError, match="non-finite entries"):
             resolve_sizes(np.array([np.nan, np.inf]), 1.0, 2.0)
+
+    def test_partial_non_finite_raises(self):
+        """A single non-finite entry among finite ones still raises.
+
+        Test scenario:
+            One NaN mixed with valid magnitudes is rejected.
+        """
+        with pytest.raises(ValueError, match="non-finite entries"):
+            resolve_sizes(np.array([1.0, np.nan, 3.0]), 1.0, 2.0)
+
+    def test_empty_raises(self):
+        """An empty magnitude array raises a clear ``ValueError``.
+
+        Test scenario:
+            There is nothing to map to sizes.
+        """
+        with pytest.raises(ValueError, match="is empty"):
+            resolve_sizes(np.array([]), 1.0, 2.0)
 
 
 class TestSizeLegend:


### PR DESCRIPTION
## Summary

Consolidates the four geoplot/Digital-Earth upstream tasks (cleopatra CLEO-1…4) into one branch. Four linear commits, one per issue, in dependency order:

1. **`feat(glyph)`: categorical color scheme** — closes #154
2. **`feat(scatter_glyph)`: value-to-size scaling + size legend** — closes #155
3. **`feat(flow_glyph)`: magnitude-coloured, width-scaled flow/Sankey glyph** — closes #157
4. **`feat(kde_glyph)`: 2-D kernel-density (isochrone) glyph (numpy-only)** — closes #156

Supersedes the per-issue PRs #158, #159, #160, #161 (now closed).

## What changed

- **#154** — `cleopatra.styles.classify` + `scheme`/`k` options wired into the shared `Glyph._prepare_scalar_mapping` (`_prepare_classified_mapping`), so every colour-by-value glyph gets discrete `BoundaryNorm` classes + a stepped colorbar. All schemes are numpy-only, including the Fisher-Jenks / natural-breaks optimisation (native dynamic program).
- **#155** — `ScatterGlyph(sizes=...)` with `size_limits`/`size_scale`/`size_legend*` options, factored into the reusable `cleopatra.styles.resolve_sizes` helper, plus `cleopatra.styles.size_legend`.
- **#157** — `cleopatra.flow_glyph.FlowGlyph`: magnitude-coloured, width-scaled `LineCollection`; reuses `resolve_sizes` for width and adds `cleopatra.styles.width_legend`.
- **#156** — `cleopatra.kde_glyph.KDEGlyph`: numpy-only 2-D Gaussian KDE drawn as `contourf`/`contour` through the shared colour pipeline, optional `clip_path`, memory-chunked evaluation.

## Dependency safety

Pure **numpy + matplotlib** — no new dependency (optional or otherwise). The Fisher-Jenks / natural-breaks schemes are implemented natively as an exact O(k·n²) dynamic program.

## Tests

New suites: `test_classify.py` (39), `test_value_to_size.py` (32), `test_flow_glyph.py` (29), `test_kde_glyph.py` (31). `flow_glyph` and `kde_glyph` registered in `tests/test_init.py`. New glyph modules at **100% line+branch**.

- Full suite: **873 passed, 4 skipped**.
- All new docstring examples validated via doctest.

## Notes

- Commits follow Conventional Commits; changelog is commitizen-generated in CI.
- Pre-existing `MidpointNormalize` doctest quirk under `--doctest-modules` is unrelated and left untouched (CI uses per-module doctest runners, not a global one).

