### PR TITLE
feat(reference): Natural Earth feature and relief basemap helpers

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -54,7 +54,15 @@ colorbars, ticks, classification, and animation.
   — all NumPy-native), and reusable legend builders (disjoint/size/width/
   histogram/colorbar).
 - `tiles` (optional `cleopatra[tiles]` extra): fetch + stitch XYZ web-tile
-  basemaps; reprojection helpers. The **only** networked feature.
+  basemaps; reprojection helpers.
+- `reference` (uses the `cleopatra[tiles]` extra for relief decoding /
+  reprojection): fetch + draw fixed public reference-basemap data *under* your
+  plot — Natural Earth vector layers (`add_features`) and a global hypsometric
+  relief raster (`add_relief`), the `cartopy` `ax.coastlines()` /
+  `GeoAxes.stock_img()` niche. It acquires only **fixed public datasets** that
+  cleopatra re-hosts as dependency-light artifacts (gzipped GeoJSON / PNG);
+  it reads no user files and never imports GDAL/geopandas.
+- `tiles` and `reference` are cleopatra's **only** networked features.
 - `projection`: lightweight axes-frame / coordinate helpers.
 - `animation`: turn a matplotlib `FuncAnimation` into a saved file, GIF bytes,
   or an embeddable IPython image (via ffmpeg).
@@ -74,9 +82,13 @@ colorbars, ticks, classification, and animation.
 
 - **Non-matplotlib backends / engines:** Plotly, Bokeh, Altair, pyvista,
   datashader, OpenGL, web/JS rendering. Cleopatra is matplotlib-only.
-- **Data I/O and formats:** reading/writing GeoTIFF, NetCDF, shapefiles,
-  GeoJSON, CSV, databases. Users bring NumPy arrays already; file/raster I/O
-  belongs in sibling packages (e.g. `pyramids`), not here.
+- **Data I/O and formats:** reading/writing *user* GeoTIFF, NetCDF,
+  shapefiles, GeoJSON, CSV, databases. Users bring NumPy arrays already;
+  file/raster I/O of user data belongs in sibling packages (e.g. `pyramids`),
+  not here. The deliberate exception is the `tiles` / `reference` basemap
+  helpers, which fetch a handful of *fixed public* reference datasets (never
+  user data) that cleopatra re-hosts as dependency-light artifacts — see
+  "Supporting utilities".
 - **GIS / geoprocessing:** reprojection of user data, clipping, resampling,
   zonal stats, CRS management beyond what the optional `tiles` basemap needs.
 - **Interactive / GUI apps:** dashboards, widget servers, event callbacks,
@@ -88,14 +100,16 @@ colorbars, ticks, classification, and animation.
   (plus `ffmpeg-python`, `hpc-utils`). Anything bigger must be an optional
   extra like `tiles`, and only with strong justification.
 - **3D rendering** (mplot3d surfaces/volumes), networked data sources other
-  than `tiles`, and general-purpose plotting that matplotlib already does well
-  without added value.
+  than the `tiles` / `reference` basemap helpers, and general-purpose plotting
+  that matplotlib already does well without added value.
 
 ## Boundary heuristic for a feature request
 
 Ask, in order:
 
 1. **Input** — does it start from in-memory NumPy data (not a file/CRS/URL)?
+   (The `tiles` / `reference` basemap helpers are the deliberate exception:
+   they acquire fixed *public* reference data, never user files.)
 2. **Output** — does it produce a matplotlib `Figure`/`Axes`/artist (or an
    animation of one)?
 3. **Reuse** — can it build on `Glyph` and the shared colour/colorbar/legend

--- a/docs/reference/reference-data.md
+++ b/docs/reference/reference-data.md
@@ -1,0 +1,136 @@
+# Reference Data — Coastlines, Borders & Relief
+
+The `cleopatra.reference` module draws public cartographic reference data
+*underneath* your own plot — the `cartopy` `ax.coastlines()` /
+`GeoAxes.stock_img()` niche, and the vector/raster sibling of
+[`add_tiles`](tiles.md):
+
+- **`add_features`** — a Natural Earth vector layer: `coastline`, `borders`,
+  `land`, `ocean`, `rivers`, or `lakes`.
+- **`add_relief`** — a global hypsometric relief backdrop.
+
+Both fetch a small, **fixed public dataset** that cleopatra re-hosts as a
+dependency-light artifact (gzipped GeoJSON / PNG), cache it on disk, and render
+it with matplotlib. They acquire reference data only — they never read your
+files and **never import GDAL or geopandas**.
+
+## Dependencies
+
+`add_features` in EPSG:4326 needs nothing beyond `numpy` + `matplotlib`: the
+layers are pre-converted to gzipped GeoJSON and read with the standard library.
+Two paths use the optional `cleopatra[tiles]` extra:
+
+- `add_relief` decodes a PNG with **Pillow**.
+- `add_features(..., crs=...)` reprojection uses **pyproj**.
+
+=== "pip"
+
+    ```bash
+    pip install "cleopatra[tiles]"
+    ```
+
+=== "conda"
+
+    ```bash
+    conda install -c conda-forge cleopatra-tiles
+    ```
+
+If a required package is missing, the function raises a clear `ImportError` with
+the install hint.
+
+## Usage
+
+Draw a relief backdrop with coastlines and country borders on a global
+lon/lat (EPSG:4326) map:
+
+```python
+import matplotlib
+matplotlib.use("Agg")  # any backend; Agg shown for headless rendering
+import matplotlib.pyplot as plt
+
+from cleopatra.reference import add_relief, add_features
+
+fig, ax = plt.subplots(figsize=(8, 4))
+ax.set_xlim(-180, 180)
+ax.set_ylim(-90, 90)
+
+add_relief(ax, resolution="low")                 # hypsometric backdrop
+add_features(ax, "coastline", "110m", colors="black")
+add_features(ax, "borders", "110m", colors="0.4")
+
+fig.savefig("world.png", dpi=100)
+```
+
+A regional map with a filled land layer and higher-resolution coastline:
+
+```python
+fig, ax = plt.subplots()
+ax.set_xlim(-20, 40)   # Europe / N. Africa, in lon/lat
+ax.set_ylim(0, 60)
+
+add_features(ax, "ocean", "50m", facecolors="#bdd7e7")
+add_features(ax, "land", "50m", facecolors="0.9", edgecolors="0.5")
+add_features(ax, "coastline", "50m", colors="navy", linewidths=0.8)
+
+fig.savefig("europe.png")
+```
+
+If your data is in a projected CRS, pass `crs=` so the vectors are reprojected
+to match (requires `pyproj`):
+
+```python
+add_features(ax, "coastline", "50m", crs=3857)   # Web Mercator axes
+```
+
+The raw data is also available without drawing:
+
+```python
+from cleopatra.reference import natural_earth, relief
+
+parts = natural_earth("coastline", "110m")   # list of (N, 2) lon/lat arrays
+rgb = relief("low")                          # (H, W, 3) uint8 RGB array
+```
+
+!!! note
+    `add_features` / `add_relief` read the axes' current `xlim`/`ylim` and
+    preserve them, so **plot your data first**. Polygon layers
+    (`land`/`ocean`/`lakes`) are drawn as a filled `PolyCollection` (style with
+    `facecolors` / `edgecolors` / `linewidths`); line layers
+    (`coastline`/`rivers`/`borders`) as a `LineCollection` (style with `colors`
+    / `linewidths`). Coordinates are EPSG:4326 unless you pass `crs=`.
+
+!!! tip "Caching"
+    The first call downloads the asset from the cleopatra
+    [`basemap-data-v1`](https://github.com/serapeum-org/cleopatra/releases/tag/basemap-data-v1)
+    release and caches it under `~/.cleopatra/naturalearth`; subsequent calls
+    work offline. Override the location with the `CLEOPATRA_CACHE_DIR`
+    environment variable. Downloads are restricted to `http(s)` URLs.
+
+## Migrating from `pyramids.basemap`
+
+This data used to live in `pyramids.basemap` (`natural_earth` / `relief`). It
+has moved to `cleopatra.reference`, which is the matplotlib map-decoration layer
+— the same boundary the web-tile basemaps already follow (`pyramids.basemap`
+forwarded to [`cleopatra.tiles`](tiles.md)). cleopatra hosts its own copy of the
+assets and has **no dependency on pyramids**.
+
+| Old (`pyramids.basemap`) | New (`cleopatra.reference`) | Notes |
+| --- | --- | --- |
+| `natural_earth(layer, resolution)` → `FeatureCollection` | `natural_earth(layer, resolution)` → `list[np.ndarray]` | Now returns plain `(N, 2)` lon/lat arrays (exterior rings for polygons), not a GIS feature object. |
+| `relief(resolution)` → GDAL `Dataset` | `relief(resolution)` → `(H, W, 3)` uint8 array | Now a NumPy RGB array; the asset is a PNG (no GeoTIFF / GDAL). |
+| *(draw it yourself)* | `add_features(ax, layer, resolution)` | New axes helper — the `ax.coastlines()` analogue. |
+| *(draw it yourself)* | `add_relief(ax, resolution)` | New axes helper — the `stock_img()` analogue. |
+| `PYRAMIDS_CACHE_DIR`, `~/.pyramids/naturalearth` | `CLEOPATRA_CACHE_DIR`, `~/.cleopatra/naturalearth` | Cache env var and default directory renamed. |
+
+The `pyramids.basemap.natural_earth` / `relief` entry points are deprecated and
+emit a `DeprecationWarning`; update imports to `cleopatra.reference`. Resolutions
+are unchanged (`110m` / `50m` / `10m` for vectors; `low` / `medium` for relief),
+as are the six layer names.
+
+## Module Documentation
+
+::: cleopatra.reference
+    options:
+      show_root_heading: true
+      show_source: true
+      heading_level: 3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
     - PolygonGlyph: reference/polygon-glyph.md
     - KDEGlyph: reference/kde-glyph.md
     - Tiles (basemaps): reference/tiles.md
+    - Reference data (coastlines/relief): reference/reference-data.md
     - Projection (globe frames): reference/projection.md
     - Animations (save/embed): reference/animation.md
     - Colors: reference/colors-glyph.md

--- a/src/cleopatra/__init__.py
+++ b/src/cleopatra/__init__.py
@@ -7,7 +7,8 @@ classes/functions from their submodules, e.g.
 `from cleopatra.config import Config`.
 
 Submodules: `array_glyph`, `glyph`, `mesh_glyph`, `statistical_glyph`,
-`colors`, `styles`, `tiles`, `projection`, `animation`, `config`.
+`colors`, `styles`, `tiles`, `reference`, `projection`, `animation`,
+`config`.
 
 Importing cleopatra does not change the active matplotlib backend. If you
 want the old convenience behaviour (`%matplotlib inline` in a notebook,

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -585,20 +585,22 @@ def _load_features(layer: str, resolution: str) -> list[dict]:
     try:
         with gzip.open(path, "rt", encoding="utf-8") as fh:
             collection = json.load(fh)
-    except (OSError, EOFError, ValueError) as e:
-        # Corrupt/poisoned cache (truncated gzip, HTML error page, bad
-        # JSON): drop it so the next call re-fetches rather than failing
-        # forever on the cached bytes.
+        features = collection["features"]
+        return [
+            feature["geometry"]
+            for feature in features
+            if feature.get("geometry") is not None
+        ]
+    except (OSError, EOFError, ValueError, KeyError, TypeError) as e:
+        # Corrupt/poisoned cache: truncated gzip, HTML error page, bad JSON,
+        # or valid JSON that is not a GeoJSON FeatureCollection (missing
+        # "features", wrong shape). Drop it so the next call re-fetches
+        # rather than failing forever on the cached bytes.
         path.unlink(missing_ok=True)
         raise OSError(
             f"Cached layer asset {path} could not be parsed ({e}); removed "
             "it -- retry to re-download."
         ) from e
-    return [
-        feature["geometry"]
-        for feature in collection["features"]
-        if feature.get("geometry") is not None
-    ]
 
 
 def natural_earth(
@@ -669,6 +671,7 @@ def _make_transformer(crs: int | str) -> Any:
 
     Raises:
         ImportError: If `pyproj` (the `[tiles]` extra) is not installed.
+        ValueError: If `crs` cannot be interpreted as a CRS.
     """
     if importlib.util.find_spec("pyproj") is None:
         raise ImportError(
@@ -677,9 +680,16 @@ def _make_transformer(crs: int | str) -> Any:
             "`pip install cleopatra[tiles]`, or plot your data in EPSG:4326."
         )
     from pyproj import Transformer
+    from pyproj.exceptions import CRSError
 
     dst = f"EPSG:{crs}" if isinstance(crs, int) else str(crs)
-    return Transformer.from_crs("EPSG:4326", dst, always_xy=True)
+    try:
+        return Transformer.from_crs("EPSG:4326", dst, always_xy=True)
+    except CRSError as e:
+        raise ValueError(
+            f"Invalid CRS {crs!r}: {e}. Provide a valid EPSG code or CRS "
+            "string."
+        ) from e
 
 
 def _reproject_arr(arr: np.ndarray, transformer: Any) -> np.ndarray:

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -291,6 +291,35 @@ def add_relief(
         ValueError: If `resolution` is unknown.
         ConnectionError: If the asset must be downloaded and the fetch
             fails.
+
+    Examples:
+        - Draw a relief backdrop under data already plotted in lon/lat
+            (downloads the asset on first use, then caches it):
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.reference import add_relief
+            >>> fig, ax = plt.subplots()
+            >>> ax.set_xlim(-180, 180); ax.set_ylim(-90, 90)  # doctest: +SKIP
+            >>> ax = add_relief(ax, "low")  # doctest: +SKIP
+            >>> len(ax.images)  # doctest: +SKIP
+            1
+
+            ```
+        - Unknown resolutions are rejected before any download:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.reference import add_relief
+            >>> fig, ax = plt.subplots()
+            >>> add_relief(ax, "high")
+            Traceback (most recent call last):
+                ...
+            ValueError: Unknown relief resolution 'high'. Choose from ['low', 'medium'].
+
+            ```
     """
     _validate_axes(ax)
     rgb = relief(resolution)
@@ -595,6 +624,26 @@ def natural_earth(
         ValueError: If `layer` or `resolution` is unknown.
         ConnectionError: If the asset must be downloaded and the fetch
             fails.
+
+    Examples:
+        - Fetch coastlines and inspect the parts (downloads on first use,
+            then reads from the cache):
+            ```python
+            >>> from cleopatra.reference import natural_earth
+            >>> parts = natural_earth("coastline", "110m")  # doctest: +SKIP
+            >>> parts[0].shape[1]  # each part is an (N, 2) lon/lat array  # doctest: +SKIP
+            2
+
+            ```
+        - Unknown layers are rejected before any download:
+            ```python
+            >>> from cleopatra.reference import natural_earth
+            >>> natural_earth("countries")
+            Traceback (most recent call last):
+                ...
+            ValueError: Unknown layer 'countries'. Choose from ['coastline', 'land', 'ocean', 'rivers', 'lakes', 'borders'].
+
+            ```
     """
     parts: list[np.ndarray] = []
     for geometry in _load_features(layer, resolution):
@@ -744,6 +793,34 @@ def add_features(
             installed.
         ConnectionError: If the asset must be downloaded and the fetch
             fails.
+
+    Examples:
+        - Overlay a coastline and country borders on a lon/lat map
+            (downloads each layer on first use, then caches it):
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.reference import add_features
+            >>> fig, ax = plt.subplots()
+            >>> ax.set_xlim(-20, 40); ax.set_ylim(0, 60)  # doctest: +SKIP
+            >>> ax = add_features(ax, "coastline", "50m", colors="navy")  # doctest: +SKIP
+            >>> ax = add_features(ax, "borders", "50m")  # doctest: +SKIP
+
+            ```
+        - Unknown layers are rejected before any download:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.reference import add_features
+            >>> fig, ax = plt.subplots()
+            >>> add_features(ax, "countries")
+            Traceback (most recent call last):
+                ...
+            ValueError: Unknown layer 'countries'. Choose from ['coastline', 'land', 'ocean', 'rivers', 'lakes', 'borders'].
+
+            ```
     """
     _validate_axes(ax)
     geoms = _load_features(layer, resolution)

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -798,7 +798,8 @@ def add_features(
 
     Raises:
         TypeError: If `ax` is not a matplotlib Axes.
-        ValueError: If `layer` or `resolution` is unknown.
+        ValueError: If `layer` or `resolution` is unknown, or `crs` is not
+            a valid CRS.
         ImportError: If `crs` requires reprojection but `pyproj` is not
             installed.
         ConnectionError: If the asset must be downloaded and the fetch

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -47,17 +47,18 @@ from __future__ import annotations
 
 import gzip
 import importlib.util
-import io
 import json
 import logging
 import os
+import shutil
 import urllib.error
 import urllib.request
 from pathlib import Path
 from typing import Any
 
 import numpy as np
-from matplotlib.collections import LineCollection, PolyCollection
+from matplotlib.collections import LineCollection, PathCollection
+from matplotlib.path import Path as MplPath
 
 from cleopatra import __version__
 
@@ -100,9 +101,10 @@ def _cache_dir() -> Path:
 def _download(url: str, dest: Path, *, timeout: int = 60) -> Path:
     """Download `url` to `dest`, skipping the fetch if already cached.
 
-    The write is atomic: data lands in a `.part` sibling that is renamed
-    onto `dest` only after a complete download, so an interrupted fetch
-    never leaves a half-written cache file.
+    The body is streamed to a `.part` sibling and renamed onto `dest`
+    only after a complete download, so an interrupted fetch never leaves
+    a half-written cache file and the response is not buffered whole in
+    memory.
 
     Args:
         url: Source URL. Must use the `http` or `https` scheme.
@@ -122,16 +124,17 @@ def _download(url: str, dest: Path, *, timeout: int = 60) -> Path:
         raise ValueError(f"Refusing to fetch non-http(s) URL: {url!r}")
     logger.debug("Fetching reference asset %s", url)
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
-            data = response.read()
+            with open(tmp, "wb") as handle:
+                shutil.copyfileobj(response, handle)
     except (urllib.error.URLError, OSError) as e:
+        tmp.unlink(missing_ok=True)
         raise ConnectionError(
             f"Failed to download reference asset {url!r}: {e}"
         ) from e
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dest.with_suffix(dest.suffix + ".part")
-    tmp.write_bytes(data)
     tmp.replace(dest)
     return dest
 
@@ -204,6 +207,8 @@ def relief(resolution: str = "low") -> np.ndarray:
         ValueError: If `resolution` is not a known product.
         ConnectionError: If the asset must be downloaded and the fetch
             fails.
+        OSError: If the cached file cannot be decoded as an image (the
+            poisoned file is removed first so a retry re-downloads).
 
     Examples:
         - Unknown resolutions raise `ValueError` before any download:
@@ -223,12 +228,23 @@ def relief(resolution: str = "low") -> np.ndarray:
         )
     if not _PILLOW_AVAILABLE:
         raise ImportError(_PILLOW_HINT)
-    from PIL import Image
+    from PIL import Image, UnidentifiedImageError
 
     name = _RELIEF_PRODUCTS[resolution]
     path = _download(_RELIEF_BASE_URL + name, _cache_dir() / name)
-    with Image.open(io.BytesIO(path.read_bytes())) as img:
-        return np.asarray(img.convert("RGB"))
+    try:
+        with Image.open(path) as img:
+            return np.asarray(img.convert("RGB"))
+    except (UnidentifiedImageError, OSError, ValueError) as e:
+        # A complete-but-unreadable cache file (e.g. an HTML error page
+        # served with HTTP 200) would fail forever because `_download`
+        # returns the cached file unconditionally. Drop it so the next
+        # call re-fetches instead of staying poisoned.
+        path.unlink(missing_ok=True)
+        raise OSError(
+            f"Cached relief asset {path} could not be decoded ({e}); removed "
+            "it -- retry to re-download."
+        ) from e
 
 
 def add_relief(
@@ -246,6 +262,13 @@ def add_relief(
     in EPSG:4326 (lon/lat); for data in another CRS pass `extent` in the
     axes' own units. The current axis limits are preserved so adding the
     backdrop never changes the view.
+
+    Note:
+        The relief image is equirectangular (EPSG:4326). When placed with
+        a non-EPSG:4326 `extent` it is simply stretched by `imshow` to fit
+        those bounds -- visually acceptable for small extents but not a
+        true reprojection. For a pixel-accurate backdrop in another
+        projection, reproject the source before drawing.
 
     Args:
         ax: A matplotlib `Axes` with data already plotted (so its limits
@@ -311,7 +334,7 @@ _RESOLUTIONS = ("110m", "50m", "10m")
 _FEATURE_BASE_URL = _RELIEF_BASE_URL
 
 #: Per-kind default styling, merged under caller `**style` overrides. Keys
-#: match the target collection's constructor (`PolyCollection` /
+#: match the target collection's constructor (`PathCollection` /
 #: `LineCollection`).
 _FEATURE_STYLE = {
     "line": {"colors": "0.2", "linewidths": 0.6},
@@ -358,8 +381,9 @@ def _paths(geometry: dict) -> list[np.ndarray]:
     """Flatten a GeoJSON geometry into a list of `(N, 2)` float arrays.
 
     Polygons contribute their exterior ring only (interior holes are
-    dropped -- a reference backdrop does not need them). `Multi*`
-    geometries expand to one array per part.
+    dropped). This is the coordinate view used by `natural_earth` and the
+    line-layer renderer; the filled-polygon renderer uses `_polygons`,
+    which keeps holes. `Multi*` geometries expand to one array per part.
 
     Args:
         geometry: A GeoJSON geometry object with `type` and
@@ -412,6 +436,142 @@ def _paths(geometry: dict) -> list[np.ndarray]:
     raise ValueError(f"Unsupported geometry type: {gtype!r}")
 
 
+def _polygons(geometry: dict) -> list[list[np.ndarray]]:
+    """Return a GeoJSON geometry's polygons, each as `[exterior, *holes]`.
+
+    Unlike `_paths`, interior rings (holes) are preserved so a filled
+    polygon can be cut out correctly. Non-polygon geometries return an
+    empty list.
+
+    Args:
+        geometry: A GeoJSON geometry object.
+
+    Returns:
+        list[list[numpy.ndarray]]: One entry per polygon part; each entry
+            is `[exterior_ring, hole_ring, ...]` of `(N, 2)` arrays.
+
+    Examples:
+        - A polygon with one hole keeps both rings:
+            ```python
+            >>> from cleopatra.reference import _polygons
+            >>> geom = {
+            ...     "type": "Polygon",
+            ...     "coordinates": [
+            ...         [[0, 0], [2, 0], [2, 2], [0, 0]],
+            ...         [[0.5, 0.5], [1, 0.5], [1, 1], [0.5, 0.5]],
+            ...     ],
+            ... }
+            >>> [len(p) for p in _polygons(geom)]
+            [2]
+
+            ```
+    """
+    gtype = geometry["type"]
+    coords = geometry["coordinates"]
+    if gtype == "Polygon":
+        return [[np.asarray(ring, dtype=float) for ring in coords]]
+    if gtype == "MultiPolygon":
+        return [
+            [np.asarray(ring, dtype=float) for ring in poly] for poly in coords
+        ]
+    return []
+
+
+def _signed_area(ring: np.ndarray) -> float:
+    """Return the signed area of a ring (positive when counter-clockwise)."""
+    x = ring[:, 0]
+    y = ring[:, 1]
+    return 0.5 * float(np.sum(x * np.roll(y, -1) - np.roll(x, -1) * y))
+
+
+def _orient(ring: np.ndarray, ccw: bool) -> np.ndarray:
+    """Return `ring` wound counter-clockwise when `ccw`, else clockwise.
+
+    Source GeoJSON winding is not guaranteed (GDAL does not enforce RFC
+    7946), so exterior rings are forced CCW and holes CW. With opposite
+    windings the nonzero fill rule cuts the holes out of the exterior.
+    """
+    if (_signed_area(ring) > 0) != ccw:
+        return ring[::-1]
+    return ring
+
+
+def _finite_runs(arr: np.ndarray) -> list[np.ndarray]:
+    """Split `arr` into maximal runs of finite `(x, y)` rows (length >= 2).
+
+    Reprojection (`crs=`) can map points at a projection's singularity
+    (e.g. the poles in Web Mercator) to non-finite values; emitting those
+    to matplotlib produces broken paths and warnings. Splitting keeps the
+    finite spans and drops the non-finite breaks.
+    """
+    if arr.size == 0:
+        return []
+    mask = np.isfinite(arr).all(axis=1)
+    if mask.all():
+        return [arr] if len(arr) >= 2 else []
+    runs: list[np.ndarray] = []
+    start: int | None = None
+    for i, ok in enumerate(mask):
+        if ok and start is None:
+            start = i
+        elif not ok and start is not None:
+            if i - start >= 2:
+                runs.append(arr[start:i])
+            start = None
+    if start is not None and len(arr) - start >= 2:
+        runs.append(arr[start:])
+    return runs
+
+
+def _load_features(layer: str, resolution: str) -> list[dict]:
+    """Download/cache a layer and return its non-null GeoJSON geometries.
+
+    Args:
+        layer: One of `available_layers()`.
+        resolution: One of `available_resolutions()`.
+
+    Returns:
+        list[dict]: The GeoJSON geometry objects of every feature that has
+            one.
+
+    Raises:
+        ValueError: If `layer` or `resolution` is unknown.
+        ConnectionError: If the asset must be downloaded and the fetch
+            fails.
+        OSError: If the cached file cannot be parsed (the poisoned file is
+            removed first so a retry re-downloads).
+    """
+    if layer not in _LAYERS:
+        raise ValueError(
+            f"Unknown layer {layer!r}. Choose from {available_layers()}."
+        )
+    if resolution not in _RESOLUTIONS:
+        raise ValueError(
+            f"Unknown resolution {resolution!r}. "
+            f"Choose from {available_resolutions()}."
+        )
+    stem = _LAYERS[layer][0]
+    name = f"ne_{resolution}_{stem}.geojson.gz"
+    path = _download(_FEATURE_BASE_URL + name, _cache_dir() / name)
+    try:
+        with gzip.open(path, "rt", encoding="utf-8") as fh:
+            collection = json.load(fh)
+    except (OSError, EOFError, ValueError) as e:
+        # Corrupt/poisoned cache (truncated gzip, HTML error page, bad
+        # JSON): drop it so the next call re-fetches rather than failing
+        # forever on the cached bytes.
+        path.unlink(missing_ok=True)
+        raise OSError(
+            f"Cached layer asset {path} could not be parsed ({e}); removed "
+            "it -- retry to re-download."
+        ) from e
+    return [
+        feature["geometry"]
+        for feature in collection["features"]
+        if feature.get("geometry") is not None
+    ]
+
+
 def natural_earth(
     layer: str = "coastline", resolution: str = "110m"
 ) -> list[np.ndarray]:
@@ -419,7 +579,8 @@ def natural_earth(
 
     The layer is downloaded as preprocessed gzipped GeoJSON and parsed
     with the standard library only -- no GDAL/geopandas. Coordinates are
-    EPSG:4326 lon/lat.
+    EPSG:4326 lon/lat. Polygon layers return exterior rings only; use
+    `add_features` for hole-aware filled rendering.
 
     Args:
         layer: One of `available_layers()`.
@@ -435,37 +596,27 @@ def natural_earth(
         ConnectionError: If the asset must be downloaded and the fetch
             fails.
     """
-    if layer not in _LAYERS:
-        raise ValueError(
-            f"Unknown layer {layer!r}. Choose from {available_layers()}."
-        )
-    if resolution not in _RESOLUTIONS:
-        raise ValueError(
-            f"Unknown resolution {resolution!r}. "
-            f"Choose from {available_resolutions()}."
-        )
-    stem = _LAYERS[layer][0]
-    name = f"ne_{resolution}_{stem}.geojson.gz"
-    path = _download(_FEATURE_BASE_URL + name, _cache_dir() / name)
-    with gzip.open(path, "rt", encoding="utf-8") as fh:
-        collection = json.load(fh)
     parts: list[np.ndarray] = []
-    for feature in collection["features"]:
-        geometry = feature.get("geometry")
-        if geometry is not None:
-            parts.extend(_paths(geometry))
+    for geometry in _load_features(layer, resolution):
+        parts.extend(_paths(geometry))
     return parts
 
 
-def _reproject(parts: list[np.ndarray], crs: int | str) -> list[np.ndarray]:
-    """Reproject EPSG:4326 lon/lat parts to `crs`.
+def _is_4326(crs: int | str | None) -> bool:
+    """Return True when `crs` denotes EPSG:4326 (or is unspecified)."""
+    if crs is None:
+        return True
+    return str(crs).upper().replace("EPSG:", "") == "4326"
+
+
+def _make_transformer(crs: int | str) -> Any:
+    """Build a pyproj transformer from EPSG:4326 to `crs`.
 
     Args:
-        parts: `(N, 2)` lon/lat arrays from `natural_earth`.
         crs: Target CRS -- an int EPSG code or a CRS string/WKT.
 
     Returns:
-        list[numpy.ndarray]: The parts in the target CRS.
+        pyproj.Transformer: An `always_xy` transformer.
 
     Raises:
         ImportError: If `pyproj` (the `[tiles]` extra) is not installed.
@@ -479,19 +630,76 @@ def _reproject(parts: list[np.ndarray], crs: int | str) -> list[np.ndarray]:
     from pyproj import Transformer
 
     dst = f"EPSG:{crs}" if isinstance(crs, int) else str(crs)
-    transformer = Transformer.from_crs("EPSG:4326", dst, always_xy=True)
-    out: list[np.ndarray] = []
-    for part in parts:
-        x, y = transformer.transform(part[:, 0], part[:, 1])
-        out.append(np.column_stack([np.asarray(x), np.asarray(y)]))
-    return out
+    return Transformer.from_crs("EPSG:4326", dst, always_xy=True)
 
 
-def _is_4326(crs: int | str | None) -> bool:
-    """Return True when `crs` denotes EPSG:4326 (or is unspecified)."""
-    if crs is None:
-        return True
-    return str(crs).upper().replace("EPSG:", "") == "4326"
+def _reproject_arr(arr: np.ndarray, transformer: Any) -> np.ndarray:
+    """Reproject an `(N, 2)` lon/lat array with `transformer`."""
+    x, y = transformer.transform(arr[:, 0], arr[:, 1])
+    return np.column_stack([np.asarray(x, dtype=float), np.asarray(y, dtype=float)])
+
+
+def _line_segments(geoms: list[dict], transformer: Any) -> list[np.ndarray]:
+    """Build LineCollection segments from line geometries.
+
+    Each part is reprojected (when `transformer` is set) and split into
+    finite runs so projection singularities do not introduce broken
+    segments.
+    """
+    segments: list[np.ndarray] = []
+    for geometry in geoms:
+        for part in _paths(geometry):
+            if transformer is not None:
+                part = _reproject_arr(part, transformer)
+            segments.extend(_finite_runs(part))
+    return segments
+
+
+def _polygon_paths(geoms: list[dict], transformer: Any) -> list[MplPath]:
+    """Build hole-aware compound `Path`s from polygon geometries.
+
+    Each polygon becomes one compound path: the exterior ring forced
+    counter-clockwise and every hole clockwise, so the nonzero fill rule
+    renders the holes as cut-outs. Rings are reprojected (when
+    `transformer` is set) and stripped of non-finite vertices first.
+    """
+    paths: list[MplPath] = []
+    for geometry in geoms:
+        for polygon in _polygons(geometry):
+            oriented: list[np.ndarray] = []
+            for index, ring in enumerate(polygon):
+                if transformer is not None:
+                    ring = _reproject_arr(ring, transformer)
+                ring = ring[np.isfinite(ring).all(axis=1)]
+                if len(ring) >= 3:
+                    oriented.append(_orient(ring, ccw=(index == 0)))
+            path = _compound_path(oriented)
+            if path is not None:
+                paths.append(path)
+    return paths
+
+
+def _compound_path(rings: list[np.ndarray]) -> MplPath | None:
+    """Assemble `[exterior, *holes]` rings into one compound `Path`.
+
+    Returns None when there is no drawable exterior ring.
+    """
+    if not rings:
+        return None
+    verts: list[np.ndarray] = []
+    codes: list[np.ndarray] = []
+    for ring in rings:
+        # MOVETO, LINETO..., CLOSEPOLY. The explicit CLOSEPOLY (with a
+        # placeholder vertex) is what makes the nonzero fill rule treat the
+        # ring as a closed contour, so an oppositely-wound hole is cut out
+        # rather than filled solid.
+        n = len(ring)
+        ring_codes = np.full(n + 1, MplPath.LINETO, dtype=np.uint8)
+        ring_codes[0] = MplPath.MOVETO
+        ring_codes[-1] = MplPath.CLOSEPOLY
+        verts.append(np.vstack([ring, ring[0]]))
+        codes.append(ring_codes)
+    return MplPath(np.concatenate(verts), np.concatenate(codes))
 
 
 def add_features(
@@ -506,11 +714,12 @@ def add_features(
     """Draw a Natural Earth reference layer on an Axes.
 
     The `cartopy` `ax.coastlines()` analogue. Polygon layers
-    (`land`/`ocean`/`lakes`) are drawn as a filled `PolyCollection`; line
-    layers (`coastline`/`rivers`/`borders`) as a `LineCollection`. The
-    source data is EPSG:4326; pass `crs` to reproject the geometry into
-    the axes' CRS (requires `pyproj`). The current axis limits are
-    preserved.
+    (`land`/`ocean`/`lakes`) are drawn hole-aware as a filled
+    `PathCollection` (so `ocean`'s continent cut-outs and islands-in-lakes
+    render correctly); line layers (`coastline`/`rivers`/`borders`) as a
+    `LineCollection`. The source data is EPSG:4326; pass `crs` to reproject
+    the geometry into the axes' CRS (requires `pyproj`). The current axis
+    limits are preserved.
 
     Args:
         ax: A matplotlib `Axes` with data already plotted.
@@ -521,10 +730,9 @@ def add_features(
             reprojects from EPSG:4326 first.
         zorder: Matplotlib draw order for the layer.
         **style: Overrides merged over the per-kind defaults and
-            forwarded to the underlying collection. Use
-            `PolyCollection` keys for polygon layers (`facecolors`,
-            `edgecolors`, `linewidths`) and `LineCollection` keys for
-            line layers (`colors`, `linewidths`).
+            forwarded to the underlying collection. Use polygon keys for
+            polygon layers (`facecolors`, `edgecolors`, `linewidths`) and
+            line keys for line layers (`colors`, `linewidths`).
 
     Returns:
         matplotlib.axes.Axes: The same axes, for chaining.
@@ -538,23 +746,25 @@ def add_features(
             fails.
     """
     _validate_axes(ax)
-    if layer not in _LAYERS:
-        raise ValueError(
-            f"Unknown layer {layer!r}. Choose from {available_layers()}."
-        )
-
-    parts = natural_earth(layer, resolution)
-    if not _is_4326(crs):
-        parts = _reproject(parts, crs)  # type: ignore[arg-type]
+    geoms = _load_features(layer, resolution)
+    transformer = None if _is_4326(crs) else _make_transformer(crs)  # type: ignore[arg-type]
 
     kind = _LAYERS[layer][1]
     opts = {**_FEATURE_STYLE[kind], **style}
 
     xlim, ylim = ax.get_xlim(), ax.get_ylim()
+    collection: Any
     if kind == "polygon":
-        collection: Any = PolyCollection(parts, zorder=zorder, **opts)
+        collection = PathCollection(
+            _polygon_paths(geoms, transformer), zorder=zorder, **opts
+        )
+        # PathCollection paths default to a non-data transform (its scatter
+        # heritage); place them in data coordinates explicitly.
+        collection.set_transform(ax.transData)
     else:
-        collection = LineCollection(parts, zorder=zorder, **opts)
+        collection = LineCollection(
+            _line_segments(geoms, transformer), zorder=zorder, **opts
+        )
     ax.add_collection(collection)
     ax.set_xlim(xlim)
     ax.set_ylim(ylim)

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -1,0 +1,561 @@
+"""Reference-basemap backdrops for matplotlib axes.
+
+Two axes-level helpers that draw public cartographic reference data
+*underneath* your own plotted data -- the `cartopy`
+`GeoAxes.stock_img()` / `ax.coastlines()` niche, and the vector/raster
+sibling of `cleopatra.tiles.add_tiles`:
+
+* `add_relief` -- a global hypsometric relief image (the
+    `stock_img()` analogue).
+* `add_features` -- a Natural Earth vector layer: coastline, borders,
+    land, ocean, rivers, or lakes (the `coastlines()` analogue).
+
+Both fetch a small, **fixed public dataset** that cleopatra re-hosts as a
+dependency-light artifact, cache it on disk, and render it with
+matplotlib. They acquire reference data only; they never read user files
+and never touch GDAL/geopandas:
+
+* Relief is re-hosted as a plain **PNG**, so decoding needs only Pillow
+    (already part of the `cleopatra[tiles]` extra). Every relief product
+    is a global EPSG:4326 raster, so its extent is hardcoded rather than
+    read from a geotransform.
+* Natural Earth layers are pre-converted (offline, maintainer-side) to
+    gzipped **GeoJSON**, so reading them needs only the standard library
+    (`json` + `gzip`) plus numpy. Drawing in EPSG:4326 needs nothing
+    beyond matplotlib; reprojecting to another CRS lazily uses `pyproj`
+    (also in the `[tiles]` extra).
+
+The cache directory defaults to `~/.cleopatra/naturalearth` and can be
+overridden with the `CLEOPATRA_CACHE_DIR` environment variable. Downloads
+are restricted to `http(s)` URLs.
+
+Examples:
+    Draw a relief backdrop and a coastline over data plotted in
+    lon/lat (EPSG:4326):
+
+    >>> import matplotlib
+    >>> matplotlib.use("Agg")
+    >>> import matplotlib.pyplot as plt
+    >>> from cleopatra.reference import add_relief, add_features
+    >>> fig, ax = plt.subplots()
+    >>> ax.set_xlim(-20, 40); ax.set_ylim(0, 60)  # doctest: +SKIP
+    >>> _ = add_relief(ax, resolution="low")            # doctest: +SKIP
+    >>> _ = add_features(ax, "coastline", "50m")        # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import io
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from matplotlib.collections import LineCollection, PolyCollection
+
+from cleopatra import __version__
+
+logger = logging.getLogger(__name__)
+
+#: `User-Agent` sent on every reference-data download, identifying
+#: cleopatra and its version so asset hosts can attribute the traffic.
+USER_AGENT = f"cleopatra/{__version__} (+https://github.com/serapeum-org/cleopatra)"
+
+_PILLOW_HINT = (
+    "Relief backdrops require Pillow, provided by the [tiles] extra. "
+    "Install with `pip install cleopatra[tiles]`."
+)
+#: True when Pillow is importable. Probed with `find_spec` so importing
+#: this module never pulls Pillow in for callers who only use
+#: `add_features` (which needs no third-party dependency).
+_PILLOW_AVAILABLE = importlib.util.find_spec("PIL") is not None
+
+
+# --------------------------------------------------------------------------
+# Shared download / cache helpers
+# --------------------------------------------------------------------------
+
+
+def _cache_dir() -> Path:
+    """Resolve (and create) the on-disk cache directory.
+
+    Honours the `CLEOPATRA_CACHE_DIR` environment variable; defaults to
+    `~/.cleopatra/naturalearth`.
+
+    Returns:
+        pathlib.Path: The existing cache directory.
+    """
+    root = os.environ.get("CLEOPATRA_CACHE_DIR")
+    base = Path(root) if root else Path.home() / ".cleopatra" / "naturalearth"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _download(url: str, dest: Path, *, timeout: int = 60) -> Path:
+    """Download `url` to `dest`, skipping the fetch if already cached.
+
+    The write is atomic: data lands in a `.part` sibling that is renamed
+    onto `dest` only after a complete download, so an interrupted fetch
+    never leaves a half-written cache file.
+
+    Args:
+        url: Source URL. Must use the `http` or `https` scheme.
+        dest: Destination path in the cache.
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        pathlib.Path: `dest`, now present on disk.
+
+    Raises:
+        ValueError: If `url` is not an `http(s)` URL.
+        ConnectionError: If the download fails.
+    """
+    if dest.exists():
+        return dest
+    if not url.lower().startswith(("http://", "https://")):
+        raise ValueError(f"Refusing to fetch non-http(s) URL: {url!r}")
+    logger.debug("Fetching reference asset %s", url)
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = response.read()
+    except (urllib.error.URLError, OSError) as e:
+        raise ConnectionError(
+            f"Failed to download reference asset {url!r}: {e}"
+        ) from e
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    tmp.write_bytes(data)
+    tmp.replace(dest)
+    return dest
+
+
+def _validate_axes(ax: Any) -> None:
+    """Raise `TypeError` if `ax` is not a matplotlib Axes.
+
+    Args:
+        ax: Candidate axes object.
+
+    Raises:
+        TypeError: If `ax` lacks the `get_xlim`/`get_ylim` interface.
+    """
+    if not hasattr(ax, "get_xlim") or not hasattr(ax, "get_ylim"):
+        raise TypeError(
+            f"ax must be a matplotlib.axes.Axes instance, got {type(ax).__name__}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Relief (raster backdrop)
+# --------------------------------------------------------------------------
+
+#: Global EPSG:4326 extent shared by every relief product
+#: (west, south, east, north).
+_RELIEF_EXTENT_4326 = (-180.0, -90.0, 180.0, 90.0)
+
+#: Re-hosted on a cleopatra release as PNG (no GeoTIFF -> no GDAL).
+_RELIEF_BASE_URL = (
+    "https://github.com/serapeum-org/cleopatra/releases/download/basemap-data-v1/"
+)
+
+#: Relief resolution -> PNG asset name.
+_RELIEF_PRODUCTS = {
+    "low": "ne_hypso_rgb_720x360.png",  # ~0.5 deg
+    "medium": "ne_hypso_rgb_1440x720.png",  # ~0.25 deg
+}
+
+
+def available_relief_resolutions() -> list[str]:
+    """Return the relief resolutions that can be requested.
+
+    Returns:
+        list[str]: The valid `resolution` values for `relief` /
+            `add_relief` (`"low"`, `"medium"`).
+
+    Examples:
+        ```python
+        >>> from cleopatra.reference import available_relief_resolutions
+        >>> available_relief_resolutions()
+        ['low', 'medium']
+
+        ```
+    """
+    return list(_RELIEF_PRODUCTS)
+
+
+def relief(resolution: str = "low") -> np.ndarray:
+    """Fetch (and cache) a hypsometric relief product as an RGB array.
+
+    Args:
+        resolution: `"low"` (720x360) or `"medium"` (1440x720).
+
+    Returns:
+        numpy.ndarray: An `(H, W, 3)` uint8 RGB array in EPSG:4326,
+            north-up (row 0 is the northern edge).
+
+    Raises:
+        ImportError: If Pillow (the `[tiles]` extra) is not installed.
+        ValueError: If `resolution` is not a known product.
+        ConnectionError: If the asset must be downloaded and the fetch
+            fails.
+
+    Examples:
+        - Unknown resolutions raise `ValueError` before any download:
+            ```python
+            >>> from cleopatra.reference import relief
+            >>> relief("ultra")
+            Traceback (most recent call last):
+                ...
+            ValueError: Unknown relief resolution 'ultra'. Choose from ['low', 'medium'].
+
+            ```
+    """
+    if resolution not in _RELIEF_PRODUCTS:
+        raise ValueError(
+            f"Unknown relief resolution {resolution!r}. "
+            f"Choose from {available_relief_resolutions()}."
+        )
+    if not _PILLOW_AVAILABLE:
+        raise ImportError(_PILLOW_HINT)
+    from PIL import Image
+
+    name = _RELIEF_PRODUCTS[resolution]
+    path = _download(_RELIEF_BASE_URL + name, _cache_dir() / name)
+    with Image.open(io.BytesIO(path.read_bytes())) as img:
+        return np.asarray(img.convert("RGB"))
+
+
+def add_relief(
+    ax: Any,
+    resolution: str = "low",
+    *,
+    extent: tuple[float, float, float, float] | None = None,
+    alpha: float = 1.0,
+    zorder: int = -1,
+    interpolation: str = "bilinear",
+) -> Any:
+    """Draw a global hypsometric relief backdrop under existing data.
+
+    The `cartopy` `GeoAxes.stock_img()` analogue. Assumes the axes are
+    in EPSG:4326 (lon/lat); for data in another CRS pass `extent` in the
+    axes' own units. The current axis limits are preserved so adding the
+    backdrop never changes the view.
+
+    Args:
+        ax: A matplotlib `Axes` with data already plotted (so its limits
+            define the view).
+        resolution: `"low"` or `"medium"` (see
+            `available_relief_resolutions`).
+        extent: `(west, south, east, north)` placement in axis units.
+            Defaults to the global EPSG:4326 extent
+            `(-180, -90, 180, 90)`.
+        alpha: Backdrop opacity in `[0, 1]`.
+        zorder: Matplotlib draw order (`-1` puts it behind all data).
+        interpolation: Interpolation passed to `ax.imshow`.
+
+    Returns:
+        matplotlib.axes.Axes: The same axes, for chaining.
+
+    Raises:
+        ImportError: If Pillow (the `[tiles]` extra) is not installed.
+        TypeError: If `ax` is not a matplotlib Axes.
+        ValueError: If `resolution` is unknown.
+        ConnectionError: If the asset must be downloaded and the fetch
+            fails.
+    """
+    _validate_axes(ax)
+    rgb = relief(resolution)
+    west, south, east, north = (
+        extent if extent is not None else _RELIEF_EXTENT_4326
+    )
+
+    xlim, ylim = ax.get_xlim(), ax.get_ylim()
+    ax.imshow(
+        rgb,
+        extent=[west, east, south, north],
+        origin="upper",
+        alpha=alpha,
+        zorder=zorder,
+        interpolation=interpolation,
+        aspect=ax.get_aspect(),
+    )
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+    return ax
+
+
+# --------------------------------------------------------------------------
+# Features (Natural Earth vectors)
+# --------------------------------------------------------------------------
+
+#: layer -> (Natural Earth dataset stem, geometry kind). The stem is the
+#: artifact filename component; the kind selects the matplotlib collection
+#: and default styling.
+_LAYERS = {
+    "coastline": ("coastline", "line"),
+    "land": ("land", "polygon"),
+    "ocean": ("ocean", "polygon"),
+    "rivers": ("rivers_lake_centerlines", "line"),
+    "lakes": ("lakes", "polygon"),
+    "borders": ("admin_0_boundary_lines_land", "line"),
+}
+_RESOLUTIONS = ("110m", "50m", "10m")
+
+#: Preprocessed (gzipped GeoJSON) layers re-hosted on a cleopatra release.
+_FEATURE_BASE_URL = _RELIEF_BASE_URL
+
+#: Per-kind default styling, merged under caller `**style` overrides. Keys
+#: match the target collection's constructor (`PolyCollection` /
+#: `LineCollection`).
+_FEATURE_STYLE = {
+    "line": {"colors": "0.2", "linewidths": 0.6},
+    "polygon": {"facecolors": "0.85", "edgecolors": "0.4", "linewidths": 0.4},
+}
+
+
+def available_layers() -> list[str]:
+    """Return the Natural Earth layers that can be requested.
+
+    Returns:
+        list[str]: Valid `layer` names for `natural_earth` /
+            `add_features`.
+
+    Examples:
+        ```python
+        >>> from cleopatra.reference import available_layers
+        >>> available_layers()
+        ['coastline', 'land', 'ocean', 'rivers', 'lakes', 'borders']
+
+        ```
+    """
+    return list(_LAYERS)
+
+
+def available_resolutions() -> list[str]:
+    """Return the supported Natural Earth resolutions.
+
+    Returns:
+        list[str]: `["110m", "50m", "10m"]`.
+
+    Examples:
+        ```python
+        >>> from cleopatra.reference import available_resolutions
+        >>> available_resolutions()
+        ['110m', '50m', '10m']
+
+        ```
+    """
+    return list(_RESOLUTIONS)
+
+
+def _paths(geometry: dict) -> list[np.ndarray]:
+    """Flatten a GeoJSON geometry into a list of `(N, 2)` float arrays.
+
+    Polygons contribute their exterior ring only (interior holes are
+    dropped -- a reference backdrop does not need them). `Multi*`
+    geometries expand to one array per part.
+
+    Args:
+        geometry: A GeoJSON geometry object with `type` and
+            `coordinates`.
+
+    Returns:
+        list[numpy.ndarray]: One `(N, 2)` coordinate array per part.
+
+    Raises:
+        ValueError: If the geometry type is not a (Multi)LineString or
+            (Multi)Polygon.
+
+    Examples:
+        - A polygon yields its exterior ring; holes are ignored:
+            ```python
+            >>> from cleopatra.reference import _paths
+            >>> geom = {
+            ...     "type": "Polygon",
+            ...     "coordinates": [
+            ...         [[0, 0], [2, 0], [2, 2], [0, 0]],
+            ...         [[0.5, 0.5], [1, 0.5], [1, 1], [0.5, 0.5]],
+            ...     ],
+            ... }
+            >>> [p.shape for p in _paths(geom)]
+            [(4, 2)]
+
+            ```
+        - A MultiLineString expands to one array per line:
+            ```python
+            >>> from cleopatra.reference import _paths
+            >>> geom = {
+            ...     "type": "MultiLineString",
+            ...     "coordinates": [[[0, 0], [1, 1]], [[2, 2], [3, 3], [4, 4]]],
+            ... }
+            >>> [p.shape for p in _paths(geom)]
+            [(2, 2), (3, 2)]
+
+            ```
+    """
+    gtype = geometry["type"]
+    coords = geometry["coordinates"]
+    if gtype == "LineString":
+        return [np.asarray(coords, dtype=float)]
+    if gtype == "MultiLineString":
+        return [np.asarray(line, dtype=float) for line in coords]
+    if gtype == "Polygon":
+        return [np.asarray(coords[0], dtype=float)]
+    if gtype == "MultiPolygon":
+        return [np.asarray(poly[0], dtype=float) for poly in coords]
+    raise ValueError(f"Unsupported geometry type: {gtype!r}")
+
+
+def natural_earth(
+    layer: str = "coastline", resolution: str = "110m"
+) -> list[np.ndarray]:
+    """Fetch (and cache) a Natural Earth layer as coordinate arrays.
+
+    The layer is downloaded as preprocessed gzipped GeoJSON and parsed
+    with the standard library only -- no GDAL/geopandas. Coordinates are
+    EPSG:4326 lon/lat.
+
+    Args:
+        layer: One of `available_layers()`.
+        resolution: One of `available_resolutions()`
+            (`"110m"`/`"50m"`/`"10m"`).
+
+    Returns:
+        list[numpy.ndarray]: One `(N, 2)` lon/lat array per geometry part
+            (exterior rings for polygon layers).
+
+    Raises:
+        ValueError: If `layer` or `resolution` is unknown.
+        ConnectionError: If the asset must be downloaded and the fetch
+            fails.
+    """
+    if layer not in _LAYERS:
+        raise ValueError(
+            f"Unknown layer {layer!r}. Choose from {available_layers()}."
+        )
+    if resolution not in _RESOLUTIONS:
+        raise ValueError(
+            f"Unknown resolution {resolution!r}. "
+            f"Choose from {available_resolutions()}."
+        )
+    stem = _LAYERS[layer][0]
+    name = f"ne_{resolution}_{stem}.geojson.gz"
+    path = _download(_FEATURE_BASE_URL + name, _cache_dir() / name)
+    with gzip.open(path, "rt", encoding="utf-8") as fh:
+        collection = json.load(fh)
+    parts: list[np.ndarray] = []
+    for feature in collection["features"]:
+        geometry = feature.get("geometry")
+        if geometry is not None:
+            parts.extend(_paths(geometry))
+    return parts
+
+
+def _reproject(parts: list[np.ndarray], crs: int | str) -> list[np.ndarray]:
+    """Reproject EPSG:4326 lon/lat parts to `crs`.
+
+    Args:
+        parts: `(N, 2)` lon/lat arrays from `natural_earth`.
+        crs: Target CRS -- an int EPSG code or a CRS string/WKT.
+
+    Returns:
+        list[numpy.ndarray]: The parts in the target CRS.
+
+    Raises:
+        ImportError: If `pyproj` (the `[tiles]` extra) is not installed.
+    """
+    if importlib.util.find_spec("pyproj") is None:
+        raise ImportError(
+            "Reprojecting reference features to a non-EPSG:4326 CRS requires "
+            "pyproj, provided by the [tiles] extra. Install with "
+            "`pip install cleopatra[tiles]`, or plot your data in EPSG:4326."
+        )
+    from pyproj import Transformer
+
+    dst = f"EPSG:{crs}" if isinstance(crs, int) else str(crs)
+    transformer = Transformer.from_crs("EPSG:4326", dst, always_xy=True)
+    out: list[np.ndarray] = []
+    for part in parts:
+        x, y = transformer.transform(part[:, 0], part[:, 1])
+        out.append(np.column_stack([np.asarray(x), np.asarray(y)]))
+    return out
+
+
+def _is_4326(crs: int | str | None) -> bool:
+    """Return True when `crs` denotes EPSG:4326 (or is unspecified)."""
+    if crs is None:
+        return True
+    return str(crs).upper().replace("EPSG:", "") == "4326"
+
+
+def add_features(
+    ax: Any,
+    layer: str = "coastline",
+    resolution: str = "110m",
+    *,
+    crs: int | str | None = None,
+    zorder: int = 0,
+    **style: Any,
+) -> Any:
+    """Draw a Natural Earth reference layer on an Axes.
+
+    The `cartopy` `ax.coastlines()` analogue. Polygon layers
+    (`land`/`ocean`/`lakes`) are drawn as a filled `PolyCollection`; line
+    layers (`coastline`/`rivers`/`borders`) as a `LineCollection`. The
+    source data is EPSG:4326; pass `crs` to reproject the geometry into
+    the axes' CRS (requires `pyproj`). The current axis limits are
+    preserved.
+
+    Args:
+        ax: A matplotlib `Axes` with data already plotted.
+        layer: One of `available_layers()`.
+        resolution: One of `available_resolutions()`.
+        crs: CRS of the data on `ax`. `None` or `4326`/`"EPSG:4326"`
+            draws the lon/lat coordinates directly; any other value
+            reprojects from EPSG:4326 first.
+        zorder: Matplotlib draw order for the layer.
+        **style: Overrides merged over the per-kind defaults and
+            forwarded to the underlying collection. Use
+            `PolyCollection` keys for polygon layers (`facecolors`,
+            `edgecolors`, `linewidths`) and `LineCollection` keys for
+            line layers (`colors`, `linewidths`).
+
+    Returns:
+        matplotlib.axes.Axes: The same axes, for chaining.
+
+    Raises:
+        TypeError: If `ax` is not a matplotlib Axes.
+        ValueError: If `layer` or `resolution` is unknown.
+        ImportError: If `crs` requires reprojection but `pyproj` is not
+            installed.
+        ConnectionError: If the asset must be downloaded and the fetch
+            fails.
+    """
+    _validate_axes(ax)
+    if layer not in _LAYERS:
+        raise ValueError(
+            f"Unknown layer {layer!r}. Choose from {available_layers()}."
+        )
+
+    parts = natural_earth(layer, resolution)
+    if not _is_4326(crs):
+        parts = _reproject(parts, crs)  # type: ignore[arg-type]
+
+    kind = _LAYERS[layer][1]
+    opts = {**_FEATURE_STYLE[kind], **style}
+
+    xlim, ylim = ax.get_xlim(), ax.get_ylim()
+    if kind == "polygon":
+        collection: Any = PolyCollection(parts, zorder=zorder, **opts)
+    else:
+        collection = LineCollection(parts, zorder=zorder, **opts)
+    ax.add_collection(collection)
+    ax.set_xlim(xlim)
+    ax.set_ylim(ylim)
+    return ax

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -28,6 +28,7 @@ _SUBMODULES = [
     "mesh_glyph",
     "polygon_glyph",
     "projection",
+    "reference",
     "scatter_glyph",
     "statistical_glyph",
     "styles",

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -1,0 +1,297 @@
+"""Tests for cleopatra.reference.
+
+Covers `add_relief` / `add_features` and their helpers. No test hits the
+network: assets are pre-written into a temporary cache directory
+(`CLEOPATRA_CACHE_DIR`) so `_download` short-circuits to the cached file
+and the real read/parse/draw path is exercised offline.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.plot
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+from matplotlib.collections import LineCollection, PolyCollection  # noqa: E402
+
+from cleopatra import reference  # noqa: E402
+from cleopatra.reference import (  # noqa: E402
+    _is_4326,
+    _paths,
+    add_features,
+    add_relief,
+    available_layers,
+    available_relief_resolutions,
+    available_resolutions,
+    natural_earth,
+    relief,
+)
+
+
+@pytest.fixture
+def cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the reference cache at a temp dir for the duration of a test."""
+    monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _write_layer(cache: Path, stem: str, resolution: str, geometry: dict) -> None:
+    """Write a one-feature gzipped GeoJSON asset into the cache."""
+    collection = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "geometry": geometry}],
+    }
+    path = cache / f"ne_{resolution}_{stem}.geojson.gz"
+    with gzip.open(path, "wt", encoding="utf-8") as fh:
+        json.dump(collection, fh)
+
+
+# --- discovery helpers ------------------------------------------------------
+
+
+def test_available_layers():
+    assert available_layers() == [
+        "coastline",
+        "land",
+        "ocean",
+        "rivers",
+        "lakes",
+        "borders",
+    ]
+
+
+def test_available_resolutions():
+    assert available_resolutions() == ["110m", "50m", "10m"]
+
+
+def test_available_relief_resolutions():
+    assert available_relief_resolutions() == ["low", "medium"]
+
+
+# --- geometry flattening ----------------------------------------------------
+
+
+def test_paths_polygon_drops_holes():
+    geom = {
+        "type": "Polygon",
+        "coordinates": [
+            [[0, 0], [2, 0], [2, 2], [0, 0]],
+            [[0.5, 0.5], [1, 0.5], [1, 1], [0.5, 0.5]],
+        ],
+    }
+    parts = _paths(geom)
+    assert len(parts) == 1
+    assert parts[0].shape == (4, 2)
+
+
+def test_paths_multipolygon_one_per_part():
+    geom = {
+        "type": "MultiPolygon",
+        "coordinates": [
+            [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+            [[[5, 5], [6, 5], [6, 6], [5, 5]]],
+        ],
+    }
+    assert [p.shape for p in _paths(geom)] == [(4, 2), (4, 2)]
+
+
+def test_paths_multilinestring():
+    geom = {
+        "type": "MultiLineString",
+        "coordinates": [[[0, 0], [1, 1]], [[2, 2], [3, 3], [4, 4]]],
+    }
+    assert [p.shape for p in _paths(geom)] == [(2, 2), (3, 2)]
+
+
+def test_paths_unsupported_type_raises():
+    with pytest.raises(ValueError, match="Unsupported geometry type"):
+        _paths({"type": "Point", "coordinates": [0, 0]})
+
+
+def test_is_4326():
+    assert _is_4326(None)
+    assert _is_4326(4326)
+    assert _is_4326("EPSG:4326")
+    assert _is_4326("epsg:4326")
+    assert not _is_4326(3857)
+    assert not _is_4326("EPSG:3857")
+
+
+# --- natural_earth ----------------------------------------------------------
+
+
+def test_natural_earth_reads_cached_lines(cache: Path):
+    _write_layer(
+        cache,
+        "coastline",
+        "110m",
+        {"type": "MultiLineString", "coordinates": [[[0, 0], [10, 10]], [[5, 5], [6, 7]]]},
+    )
+    parts = natural_earth("coastline", "110m")
+    assert len(parts) == 2
+    assert all(p.ndim == 2 and p.shape[1] == 2 for p in parts)
+
+
+def test_natural_earth_skips_null_geometry(cache: Path):
+    collection = {
+        "type": "FeatureCollection",
+        "features": [
+            {"type": "Feature", "geometry": None},
+            {
+                "type": "Feature",
+                "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+            },
+        ],
+    }
+    with gzip.open(cache / "ne_110m_coastline.geojson.gz", "wt", encoding="utf-8") as fh:
+        json.dump(collection, fh)
+    parts = natural_earth("coastline", "110m")
+    assert len(parts) == 1
+
+
+def test_natural_earth_unknown_layer():
+    with pytest.raises(ValueError, match="Unknown layer"):
+        natural_earth("rivers_and_roads", "110m")
+
+
+def test_natural_earth_unknown_resolution():
+    with pytest.raises(ValueError, match="Unknown resolution"):
+        natural_earth("coastline", "1m")
+
+
+# --- add_features -----------------------------------------------------------
+
+
+def test_add_features_line_layer(cache: Path):
+    _write_layer(
+        cache,
+        "coastline",
+        "110m",
+        {"type": "MultiLineString", "coordinates": [[[0, 0], [10, 10], [20, 5]]]},
+    )
+    fig, ax = plt.subplots()
+    ax.plot([0, 20], [0, 10])
+    xlim, ylim = ax.get_xlim(), ax.get_ylim()
+    out = add_features(ax, "coastline", "110m", colors="navy")
+    assert out is ax
+    lcs = [c for c in ax.collections if isinstance(c, LineCollection)]
+    assert len(lcs) == 1
+    assert ax.get_xlim() == xlim and ax.get_ylim() == ylim
+    plt.close(fig)
+
+
+def test_add_features_polygon_layer(cache: Path):
+    _write_layer(
+        cache,
+        "land",
+        "110m",
+        {"type": "Polygon", "coordinates": [[[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]]},
+    )
+    fig, ax = plt.subplots()
+    ax.plot([0, 10], [0, 10])
+    add_features(ax, "land", "110m", facecolors="0.7")
+    assert any(isinstance(c, PolyCollection) for c in ax.collections)
+    plt.close(fig)
+
+
+def test_add_features_bad_axes():
+    with pytest.raises(TypeError, match="matplotlib.axes.Axes"):
+        add_features(object(), "coastline", "110m")
+
+
+def test_add_features_unknown_layer():
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match="Unknown layer"):
+        add_features(ax, "nope", "110m")
+    plt.close(fig)
+
+
+def test_add_features_reproject(cache: Path):
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    _write_layer(
+        cache,
+        "coastline",
+        "110m",
+        {"type": "LineString", "coordinates": [[0, 0], [10, 0]]},
+    )
+    fig, ax = plt.subplots()
+    ax.plot([0, 2e6], [0, 1e6])
+    add_features(ax, "coastline", "110m", crs=3857)
+    verts = ax.collections[0].get_paths()[0].vertices
+    # lon=0 maps to x=0 in EPSG:3857; lon=10 maps to ~1.11e6 m.
+    assert abs(verts[0][0]) < 1.0
+    assert verts[1][0] > 1.0e6
+    plt.close(fig)
+
+
+# --- relief -----------------------------------------------------------------
+
+
+def test_relief_unknown_resolution():
+    with pytest.raises(ValueError, match="Unknown relief resolution"):
+        relief("ultra")
+
+
+def test_add_relief(cache: Path):
+    Image = pytest.importorskip(
+        "PIL.Image", reason="Pillow not installed (tiles extra)"
+    )
+    arr = (np.random.default_rng(0).random((10, 20, 3)) * 255).astype("uint8")
+    Image.fromarray(arr).save(cache / "ne_hypso_rgb_720x360.png")
+
+    fig, ax = plt.subplots()
+    ax.set_xlim(-20, 40)
+    ax.set_ylim(0, 60)
+    out = add_relief(ax, "low")
+    assert out is ax
+    assert len(ax.images) == 1
+    assert ax.get_xlim() == (-20.0, 40.0)
+    img = ax.images[0]
+    assert tuple(img.get_extent()) == (-180.0, 180.0, -90.0, 90.0)
+    plt.close(fig)
+
+
+def test_add_relief_custom_extent(cache: Path):
+    Image = pytest.importorskip(
+        "PIL.Image", reason="Pillow not installed (tiles extra)"
+    )
+    arr = (np.random.default_rng(1).random((4, 8, 3)) * 255).astype("uint8")
+    Image.fromarray(arr).save(cache / "ne_hypso_rgb_720x360.png")
+
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 10)
+    ax.set_ylim(0, 10)
+    add_relief(ax, "low", extent=(0, 0, 10, 10))
+    assert tuple(ax.images[0].get_extent()) == (0.0, 10.0, 0.0, 10.0)
+    plt.close(fig)
+
+
+def test_add_relief_bad_axes():
+    with pytest.raises(TypeError, match="matplotlib.axes.Axes"):
+        add_relief(object())
+
+
+# --- download guard ---------------------------------------------------------
+
+
+def test_download_rejects_non_http(tmp_path: Path):
+    with pytest.raises(ValueError, match="non-http"):
+        reference._download("ftp://example.com/x.gz", tmp_path / "x.gz")
+
+
+def test_download_returns_cached(tmp_path: Path):
+    dest = tmp_path / "cached.bin"
+    dest.write_bytes(b"already here")
+    # No network: a cached file is returned untouched even for a bogus URL.
+    assert reference._download("https://nope.invalid/cached.bin", dest) == dest
+    assert dest.read_bytes() == b"already here"

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -243,6 +243,23 @@ def test_add_features_polygon_hole_renders_as_cutout(cache: Path):
     plt.close(fig)
 
 
+def test_add_features_zorder_and_style_passthrough(cache: Path):
+    """`zorder` and `**style` overrides reach the underlying collection."""
+    _write_layer(
+        cache,
+        "coastline",
+        "110m",
+        {"type": "LineString", "coordinates": [[0, 0], [10, 10]]},
+    )
+    fig, ax = plt.subplots()
+    ax.plot([0, 10], [0, 10])
+    add_features(ax, "coastline", "110m", zorder=5, linewidths=2.5)
+    lc = next(c for c in ax.collections if isinstance(c, LineCollection))
+    assert lc.get_zorder() == 5, f"zorder not forwarded: {lc.get_zorder()}"
+    assert lc.get_linewidths()[0] == 2.5, f"linewidth not forwarded: {lc.get_linewidths()}"
+    plt.close(fig)
+
+
 def test_add_features_bad_axes():
     with pytest.raises(TypeError, match="matplotlib.axes.Axes"):
         add_features(object(), "coastline", "110m")
@@ -357,6 +374,25 @@ def test_add_relief(cache: Path):
     assert ax.get_xlim() == (-20.0, 40.0)
     img = ax.images[0]
     assert tuple(img.get_extent()) == (-180.0, 180.0, -90.0, 90.0)
+    plt.close(fig)
+
+
+def test_add_relief_passes_imshow_params(cache: Path):
+    """`alpha`, `zorder`, and `interpolation` are forwarded to `imshow`."""
+    Image = pytest.importorskip("PIL.Image", reason="Pillow not installed (tiles extra)")
+    arr = (np.random.default_rng(2).random((4, 8, 3)) * 255).astype("uint8")
+    Image.fromarray(arr).save(cache / "ne_hypso_rgb_720x360.png")
+
+    fig, ax = plt.subplots()
+    ax.set_xlim(-180, 180)
+    ax.set_ylim(-90, 90)
+    add_relief(ax, "low", alpha=0.5, zorder=-3, interpolation="nearest")
+    img = ax.images[0]
+    assert img.get_alpha() == 0.5, f"alpha not forwarded: {img.get_alpha()}"
+    assert img.get_zorder() == -3, f"zorder not forwarded: {img.get_zorder()}"
+    assert img.get_interpolation() == "nearest", (
+        f"interpolation not forwarded: {img.get_interpolation()}"
+    )
     plt.close(fig)
 
 

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -323,6 +323,16 @@ def test_natural_earth_corrupt_cache_self_heals(cache: Path):
     assert not bad.exists()
 
 
+def test_natural_earth_non_featurecollection_cache_self_heals(cache: Path):
+    """Valid gzip+JSON that is not a FeatureCollection is also removed (L1)."""
+    bad = cache / "ne_110m_coastline.geojson.gz"
+    with gzip.open(bad, "wt", encoding="utf-8") as fh:
+        json.dump({"message": "Not Found"}, fh)
+    with pytest.raises(OSError, match="removed"):
+        natural_earth("coastline", "110m")
+    assert not bad.exists()
+
+
 # --- relief -----------------------------------------------------------------
 
 
@@ -511,6 +521,13 @@ def test_make_transformer_requires_pyproj(monkeypatch: pytest.MonkeyPatch):
     )
     with pytest.raises(ImportError, match="pyproj"):
         reference._make_transformer(3857)
+
+
+def test_make_transformer_invalid_crs_raises_valueerror():
+    """An unparseable CRS surfaces a wrapped ValueError, not a pyproj error (L2)."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    with pytest.raises(ValueError, match="Invalid CRS"):
+        reference._make_transformer("not-a-real-crs")
 
 
 def test_reproject_arr_roundtrip():

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -22,7 +22,7 @@ import matplotlib
 matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt  # noqa: E402
-from matplotlib.collections import LineCollection, PolyCollection  # noqa: E402
+from matplotlib.collections import LineCollection, PathCollection  # noqa: E402
 
 from cleopatra import reference  # noqa: E402
 from cleopatra.reference import (  # noqa: E402
@@ -199,8 +199,45 @@ def test_add_features_polygon_layer(cache: Path):
     )
     fig, ax = plt.subplots()
     ax.plot([0, 10], [0, 10])
+    xlim, ylim = ax.get_xlim(), ax.get_ylim()
     add_features(ax, "land", "110m", facecolors="0.7")
-    assert any(isinstance(c, PolyCollection) for c in ax.collections)
+    assert any(isinstance(c, PathCollection) for c in ax.collections)
+    assert ax.get_xlim() == xlim and ax.get_ylim() == ylim
+    plt.close(fig)
+
+
+def test_add_features_polygon_hole_renders_as_cutout(cache: Path):
+    """A polygon with a hole must leave the hole unfilled (H1 regression)."""
+    _write_layer(
+        cache,
+        "ocean",
+        "110m",
+        {
+            "type": "Polygon",
+            "coordinates": [
+                [[0, 0], [10, 0], [10, 10], [0, 10], [0, 0]],  # exterior
+                [[4, 4], [6, 4], [6, 6], [4, 6], [4, 4]],  # hole
+            ],
+        },
+    )
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 10)
+    ax.set_ylim(0, 10)
+    ax.set_position([0, 0, 1, 1])
+    ax.axis("off")
+    add_features(ax, "ocean", "110m", facecolors="black", edgecolors="none")
+    fig.canvas.draw()
+    buf = np.asarray(fig.canvas.buffer_rgba())
+    height, width, _ = buf.shape
+
+    def pixel(x_frac: float, y_frac: float) -> np.ndarray:
+        # y is flipped: buffer row 0 is the top of the figure.
+        return buf[int((1 - y_frac) * height) - 1, int(x_frac * width) - 1, :3]
+
+    # The exterior ring is filled (dark); the hole's centre is the white
+    # background — i.e. the hole is cut out, not painted over (H1).
+    assert pixel(0.1, 0.1).sum() < 60
+    assert pixel(0.5, 0.5).sum() > 600
     plt.close(fig)
 
 
@@ -232,6 +269,56 @@ def test_add_features_reproject(cache: Path):
     assert abs(verts[0][0]) < 1.0
     assert verts[1][0] > 1.0e6
     plt.close(fig)
+
+
+def test_add_features_reproject_polygon_drops_nonfinite_at_poles(cache: Path):
+    """Reprojecting a pole-touching polygon to 3857 must not emit inf (M1)."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    _write_layer(
+        cache,
+        "land",
+        "110m",
+        {
+            "type": "Polygon",
+            "coordinates": [[[-10, -90], [10, -90], [10, -80], [-10, -80], [-10, -90]]],
+        },
+    )
+    fig, ax = plt.subplots()
+    ax.plot([0, 1e6], [0, 1e6])
+    add_features(ax, "land", "110m", crs=3857)
+    pc = next(c for c in ax.collections if isinstance(c, PathCollection))
+    for path in pc.get_paths():
+        assert np.isfinite(path.vertices).all()
+    plt.close(fig)
+
+
+def test_add_features_reproject_line_drops_nonfinite_at_poles(cache: Path):
+    """A meridian line through the pole keeps only its finite span (M1)."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    _write_layer(
+        cache,
+        "coastline",
+        "110m",
+        {"type": "LineString", "coordinates": [[0, -90], [0, -80], [0, 0], [0, 80]]},
+    )
+    fig, ax = plt.subplots()
+    ax.plot([0, 1e6], [0, 1e6])
+    add_features(ax, "coastline", "110m", crs=3857)
+    lc = next(c for c in ax.collections if isinstance(c, LineCollection))
+    segments = lc.get_segments()
+    assert segments  # the finite span survived
+    for seg in segments:
+        assert np.isfinite(seg).all()
+    plt.close(fig)
+
+
+def test_natural_earth_corrupt_cache_self_heals(cache: Path):
+    """A poisoned (non-gzip) cache file is removed so a retry re-fetches (L1)."""
+    bad = cache / "ne_110m_coastline.geojson.gz"
+    bad.write_bytes(b"this is not gzip data")
+    with pytest.raises(OSError, match="removed"):
+        natural_earth("coastline", "110m")
+    assert not bad.exists()
 
 
 # --- relief -----------------------------------------------------------------
@@ -279,6 +366,16 @@ def test_add_relief_custom_extent(cache: Path):
 def test_add_relief_bad_axes():
     with pytest.raises(TypeError, match="matplotlib.axes.Axes"):
         add_relief(object())
+
+
+def test_relief_corrupt_cache_self_heals(cache: Path):
+    """A poisoned (non-image) relief cache file is removed on read (L1)."""
+    pytest.importorskip("PIL.Image", reason="Pillow not installed (tiles extra)")
+    bad = cache / "ne_hypso_rgb_720x360.png"
+    bad.write_bytes(b"this is not a png")
+    with pytest.raises(OSError, match="removed"):
+        relief("low")
+    assert not bad.exists()
 
 
 # --- download guard ---------------------------------------------------------

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -9,7 +9,9 @@ and the real read/parse/draw path is exercised offline.
 from __future__ import annotations
 
 import gzip
+import io
 import json
+import urllib.error
 from pathlib import Path
 
 import numpy as np
@@ -392,3 +394,130 @@ def test_download_returns_cached(tmp_path: Path):
     # No network: a cached file is returned untouched even for a bogus URL.
     assert reference._download("https://nope.invalid/cached.bin", dest) == dest
     assert dest.read_bytes() == b"already here"
+
+
+def test_download_streams_to_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A successful download is streamed to `dest`, leaving no `.part` file."""
+    payload = b"reference-asset-bytes"
+    monkeypatch.setattr(
+        reference.urllib.request,
+        "urlopen",
+        lambda request, timeout=None: io.BytesIO(payload),
+    )
+    dest = tmp_path / "asset.bin"
+    out = reference._download("https://example.com/asset.bin", dest)
+    assert out == dest
+    assert dest.read_bytes() == payload
+    assert not (tmp_path / "asset.bin.part").exists()
+
+
+def test_download_failure_raises_and_cleans_part(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A failed fetch raises ConnectionError and removes the partial file."""
+
+    def boom(request, timeout=None):
+        raise urllib.error.URLError("network down")
+
+    monkeypatch.setattr(reference.urllib.request, "urlopen", boom)
+    dest = tmp_path / "asset.bin"
+    with pytest.raises(ConnectionError, match="Failed to download"):
+        reference._download("https://example.com/asset.bin", dest)
+    assert not dest.exists()
+    assert not (tmp_path / "asset.bin.part").exists()
+
+
+# --- helpers: geometry, orientation, finite runs ----------------------------
+
+
+def test_polygons_multipolygon_keeps_rings():
+    geom = {
+        "type": "MultiPolygon",
+        "coordinates": [
+            [[[0, 0], [1, 0], [1, 1], [0, 0]], [[0.2, 0.2], [0.6, 0.2], [0.6, 0.6], [0.2, 0.2]]],
+            [[[5, 5], [6, 5], [6, 6], [5, 5]]],
+        ],
+    }
+    polys = reference._polygons(geom)
+    assert [len(p) for p in polys] == [2, 1]
+
+
+def test_polygons_non_polygon_returns_empty():
+    assert reference._polygons({"type": "LineString", "coordinates": [[0, 0], [1, 1]]}) == []
+
+
+def test_signed_area_sign():
+    ccw = np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]], dtype=float)
+    assert reference._signed_area(ccw) > 0
+    assert reference._signed_area(ccw[::-1]) < 0
+
+
+def test_orient_forces_requested_winding():
+    ccw = np.array([[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]], dtype=float)
+    assert reference._signed_area(reference._orient(ccw, ccw=True)) > 0
+    assert reference._signed_area(reference._orient(ccw, ccw=False)) < 0
+    # Already-correct winding is returned unchanged (no needless copy/flip).
+    assert np.array_equal(reference._orient(ccw, ccw=True), ccw)
+
+
+@pytest.mark.parametrize(
+    "rows, expected_lengths",
+    [
+        ([], []),
+        ([[0, 0]], []),
+        ([[0, 0], [1, 1]], [2]),
+        ([[0, 0], [1, 1], [np.inf, 0], [2, 2], [3, 3]], [2, 2]),
+        ([[np.inf, np.inf], [1, 1], [2, 2]], [2]),
+        ([[0, 0], [1, 1], [np.inf, 0], [2, 2]], [2]),
+        ([[0, 0], [np.inf, 0], [2, 2], [3, 3]], [2]),
+    ],
+)
+def test_finite_runs(rows, expected_lengths):
+    """`_finite_runs` keeps maximal finite spans of length >= 2."""
+    arr = np.array(rows, dtype=float).reshape(-1, 2) if rows else np.empty((0, 2))
+    runs = reference._finite_runs(arr)
+    assert [len(r) for r in runs] == expected_lengths
+    for run in runs:
+        assert np.isfinite(run).all()
+
+
+def test_compound_path_empty_returns_none():
+    assert reference._compound_path([]) is None
+
+
+def test_polygon_paths_skips_degenerate_rings():
+    """A polygon whose only ring has < 3 points yields no drawable path."""
+    geom = {"type": "Polygon", "coordinates": [[[0, 0], [1, 1]]]}
+    assert reference._polygon_paths([geom], None) == []
+
+
+# --- dependency guards ------------------------------------------------------
+
+
+def test_relief_requires_pillow(monkeypatch: pytest.MonkeyPatch):
+    """`relief` raises a helpful ImportError when Pillow is unavailable."""
+    monkeypatch.setattr(reference, "_PILLOW_AVAILABLE", False)
+    with pytest.raises(ImportError, match="Pillow"):
+        relief("low")
+
+
+def test_make_transformer_requires_pyproj(monkeypatch: pytest.MonkeyPatch):
+    """`_make_transformer` raises ImportError when pyproj is unavailable."""
+    real_find_spec = reference.importlib.util.find_spec
+    monkeypatch.setattr(
+        reference.importlib.util,
+        "find_spec",
+        lambda name: None if name == "pyproj" else real_find_spec(name),
+    )
+    with pytest.raises(ImportError, match="pyproj"):
+        reference._make_transformer(3857)
+
+
+def test_reproject_arr_roundtrip():
+    """`_reproject_arr` maps EPSG:4326 lon/lat into the target CRS."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    transformer = reference._make_transformer(3857)
+    out = reference._reproject_arr(np.array([[0.0, 0.0], [10.0, 0.0]]), transformer)
+    assert out.shape == (2, 2)
+    assert abs(out[0, 0]) < 1.0
+    assert out[1, 0] > 1.0e6

--- a/tools/build_basemap_assets.py
+++ b/tools/build_basemap_assets.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Build cleopatra's reference-basemap assets (maintainer-side, offline).
+
+This script is **not** part of the shipped package and is **not** run at
+import or install time. It is the one-off, maintainer-machine tool that
+converts upstream public datasets into the lightweight, dependency-free
+artifacts that ``cleopatra.reference`` downloads and reads at runtime:
+
+* **Natural Earth vectors** -> gzipped GeoJSON
+  (``ne_<res>_<stem>.geojson.gz``), read at runtime with stdlib ``json``.
+  Conversion happens here, where heavy GIS deps (geopandas/GDAL) are fine;
+  the published artifact carries none of them.
+* **Hypsometric relief** -> plain RGB PNG
+  (``ne_hypso_rgb_<W>x<H>.png``), read at runtime with Pillow only. The
+  geotransform is intentionally dropped: every product is a global
+  EPSG:4326 raster, so ``cleopatra.reference`` hardcodes the extent.
+
+Outputs land in ``--out-dir`` with exactly the filenames the runtime
+helpers expect, ready to attach to a cleopatra release
+(``basemap-data-v1``).
+
+Maintainer dependencies (install in a throwaway env, *not* in cleopatra)::
+
+    pip install geopandas shapely pillow
+
+Examples::
+
+    # Build everything (downloads Natural Earth zips from naciscdn.org).
+    python tools/build_basemap_assets.py --out-dir dist/basemap
+
+    # Vectors only, just the 110m + 50m resolutions, more aggressive
+    # simplification to shrink the artifacts.
+    python tools/build_basemap_assets.py --out-dir dist/basemap \
+        --skip-relief --resolutions 110m 50m --simplify 0.02
+
+    # Relief only, from local source GeoTIFFs you already downloaded.
+    python tools/build_basemap_assets.py --out-dir dist/basemap \
+        --skip-vectors --relief-src ./tif
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# --- runtime-mirrored maps (keep in sync with cleopatra/reference.py) -------
+
+#: layer -> (Natural Earth category, dataset stem). Geometry kind is
+#: irrelevant here -- the runtime infers it; we only need the source path.
+_LAYERS = {
+    "coastline": ("physical", "coastline"),
+    "land": ("physical", "land"),
+    "ocean": ("physical", "ocean"),
+    "rivers": ("physical", "rivers_lake_centerlines"),
+    "lakes": ("physical", "lakes"),
+    "borders": ("cultural", "admin_0_boundary_lines_land"),
+}
+_RESOLUTIONS = ("110m", "50m", "10m")
+
+_NE_BASE_URL = "https://naciscdn.org/naturalearth"
+
+#: Relief products: output PNG name -> source GeoTIFF name. The source TIFFs
+#: currently live on the *pyramids* basemap-data-v1 release; this script
+#: re-emits them as PNG so the cleopatra asset owns no GeoTIFF.
+_RELIEF_PRODUCTS = {
+    "ne_hypso_rgb_720x360.png": "ne_hypso_rgb_720x360.tif",
+    "ne_hypso_rgb_1440x720.png": "ne_hypso_rgb_1440x720.tif",
+}
+_RELIEF_SRC_URL = (
+    "https://github.com/serapeum-org/pyramids/releases/download/basemap-data-v1/"
+)
+
+#: Per-resolution simplification tolerance (degrees) and coordinate grid
+#: (degrees) applied before export. Coarser resolutions need almost no
+#: help; 10m is where the savings matter. Overridable via --simplify /
+#: --precision.
+_DEFAULT_SIMPLIFY = {"110m": 0.0, "50m": 0.005, "10m": 0.01}
+_DEFAULT_PRECISION = {"110m": 0.001, "50m": 0.0005, "10m": 0.0001}
+
+USER_AGENT = "cleopatra-asset-builder (+https://github.com/serapeum-org/cleopatra)"
+
+
+def _log(msg: str) -> None:
+    print(msg, file=sys.stderr, flush=True)
+
+
+def _download(url: str, dest: Path) -> Path:
+    """Download ``url`` to ``dest`` (skipping if already present). http(s)."""
+    if dest.exists():
+        _log(f"  cached  {dest.name}")
+        return dest
+    if not url.lower().startswith(("http://", "https://")):
+        raise ValueError(f"Refusing non-http(s) URL: {url!r}")
+    _log(f"  fetch   {url}")
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=120) as response:
+            data = response.read()
+    except (urllib.error.URLError, OSError) as e:
+        raise ConnectionError(f"Failed to download {url!r}: {e}") from e
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    tmp.write_bytes(data)
+    tmp.replace(dest)
+    return dest
+
+
+# --- vectors ----------------------------------------------------------------
+
+
+def build_vectors(
+    out_dir: Path,
+    cache_dir: Path,
+    resolutions: list[str],
+    layers: list[str],
+    simplify: dict[str, float],
+    precision: dict[str, float],
+) -> None:
+    """Convert Natural Earth shapefiles to gzipped GeoJSON in ``out_dir``."""
+    import geopandas as gpd
+    from shapely import set_precision
+
+    for resolution in resolutions:
+        for layer in layers:
+            category, stem = _LAYERS[layer]
+            zip_name = f"ne_{resolution}_{stem}.zip"
+            url = f"{_NE_BASE_URL}/{resolution}/{category}/{zip_name}"
+            out_name = f"ne_{resolution}_{stem}.geojson.gz"
+            _log(f"[vector] {resolution}/{layer} -> {out_name}")
+
+            zip_path = _download(url, cache_dir / zip_name)
+            gdf = gpd.read_file(f"zip://{zip_path}")
+
+            # Keep geometry only; runtime needs no attributes. Reproject to
+            # EPSG:4326 defensively (Natural Earth already is, but be safe).
+            gdf = gdf[[gdf.geometry.name]]
+            if gdf.crs is not None and gdf.crs.to_epsg() != 4326:
+                gdf = gdf.to_crs(4326)
+
+            tol = simplify.get(resolution, 0.0)
+            if tol > 0:
+                gdf["geometry"] = gdf.geometry.simplify(
+                    tol, preserve_topology=True
+                )
+            grid = precision.get(resolution, 0.0)
+            if grid > 0:
+                gdf["geometry"] = set_precision(gdf.geometry.values, grid)
+                gdf = gdf[~gdf.geometry.is_empty]
+
+            # to_json -> a GeoJSON FeatureCollection string. drop_id keeps it
+            # small; the runtime only reads .features[].geometry.
+            geojson = gdf.to_json(drop_id=True)
+            out_path = out_dir / out_name
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            raw = geojson.encode("utf-8")
+            with gzip.open(out_path, "wb", compresslevel=9) as fh:
+                fh.write(raw)
+            _log(
+                f"         {len(gdf)} features, "
+                f"{len(raw) / 1e6:.1f} MB -> {out_path.stat().st_size / 1e6:.2f} MB gz"
+            )
+
+
+# --- relief -----------------------------------------------------------------
+
+
+def build_relief(out_dir: Path, cache_dir: Path, relief_src: Path | None) -> None:
+    """Convert relief GeoTIFFs to RGB PNGs in ``out_dir``.
+
+    ``relief_src`` is a directory of source ``.tif`` files; if ``None`` the
+    sources are downloaded from the pyramids basemap-data-v1 release.
+    """
+    from PIL import Image
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for png_name, tif_name in _RELIEF_PRODUCTS.items():
+        _log(f"[relief] {tif_name} -> {png_name}")
+        if relief_src is not None:
+            tif_path = relief_src / tif_name
+            if not tif_path.exists():
+                raise FileNotFoundError(f"Missing relief source: {tif_path}")
+        else:
+            tif_path = _download(_RELIEF_SRC_URL + tif_name, cache_dir / tif_name)
+
+        # Pillow reads the raster pixels and ignores the geo metadata, which
+        # is exactly what we want: a plain north-up RGB image.
+        with Image.open(tif_path) as img:
+            rgb = img.convert("RGB")
+            out_path = out_dir / png_name
+            rgb.save(out_path, format="PNG", optimize=True)
+        _log(
+            f"         {rgb.size[0]}x{rgb.size[1]} -> "
+            f"{out_path.stat().st_size / 1e6:.2f} MB"
+        )
+
+
+# --- cli --------------------------------------------------------------------
+
+
+def _parse_kv(values: list[str] | None, base: dict[str, float]) -> dict[str, float]:
+    """Merge ``res=value`` overrides (or a single scalar) into ``base``."""
+    if not values:
+        return dict(base)
+    merged = dict(base)
+    for item in values:
+        if "=" in item:
+            res, val = item.split("=", 1)
+            merged[res] = float(val)
+        else:  # a bare scalar applies to every resolution
+            merged = {res: float(item) for res in merged}
+    return merged
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--out-dir", type=Path, required=True, help="Directory for built assets."
+    )
+    parser.add_argument(
+        "--cache-dir",
+        type=Path,
+        default=None,
+        help="Where to cache downloaded sources (default: a temp dir).",
+    )
+    parser.add_argument(
+        "--resolutions",
+        nargs="+",
+        default=list(_RESOLUTIONS),
+        choices=_RESOLUTIONS,
+        help="Natural Earth resolutions to build.",
+    )
+    parser.add_argument(
+        "--layers",
+        nargs="+",
+        default=list(_LAYERS),
+        choices=list(_LAYERS),
+        help="Natural Earth layers to build.",
+    )
+    parser.add_argument(
+        "--simplify",
+        nargs="+",
+        default=None,
+        metavar="RES=TOL|TOL",
+        help="Simplify tolerance in degrees, per resolution or a single "
+        "scalar (e.g. '10m=0.02' or '0.01').",
+    )
+    parser.add_argument(
+        "--precision",
+        nargs="+",
+        default=None,
+        metavar="RES=GRID|GRID",
+        help="Coordinate grid size in degrees for quantization.",
+    )
+    parser.add_argument(
+        "--relief-src",
+        type=Path,
+        default=None,
+        help="Directory of source relief GeoTIFFs (default: download).",
+    )
+    parser.add_argument(
+        "--skip-vectors", action="store_true", help="Do not build vector assets."
+    )
+    parser.add_argument(
+        "--skip-relief", action="store_true", help="Do not build relief assets."
+    )
+    args = parser.parse_args(argv)
+
+    simplify = _parse_kv(args.simplify, _DEFAULT_SIMPLIFY)
+    precision = _parse_kv(args.precision, _DEFAULT_PRECISION)
+
+    out_dir: Path = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        cache_dir = args.cache_dir if args.cache_dir is not None else Path(tmp)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        if not args.skip_vectors:
+            build_vectors(
+                out_dir,
+                cache_dir,
+                args.resolutions,
+                args.layers,
+                simplify,
+                precision,
+            )
+        if not args.skip_relief:
+            build_relief(out_dir, cache_dir, args.relief_src)
+
+    _log(f"\nDone. Assets written to {out_dir.resolve()}")
+    _log("Attach the contents to the cleopatra 'basemap-data-v1' release.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Closes #165. Moves the reference cartographic data helpers (Natural Earth vectors + hypsometric relief) into cleopatra as a matplotlib map-decoration layer — the `cartopy` `ax.coastlines()` / `GeoAxes.stock_img()` niche, and the vector/raster sibling of `cleopatra.tiles`. This closes the seam where web-tile basemaps already lived in cleopatra while the vector/raster reference data lived in pyramids.

New module `cleopatra.reference`:

- **`add_features(ax, layer, resolution, *, crs=None, **style)`** — draw a Natural Earth layer (`coastline`/`borders`/`land`/`ocean`/`rivers`/`lakes`) across `110m`/`50m`/`10m`. Polygon layers render as a filled `PolyCollection`, line layers as a `LineCollection`. Optional `pyproj` reprojection via `crs=`.
- **`add_relief(ax, resolution, *, extent=None)`** — draw a global hypsometric relief backdrop (`low`/`medium`).
- Raw accessors **`natural_earth()`** (→ `list[(N,2)]` lon/lat arrays) and **`relief()`** (→ `(H,W,3)` uint8 RGB).
- Discovery helpers `available_layers()` / `available_resolutions()` / `available_relief_resolutions()`.

## Design

- **No GDAL/geopandas, no pyramids dependency.** Layers are pre-converted offline to gzipped GeoJSON and read with stdlib `json`; relief is a PNG decoded with Pillow. `add_features` in EPSG:4326 needs only `numpy` + `matplotlib`; relief decode and reprojection use the existing `cleopatra[tiles]` extra (Pillow/pyproj), probed lazily so importing the module pulls in nothing extra.
- **Assets are fixed public data**, re-hosted on the cleopatra [`basemap-data-v1`](https://github.com/serapeum-org/cleopatra/releases/tag/basemap-data-v1) release (20 artifacts, ~6.7 MB) so cleopatra owns its own copy. Cached under `~/.cleopatra/naturalearth` (override `CLEOPATRA_CACHE_DIR`); downloads are `http(s)`-only with an atomic write.
- Both helpers preserve the axes' current limits.

## Tooling, docs, scope

- `tools/build_basemap_assets.py` — offline, maintainer-side builder that turns upstream Natural Earth shapefiles + relief GeoTIFFs into the runtime artifacts (heavy GIS deps imported inside the build functions only; not part of the package).
- `docs/reference/reference-data.md` — usage examples (global + regional + reprojection + raw accessors) and a **migration note** mapping `pyramids.basemap.natural_earth` / `relief` → `cleopatra.reference`. Added to the nav.
- `SCOPE.md` amended to record the `tiles` / `reference` basemap helpers as the deliberate, bounded networked exception (fixed public data, never user-file I/O).

## Testing

- New `tests/test_reference.py` (23 tests) — offline via a synthetic `CLEOPATRA_CACHE_DIR`; covers geometry flattening, both draw paths, reprojection, error cases, and the download guard.
- Module doctests pass (19); `tests/test_init.py` updated for the new submodule.
- Verified **live** end-to-end: fresh empty cache → fetch from the published release → render a world map (relief + coastline + borders).

## Acceptance criteria (#165)

- [x] `cleopatra.reference` exposes `add_features` / `add_relief` (+ raw accessors), 6 layers × 3 resolutions, `low`/`medium` relief
- [x] Download + cache works offline after first fetch; cache dir configurable; `http(s)`-only
- [x] cleopatra has no dependency on pyramids
- [x] Relief assets hosted on a cleopatra-owned release
- [x] Docs example demonstrating coastline/border/relief
- [x] Migration note from `pyramids.basemap.natural_earth` / `relief`

## Follow-ups (out of scope here)

- pyramids-side: turn `natural_earth` / `relief` into forwarding shims (or remove after the deprecation cycle) and drop the `basemap-data-v1` attachment now that cleopatra hosts its own.
