### PR TITLE
fix(animation): accept os.PathLike in save_animation

### DIFF
--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -44,7 +44,9 @@ def save_animation(
         fps: Frames per second. Default is 2.
 
     Returns:
-        The `path` that was written (convenient for chaining).
+        The output path as a `str` (the `os.fspath` of `path`),
+        convenient for chaining. Note a `pathlib.Path` argument comes
+        back as its string form, not the original object.
 
     Raises:
         ValueError: If the file format is not supported.

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -28,7 +28,9 @@ if TYPE_CHECKING:  # import only for type checkers; IPython stays optional
 SUPPORTED_VIDEO_FORMAT = ["gif", "mov", "avi", "mp4"]
 
 
-def save_animation(anim: FuncAnimation, path: str, fps: int = 2) -> str:
+def save_animation(
+    anim: FuncAnimation, path: str | os.PathLike, fps: int = 2
+) -> str:
     """Save any `FuncAnimation` to a file.
 
     The output format is determined by the file extension. GIF uses
@@ -36,7 +38,8 @@ def save_animation(anim: FuncAnimation, path: str, fps: int = 2) -> str:
 
     Args:
         anim: The animation to save.
-        path: Output file path. Extension determines format.
+        path: Output file path, as a `str` or `os.PathLike` (e.g. a
+            `pathlib.Path`). Extension determines format.
             Supported: gif, mov, avi, mp4.
         fps: Frames per second. Default is 2.
 
@@ -113,7 +116,10 @@ def save_animation(anim: FuncAnimation, path: str, fps: int = 2) -> str:
         to_gif: Render an animation to in-memory GIF bytes instead of a file.
         embed_gif: Wrap an animation as an ``IPython.display.Image``.
     """
-    video_format = path.rsplit(".", 1)[-1].lower()
+    # Accept str or os.PathLike (e.g. pathlib.Path): normalise to a string
+    # once so the extension parse and the writers both get a plain path.
+    path = os.fspath(path)
+    video_format = os.path.splitext(path)[1].lstrip(".").lower()
     if video_format not in SUPPORTED_VIDEO_FORMAT:
         raise ValueError(
             f"The given extension {video_format} implies a format that is "

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -120,6 +120,12 @@ def save_animation(
     # once so the extension parse and the writers both get a plain path.
     path = os.fspath(path)
     video_format = os.path.splitext(path)[1].lstrip(".").lower()
+    if not video_format:
+        raise ValueError(
+            f"The output path {path!r} has no file extension; the output "
+            f"format is taken from the extension, so use one of "
+            f"{SUPPORTED_VIDEO_FORMAT}."
+        )
     if video_format not in SUPPORTED_VIDEO_FORMAT:
         raise ValueError(
             f"The given extension {video_format} implies a format that is "

--- a/src/cleopatra/colors.py
+++ b/src/cleopatra/colors.py
@@ -151,7 +151,7 @@ class Colors:
         self._color_value = color_value
 
     @classmethod
-    def create_from_image(cls, path: str | os.PathLike) -> "Colors":
+    def create_from_image(cls, path: Union[str, os.PathLike]) -> "Colors":
         """Create a color object from an image.
 
         if you have an image of a color ramp, and you want to extract the colors from it, you can use this method.

--- a/src/cleopatra/colors.py
+++ b/src/cleopatra/colors.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from typing import Any, List, Tuple, Union
 
@@ -150,7 +151,7 @@ class Colors:
         self._color_value = color_value
 
     @classmethod
-    def create_from_image(cls, path: str) -> "Colors":
+    def create_from_image(cls, path: str | os.PathLike) -> "Colors":
         """Create a color object from an image.
 
         if you have an image of a color ramp, and you want to extract the colors from it, you can use this method.
@@ -158,7 +159,8 @@ class Colors:
         ![color-ramp](./../images/colors/color-ramp.png)
 
         Args:
-            path: The path to the image file.
+            path: The path to the image file, as a `str` or `os.PathLike`
+                (e.g. a `pathlib.Path`).
 
         Returns:
             Colors: A color object.
@@ -175,6 +177,7 @@ class Colors:
 
         ```
         """
+        path = os.fspath(path)
         if not Path(path).exists():
             raise FileNotFoundError(f"The file {path} does not exist.")
         try:

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import inspect
 import math
+import os
 import warnings
 
 import matplotlib.colors as colors
@@ -1084,7 +1085,7 @@ class Glyph:
         )
         return list(map(write_points, point_table))
 
-    def save_animation(self, path: str, fps: int = 2) -> None:
+    def save_animation(self, path: str | os.PathLike, fps: int = 2) -> None:
         """Save this glyph's animation (`self.anim`) to a file.
 
         Thin wrapper around `cleopatra.animation.save_animation`; the output
@@ -1092,7 +1093,8 @@ class Glyph:
         mov/avi/mp4 require FFmpeg to be installed.
 
         Args:
-            path: Output file path. Extension determines format.
+            path: Output file path, as a `str` or `os.PathLike` (e.g. a
+                `pathlib.Path`). Extension determines format.
                 Supported: gif, mov, avi, mp4.
             fps: Frames per second. Default is 2.
 

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -143,6 +143,20 @@ class TestSaveAnimation:
             save_animation(anim, "noext")
         anim.save.assert_not_called()
 
+    @pytest.mark.parametrize("path", [".gif", "dir/.gif", "gif", "mp4"])
+    def test_dotfile_or_bare_name_rejected(self, path):
+        """Dotfile-style / extension-less names have no real extension and raise.
+
+        Test scenario:
+            `os.path.splitext` treats a leading-dot basename (`.gif`) or a
+            dot-less name (`gif`) as having no extension, so these are rejected
+            rather than silently written — locking the intended behaviour.
+        """
+        anim = MagicMock(spec=FuncAnimation)
+        with pytest.raises(ValueError, match="no file extension"):
+            save_animation(anim, path)
+        anim.save.assert_not_called()
+
     def test_multi_dot_filename_uses_last_segment(self, monkeypatch):
         """Only the final dot-segment is treated as the extension.
 

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -71,6 +71,11 @@ class TestSaveAnimation:
         with pytest.raises(ValueError, match="not supported"):
             save_animation(tiny_anim, str(tmp_path / "out.webm"))
 
+    def test_unsupported_format_raises_with_path(self, tiny_anim, tmp_path):
+        """An unsupported extension raises even when the path is a `Path`."""
+        with pytest.raises(ValueError, match="not supported"):
+            save_animation(tiny_anim, tmp_path / "out.webm")
+
     def test_extension_is_case_insensitive(self, tiny_anim, tmp_path):
         """An upper/mixed-case extension is matched the same as lower-case."""
         path = tmp_path / "out.GIF"

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -131,15 +131,15 @@ class TestSaveAnimation:
         assert result == f"clip.{ext}", f"should return the path, got {result!r}"
 
     def test_no_extension_raises(self):
-        """A path with no extension is rejected as an unsupported format.
+        """A path with no extension is rejected with a clear message.
 
         Test scenario:
-            ``"noext"`` has no dot, so ``rsplit`` yields the whole string,
-            which is not a supported format and raises ``ValueError`` before
-            any save is attempted.
+            ``"noext"`` has no dot, so ``os.path.splitext`` yields an empty
+            extension, which raises ``ValueError`` naming the path before any
+            save is attempted.
         """
         anim = MagicMock(spec=FuncAnimation)
-        with pytest.raises(ValueError, match="not supported"):
+        with pytest.raises(ValueError, match="no file extension"):
             save_animation(anim, "noext")
         anim.save.assert_not_called()
 

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -53,6 +53,19 @@ class TestSaveAnimation:
         # GIF magic number — confirms a real GIF, not a stray file.
         assert path.read_bytes()[:6] in (b"GIF87a", b"GIF89a")
 
+    def test_accepts_pathlib_path(self, tiny_anim, tmp_path):
+        """A `pathlib.Path` output path is accepted, not just `str` (issue #180).
+
+        Regression: the format was derived with `str.rsplit`, so a `Path`
+        raised `AttributeError`. The path is now normalised via `os.fspath`.
+        """
+        path = tmp_path / "from_path.gif"
+        returned = save_animation(tiny_anim, path, fps=2)  # Path, not str
+
+        assert path.exists(), "GIF was not written from a pathlib.Path"
+        assert path.read_bytes()[:6] in (b"GIF87a", b"GIF89a")
+        assert returned == str(path), "should return the fspath string of the Path"
+
     def test_unsupported_format_raises(self, tiny_anim, tmp_path):
         """An unsupported extension raises a clear ValueError."""
         with pytest.raises(ValueError, match="not supported"):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -264,6 +264,21 @@ class TestAnimate:
         anim_obj = array.animate(animate_time_list, title="Flow Accumulation")
         assert isinstance(anim_obj, FuncAnimation)
 
+    def test_save_animation_accepts_pathlib_path(
+        self,
+        coello_data: np.ndarray,
+        animate_time_list: list,
+        no_data_value: float,
+        tmp_path,
+    ):
+        """`ArrayGlyph.save_animation` accepts a `pathlib.Path` directly (issue #180)."""
+        array = ArrayGlyph(coello_data, exclude_value=[no_data_value])
+        array.animate(animate_time_list, title="Flow Accumulation")
+        out = tmp_path / "flow.gif"  # Path, not str
+        array.save_animation(out, fps=2)
+        assert out.exists(), "GIF was not written from a pathlib.Path"
+        assert out.read_bytes()[:6] in (b"GIF87a", b"GIF89a")
+
     def test_save_animation_gif(
         self,
         coello_data: np.ndarray,

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -32,6 +32,11 @@ class TestCreateColors:
         assert isinstance(colors.color_value, list)
         assert len(colors.color_value) == 2713
 
+    def test_create_from_image_missing_pathlib_path_raises(self, tmp_path):
+        """A missing `pathlib.Path` raises `FileNotFoundError` (widened type, error branch)."""
+        with pytest.raises(FileNotFoundError):
+            Colors.create_from_image(tmp_path / "does-not-exist.png")
+
     def test_raise_error(self, color_ramp_image: str):
         with pytest.raises(ValueError):
             Colors(11)

--- a/tests/test_colors.py
+++ b/tests/test_colors.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from matplotlib.colors import LinearSegmentedColormap
 
@@ -23,6 +25,12 @@ class TestCreateColors:
         assert len(colors.color_value) == 2713
         with pytest.raises(FileNotFoundError):
             Colors.create_from_image("color_ramp_image")
+
+    def test_create_from_image_accepts_pathlib_path(self, color_ramp_image: str):
+        """`create_from_image` accepts a `pathlib.Path`, not just `str` (issue #180)."""
+        colors = Colors.create_from_image(Path(color_ramp_image))
+        assert isinstance(colors.color_value, list)
+        assert len(colors.color_value) == 2713
 
     def test_raise_error(self, color_ramp_image: str):
         with pytest.raises(ValueError):


### PR DESCRIPTION
# Description

Make cleopatra's path-taking public APIs uniformly accept `str` **or** `os.PathLike` (e.g. `pathlib.Path`) —
idiomatic when driven from pyramids, whose `Dataset`/`DatasetCollection` API accepts `Path` everywhere.

- **`save_animation`** (the actual bug, #180): the output format was derived with `str.rsplit(".", 1)`, so a
  `pathlib.Path` raised `AttributeError: 'WindowsPath' object has no attribute 'rsplit'`. Now normalised via
  `os.fspath` + `os.path.splitext`. Applies to `cleopatra.animation.save_animation` and `ArrayGlyph.save_animation`.
- **`Colors.create_from_image`** (consistency, folded in): already worked with a `Path` at runtime (uses
  `Path(path)` + `PIL.Image.open`), but its hint narrowly said `str`. Widened to `str | os.PathLike` and normalised
  via `os.fspath`.

These are the **only** two public path-taking APIs — everything else that touches files (`reference`, `tiles`) is
private and operates on cleopatra's own cached datasets or in-memory bytes, not user paths.

No dependencies added.

# Issues
- Fixes #180

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Run on the `Agg` backend via `uv run --active pytest`:

- [x] `test_accepts_pathlib_path` — saves a GIF from a `pathlib.Path`; asserts the file exists, has the GIF magic
      number, and the return value is the `fspath` string.
- [x] `test_create_from_image_accepts_pathlib_path` — builds `Colors` from a `pathlib.Path` image and asserts the
      same colour count as the `str` path.
- [x] No regressions:
  - `pytest tests/test_animation.py --doctest-modules src/cleopatra/animation.py src/cleopatra/glyph.py` → 39 passed
  - `pytest tests/test_colors.py --doctest-modules src/cleopatra/colors.py` → 25 passed
  - `pytest tests/test_glyph.py tests/test_array_glyph.py` → 391 passed, 3 skipped
  - Existing `multi-dot` / `no-extension` `save_animation` tests still pass (`os.path.splitext` matches the old
    last-segment / reject-no-extension behavior).

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
