### PR TITLE
fix(tiles): align web-tile basemap for non-EPSG:3857 data + auto_zoom floor

### DIFF
--- a/docs/reference/tiles.md
+++ b/docs/reference/tiles.md
@@ -53,11 +53,14 @@ fig.savefig("map.png")
 !!! note
     `add_tiles` reads the axes' current `xlim`/`ylim`, so plot your data first. When the
     data CRS is Web Mercator the tiles are placed in-place; for any other `crs=` the
-    bitmap is placed using the data's densified bounds and matplotlib stretches it — fine
-    for small extents, but for large areas or pixel-accurate results reproject the source
-    data to EPSG:3857 before plotting. The number of tiles fetched is capped by
-    `max_tiles` (default `MAX_TILES = 256`); the zoom is stepped down if a level would
-    need more.
+    mosaic's own Web-Mercator coverage is reprojected into the target CRS and used as the
+    image extent (the axis limits stay at the data bounds), so the basemap aligns with the
+    data even though the fetched tiles cover a tile-snapped area larger than it. A residual
+    Mercator-vs-linear nonlinearity remains for very large extents — for pixel-accurate
+    results reproject the source data to EPSG:3857 before plotting. The automatic zoom uses
+    a `min_tiles_across` floor (default 2) so a mid-range extent is not rendered from one or
+    two coarse tiles; the number of tiles is capped by `max_tiles` (default
+    `MAX_TILES = 256`), and the zoom is stepped down if a level would need more.
 
 ## Module Documentation
 

--- a/docs/reference/tiles.md
+++ b/docs/reference/tiles.md
@@ -57,7 +57,11 @@ fig.savefig("map.png")
     image extent (the axis limits stay at the data bounds), so the basemap aligns with the
     data even though the fetched tiles cover a tile-snapped area larger than it. A residual
     Mercator-vs-linear nonlinearity remains for very large extents — for pixel-accurate
-    results reproject the source data to EPSG:3857 before plotting. The automatic zoom uses
+    results reproject the source data to EPSG:3857 before plotting. If a coarse mosaic
+    overflows a limited-domain target CRS (e.g. a whole-world mosaic into a UTM zone), the
+    reprojection is skipped with a warning and the basemap falls back to the data bounds
+    (slightly misaligned); use a higher zoom or reproject the data to EPSG:3857 to avoid it.
+    The automatic zoom uses
     a `min_tiles_across` floor (default 2) so a mid-range extent is not rendered from one or
     two coarse tiles; the number of tiles is capped by `max_tiles` (default
     `MAX_TILES = 256`), and the zoom is stepped down if a level would need more.

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -11,13 +11,15 @@ no GDAL dependency, so the module is safe to use in environments that
 only have matplotlib + numpy installed.
 
 Notes:
-    For data in projected CRSes other than Web Mercator (EPSG:3857) the
-    stitched tile image is placed in the target CRS using the data's
-    densified bounds. Matplotlib stretches the image to fit, which is
-    visually acceptable for small extents (e.g. local maps in EPSG:4326)
-    but may show projection distortion over very large areas. If
-    pixel-accurate warping is required, reproject the source data to
-    Web Mercator (EPSG:3857) before plotting.
+    For data in CRSes other than Web Mercator (EPSG:3857) the stitched tile
+    image is placed at the mosaic's own coverage: its Web-Mercator bounds
+    are reprojected (with edge densification) into the target CRS and used
+    as the `imshow` extent, while the axis limits stay at the data bounds.
+    This aligns the basemap with the data even when the fetched tiles cover
+    a tile-snapped area larger than the data. A residual Mercator-vs-linear
+    nonlinearity remains for very large extents (the Mercator pixels are
+    placed on a linear axis); if pixel-accurate warping is required,
+    reproject the source data to Web Mercator (EPSG:3857) before plotting.
 
 Examples:
     Add a default OpenStreetMap basemap to an axes that already has
@@ -676,9 +678,10 @@ def add_tiles(
     them into a single composite image, and renders the image below the
     existing data layer. When the data is already in Web Mercator
     (EPSG:3857) the tiles are placed in-place; for any other CRS the
-    image is placed in the target CRS using the data's densified bounds
-    -- matplotlib stretches the bitmap to fit, which is visually
-    acceptable for small extents.
+    mosaic's own Web-Mercator coverage is reprojected into the target CRS
+    and used as the image extent (the axis limits stay at the data
+    bounds), so the basemap aligns with the data even though the fetched
+    tiles cover a tile-snapped area larger than it.
 
     Args:
         ax: Matplotlib `matplotlib.axes.Axes` to add the
@@ -851,10 +854,23 @@ def add_tiles(
     if is_3857:
         extent = extent_3857
     else:
-        # No GDAL: place the tile bitmap in the target CRS using the
-        # data's bounds. Matplotlib stretches the image -- accurate
-        # enough for small extents (see module docstring).
-        extent = (west, south, east, north)
+        # Place the mosaic at its OWN geographic coverage, not the data
+        # bounds. The stitched tiles span `extent_3857` (Web-Mercator
+        # metres, tile-snapped and generally larger than the data), so
+        # reproject those corners into the target CRS. Using the data
+        # bounds instead stretched the mosaic onto the smaller extent and
+        # offset the basemap by up to hundreds of km at coarse zooms (see
+        # issue #176). A residual Mercator-vs-linear-axis nonlinearity
+        # remains for large extents; reproject the data to EPSG:3857 before
+        # plotting for pixel-accurate tiles.
+        extent = _densify_and_reproject_bounds(
+            extent_3857[0],
+            extent_3857[1],
+            extent_3857[2],
+            extent_3857[3],
+            "EPSG:3857",
+            crs_str,
+        )
 
     xlim = ax.get_xlim()
     ylim = ax.get_ylim()

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -692,6 +692,7 @@ def add_tiles(
     retries: int = 2,
     user_agent: str | None = None,
     max_tiles: int = MAX_TILES,
+    min_tiles_across: int = 2,
 ) -> Any:
     """Overlay a web-tile basemap on a matplotlib axes.
 
@@ -736,6 +737,10 @@ def add_tiles(
             would need more than this, the zoom is stepped down until the
             count fits (or reaches 0). Defaults to `MAX_TILES`
             (`256`). Must be a positive int.
+        min_tiles_across: Floor for the automatic zoom, forwarded to
+            `auto_zoom` when `zoom="auto"` (ignored for an explicit `zoom=`).
+            Higher values give a sharper basemap at the cost of more tiles.
+            Defaults to 2. See `auto_zoom`.
 
     Returns:
         matplotlib.axes.Axes: The same axes, for chaining.
@@ -830,7 +835,7 @@ def add_tiles(
     bounds_4326 = (w4326, s4326, e4326, n4326)
 
     if zoom == "auto":
-        tile_zoom = auto_zoom(bounds_4326)
+        tile_zoom = auto_zoom(bounds_4326, min_tiles_across=min_tiles_across)
     else:
         try:
             tile_zoom = int(zoom)

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -775,6 +775,15 @@ def add_tiles(
     if not isinstance(max_tiles, int) or isinstance(max_tiles, bool) or max_tiles < 1:
         raise ValueError(f"max_tiles must be a positive int, got {max_tiles!r}.")
 
+    if (
+        not isinstance(min_tiles_across, int)
+        or isinstance(min_tiles_across, bool)
+        or min_tiles_across < 1
+    ):
+        raise ValueError(
+            f"min_tiles_across must be a positive int, got {min_tiles_across!r}."
+        )
+
     x0, x1 = ax.get_xlim()
     y0, y1 = ax.get_ylim()
     west, east = min(x0, x1), max(x0, x1)

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -908,6 +908,12 @@ def add_tiles(
                 crs_str,
             )
         except ValueError:
+            # `ValueError` is the complete failure surface here: `crs_str` was
+            # already validated by the forward transform above (a bad CRS would
+            # have raised there), and `_densify_and_reproject_bounds` reports an
+            # out-of-domain mosaic as `ValueError` (non-finite corners) rather
+            # than letting pyproj's `inf`/NaN through -- so no other exception
+            # type is expected from the reverse transform.
             # A coarse tile-snapped mosaic can be far larger than the data
             # and overflow a limited-domain target CRS (a UTM zone, national
             # grid, ...) when reprojected, yielding non-finite corners. Fall

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -162,12 +162,20 @@ def get_provider(name: str | None = None) -> Any:
     return provider
 
 
-def auto_zoom(bounds_4326: tuple[float, float, float, float]) -> int:
+def auto_zoom(
+    bounds_4326: tuple[float, float, float, float],
+    min_tiles_across: int = 4,
+) -> int:
     """Compute a default zoom level for the given bounds in EPSG:4326.
 
-    Uses the formula
-    `zoom = ceil(log2(360 / max(lon_extent, lat_extent)))` clamped to
-    the range 0--19.
+    Picks the smallest zoom at which the larger of the two extents spans at
+    least `min_tiles_across` tiles, i.e.
+    `zoom = ceil(log2(min_tiles_across * 360 / max(lon_extent, lat_extent)))`,
+    clamped to 0--19. The `min_tiles_across` floor (default 4) stops a
+    mid-range regional extent from collapsing onto one or two coarse tiles
+    stretched over the whole area (a 6--11 degree window would otherwise
+    fetch just 2 tiles); `min_tiles_across=1` reproduces the older
+    one-tile-across heuristic.
 
     This is a coarse heuristic that treats degrees of longitude and
     latitude as interchangeable; it does **not** account for Web
@@ -180,23 +188,34 @@ def auto_zoom(bounds_4326: tuple[float, float, float, float]) -> int:
 
     Args:
         bounds_4326: `(west, south, east, north)` in EPSG:4326 degrees.
+        min_tiles_across: Minimum number of tiles the larger extent should
+            span, `>= 1`. Higher values pick a sharper (higher) zoom.
+            Defaults to 4.
 
     Returns:
         int: Zoom level between 0 and 19.
 
     Examples:
-        - Worldwide extent maps to zoom 0:
+        - Worldwide extent maps to zoom 2 (four tiles across the globe):
             ```python
             >>> from cleopatra.tiles import auto_zoom
             >>> auto_zoom((-180, -85, 180, 85))
-            0
+            2
 
             ```
-        - A 0.6 by 0.2 degree window over Berlin yields zoom 10:
+        - A 0.6 by 0.2 degree window over Berlin yields zoom 12:
             ```python
             >>> from cleopatra.tiles import auto_zoom
             >>> auto_zoom((13.0, 52.4, 13.6, 52.6))
-            10
+            12
+
+            ```
+        - `min_tiles_across=1` restores the older, coarser one-tile
+            heuristic (worldwide -> zoom 0):
+            ```python
+            >>> from cleopatra.tiles import auto_zoom
+            >>> auto_zoom((-180, -85, 180, 85), min_tiles_across=1)
+            0
 
             ```
         - Tiny extents are clamped to the maximum zoom (19):
@@ -211,7 +230,8 @@ def auto_zoom(bounds_4326: tuple[float, float, float, float]) -> int:
     lon_extent = abs(east - west)
     lat_extent = abs(north - south)
     max_extent = max(lon_extent, lat_extent, 1e-10)
-    zoom = math.ceil(math.log2(360.0 / max_extent))
+    across = max(1, min_tiles_across)
+    zoom = math.ceil(math.log2(across * 360.0 / max_extent))
     result = max(0, min(zoom, 19))
     return result
 

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -884,14 +884,31 @@ def add_tiles(
         # issue #176). A residual Mercator-vs-linear-axis nonlinearity
         # remains for large extents; reproject the data to EPSG:3857 before
         # plotting for pixel-accurate tiles.
-        extent = _densify_and_reproject_bounds(
-            extent_3857[0],
-            extent_3857[1],
-            extent_3857[2],
-            extent_3857[3],
-            "EPSG:3857",
-            crs_str,
-        )
+        try:
+            extent = _densify_and_reproject_bounds(
+                extent_3857[0],
+                extent_3857[1],
+                extent_3857[2],
+                extent_3857[3],
+                "EPSG:3857",
+                crs_str,
+            )
+        except ValueError:
+            # A coarse tile-snapped mosaic can be far larger than the data
+            # and overflow a limited-domain target CRS (a UTM zone, national
+            # grid, ...) when reprojected, yielding non-finite corners. Fall
+            # back to the data bounds (the mosaic is then stretched onto them,
+            # slightly misaligned) so a figure is still produced rather than
+            # raising -- use a higher zoom or reproject the data to EPSG:3857
+            # for accurate placement.
+            logger.warning(
+                "Tile mosaic bounds could not be reprojected from EPSG:3857 "
+                "to %s (they overflow the target CRS domain); falling back to "
+                "the data bounds. Use a higher zoom or reproject the data to "
+                "EPSG:3857 for accurate tile placement.",
+                crs_str,
+            )
+            extent = (west, south, east, north)
 
     xlim = ax.get_xlim()
     ylim = ax.get_ylim()

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -164,15 +164,15 @@ def get_provider(name: str | None = None) -> Any:
 
 def auto_zoom(
     bounds_4326: tuple[float, float, float, float],
-    min_tiles_across: int = 4,
+    min_tiles_across: int = 2,
 ) -> int:
     """Compute a default zoom level for the given bounds in EPSG:4326.
 
     Picks the smallest zoom at which the larger of the two extents spans at
     least `min_tiles_across` tiles, i.e.
     `zoom = ceil(log2(min_tiles_across * 360 / max(lon_extent, lat_extent)))`,
-    clamped to 0--19. The `min_tiles_across` floor (default 4) stops a
-    mid-range regional extent from collapsing onto one or two coarse tiles
+    clamped to 0--19. The `min_tiles_across` floor (default 2) stops a
+    mid-range regional extent from collapsing onto a single coarse tile
     stretched over the whole area (a 6--11 degree window would otherwise
     fetch just 2 tiles); `min_tiles_across=1` reproduces the older
     one-tile-across heuristic.
@@ -189,25 +189,26 @@ def auto_zoom(
     Args:
         bounds_4326: `(west, south, east, north)` in EPSG:4326 degrees.
         min_tiles_across: Minimum number of tiles the larger extent should
-            span, `>= 1`. Higher values pick a sharper (higher) zoom.
-            Defaults to 4.
+            span; higher values pick a sharper (higher) zoom. Values below 1
+            are clamped to 1 (the older one-tile-across heuristic). Defaults
+            to 2.
 
     Returns:
         int: Zoom level between 0 and 19.
 
     Examples:
-        - Worldwide extent maps to zoom 2 (four tiles across the globe):
+        - Worldwide extent maps to zoom 1 (two tiles across the globe):
             ```python
             >>> from cleopatra.tiles import auto_zoom
             >>> auto_zoom((-180, -85, 180, 85))
-            2
+            1
 
             ```
-        - A 0.6 by 0.2 degree window over Berlin yields zoom 12:
+        - A 0.6 by 0.2 degree window over Berlin yields zoom 11:
             ```python
             >>> from cleopatra.tiles import auto_zoom
             >>> auto_zoom((13.0, 52.4, 13.6, 52.6))
-            12
+            11
 
             ```
         - `min_tiles_across=1` restores the older, coarser one-tile

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -258,6 +258,24 @@ class TestAddTilesBehaviour:
         add_tiles(mock_ax, crs=4326)
         mock_ax.imshow.assert_called_once()
 
+    def test_nonmercator_imshow_uses_mosaic_reprojected_bounds(
+        self, mock_ax, _patch_tiles
+    ):
+        """For a lon/lat axis the imshow extent is the mosaic's reprojected 3857
+        coverage, not the raw data bounds (issue #176)."""
+        mock_ax.get_xlim.return_value = (10.0, 11.0)
+        mock_ax.get_ylim.return_value = (50.0, 51.0)
+        add_tiles(mock_ax, crs=4326)
+        # The mocked stitch_tiles reports the mosaic covering these 3857 metres:
+        w, s, e, n = _densify_and_reproject_bounds(
+            1000000.0, 6000000.0, 1200000.0, 6200000.0, "EPSG:3857", "EPSG:4326"
+        )
+        got = mock_ax.imshow.call_args.kwargs["extent"]
+        assert got == pytest.approx([w, e, s, n]), (
+            f"imshow extent should be the mosaic's reprojected bounds, got {got}"
+        )
+        assert got != [10.0, 11.0, 50.0, 51.0], "extent must not be the raw data bounds"
+
     def test_axes_limits_are_restored(self, mock_ax, _patch_tiles):
         """`set_xlim` / `set_ylim` are called with the original limits."""
         add_tiles(mock_ax, crs=3857)

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -281,12 +281,11 @@ class TestAddTilesBehaviour:
         mock_ax.get_xlim.return_value = (10.0, 11.0)
         mock_ax.get_ylim.return_value = (50.0, 51.0)
         add_tiles(mock_ax, crs=4326)
-        # The mocked stitch_tiles reports the mosaic covering these 3857 metres:
-        w, s, e, n = _densify_and_reproject_bounds(
-            1000000.0, 6000000.0, 1200000.0, 6200000.0, "EPSG:3857", "EPSG:4326"
-        )
+        # Independent expected value: the mocked mosaic 3857 bounds
+        # (1e6, 6e6, 1.2e6, 6.2e6) reproject to these EPSG:4326 [w, e, s, n]
+        # degrees (precomputed, not re-derived from the production helper).
         got = mock_ax.imshow.call_args.kwargs["extent"]
-        assert got == pytest.approx([w, e, s, n]), (
+        assert got == pytest.approx([8.9832, 10.7798, 47.3537, 48.5569], abs=1e-4), (
             f"imshow extent should be the mosaic's reprojected bounds, got {got}"
         )
         assert got != [10.0, 11.0, 50.0, 51.0], "extent must not be the raw data bounds"

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -93,17 +93,32 @@ class TestGetProvider:
 class TestAutoZoom:
     """Tests for `cleopatra.tiles.auto_zoom`."""
 
-    def test_global_extent_is_zoom_0(self):
-        """A global extent collapses to zoom 0."""
-        assert auto_zoom((-180.0, -85.0, 180.0, 85.0)) == 0
+    def test_global_extent_is_zoom_2(self):
+        """A global extent spans four tiles across at the default floor."""
+        assert auto_zoom((-180.0, -85.0, 180.0, 85.0)) == 2
 
-    def test_city_extent_yields_zoom_10(self):
-        """A ~0.6-degree city extent yields zoom 10."""
-        assert auto_zoom((13.0, 52.4, 13.6, 52.6)) == 10
+    def test_city_extent_yields_zoom_12(self):
+        """A ~0.6-degree city extent yields zoom 12 at the default floor."""
+        assert auto_zoom((13.0, 52.4, 13.6, 52.6)) == 12
 
     def test_tiny_extent_clamps_to_19(self):
         """An infinitesimal extent clamps to the max zoom 19."""
         assert auto_zoom((0.0, 0.0, 1e-8, 1e-8)) == 19
+
+    def test_min_tiles_across_one_restores_coarse_heuristic(self):
+        """`min_tiles_across=1` reproduces the older one-tile-across zoom."""
+        assert auto_zoom((-180.0, -85.0, 180.0, 85.0), min_tiles_across=1) == 0
+        assert auto_zoom((13.0, 52.4, 13.6, 52.6), min_tiles_across=1) == 10
+
+    def test_regional_extent_does_not_collapse_to_two_tiles(self):
+        """A 6-11 degree extent (issue #176 Gulf) zooms past the coarse z6."""
+        gulf = (-94.314, 27.439, -87.735, 30.867)
+        assert auto_zoom(gulf) == 8  # default floor -> sharper basemap
+        assert auto_zoom(gulf, min_tiles_across=1) == 6  # old coarse value
+
+    def test_non_positive_min_tiles_across_is_treated_as_one(self):
+        """`min_tiles_across` below 1 is clamped to the one-tile heuristic."""
+        assert auto_zoom((-180.0, -85.0, 180.0, 85.0), min_tiles_across=0) == 0
 
 
 class TestDensifyAndReprojectBounds:

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -93,13 +93,13 @@ class TestGetProvider:
 class TestAutoZoom:
     """Tests for `cleopatra.tiles.auto_zoom`."""
 
-    def test_global_extent_is_zoom_2(self):
-        """A global extent spans four tiles across at the default floor."""
-        assert auto_zoom((-180.0, -85.0, 180.0, 85.0)) == 2
+    def test_global_extent_is_zoom_1(self):
+        """A global extent spans two tiles across at the default floor."""
+        assert auto_zoom((-180.0, -85.0, 180.0, 85.0)) == 1
 
-    def test_city_extent_yields_zoom_12(self):
-        """A ~0.6-degree city extent yields zoom 12 at the default floor."""
-        assert auto_zoom((13.0, 52.4, 13.6, 52.6)) == 12
+    def test_city_extent_yields_zoom_11(self):
+        """A ~0.6-degree city extent yields zoom 11 at the default floor."""
+        assert auto_zoom((13.0, 52.4, 13.6, 52.6)) == 11
 
     def test_tiny_extent_clamps_to_19(self):
         """An infinitesimal extent clamps to the max zoom 19."""
@@ -113,7 +113,7 @@ class TestAutoZoom:
     def test_regional_extent_does_not_collapse_to_two_tiles(self):
         """A 6-11 degree extent (issue #176 Gulf) zooms past the coarse z6."""
         gulf = (-94.314, 27.439, -87.735, 30.867)
-        assert auto_zoom(gulf) == 8  # default floor -> sharper basemap
+        assert auto_zoom(gulf) == 7  # default floor (2) -> sharper basemap
         assert auto_zoom(gulf, min_tiles_across=1) == 6  # old coarse value
 
     def test_non_positive_min_tiles_across_is_treated_as_one(self):

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -319,6 +319,19 @@ class TestAddTilesBehaviour:
             f"overflow should fall back to the data bounds, got {got}"
         )
 
+    def test_min_tiles_across_forwarded_to_auto_zoom(self, mock_ax, _patch_tiles):
+        """`add_tiles(min_tiles_across=...)` is forwarded to `auto_zoom` for zoom='auto'."""
+        mock_zoom, _fetch, _stitch = _patch_tiles
+        add_tiles(mock_ax, crs=3857, min_tiles_across=6)
+        mock_zoom.assert_called_once()
+        assert mock_zoom.call_args.kwargs.get("min_tiles_across") == 6
+
+    def test_explicit_zoom_ignores_min_tiles_across(self, mock_ax, _patch_tiles):
+        """An explicit `zoom=` bypasses `auto_zoom` (and thus `min_tiles_across`)."""
+        mock_zoom, _fetch, _stitch = _patch_tiles
+        add_tiles(mock_ax, crs=3857, zoom=5, min_tiles_across=6)
+        mock_zoom.assert_not_called()
+
     def test_axes_limits_are_restored(self, mock_ax, _patch_tiles):
         """`set_xlim` / `set_ylim` are called with the original limits."""
         add_tiles(mock_ax, crs=3857)

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -319,6 +319,30 @@ class TestAddTilesBehaviour:
             f"overflow should fall back to the data bounds, got {got}"
         )
 
+    def test_nonmercator_mosaic_extent_envelops_data(self, mock_ax):
+        """A mosaic larger than the data is placed enveloping the data bounds (issue #176)."""
+        pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+        mock_ax.get_xlim.return_value = (10.0, 11.0)  # lon/lat data extent
+        mock_ax.get_ylim.return_value = (50.0, 51.0)
+        # A mosaic whose Web-Mercator coverage is wider than the data's:
+        mosaic_3857 = (1.0e6, 6.3e6, 1.35e6, 6.75e6)
+        with (
+            patch.object(tiles_mod, "auto_zoom", return_value=6),
+            patch.object(
+                tiles_mod, "fetch_tiles", return_value={Tile(0, 0, 6): _make_tile_png()}
+            ),
+            patch.object(
+                tiles_mod,
+                "stitch_tiles",
+                return_value=(np.zeros((256, 256, 4), dtype=np.uint8), mosaic_3857),
+            ),
+        ):
+            add_tiles(mock_ax, crs=4326)
+        west, east, south, north = mock_ax.imshow.call_args.kwargs["extent"]
+        assert west <= 10.0 and east >= 11.0 and south <= 50.0 and north >= 51.0, (
+            f"mosaic extent {(west, east, south, north)} should envelop the data bounds"
+        )
+
     def test_min_tiles_across_forwarded_to_auto_zoom(self, mock_ax, _patch_tiles):
         """`add_tiles(min_tiles_across=...)` is forwarded to `auto_zoom` for zoom='auto'."""
         mock_zoom, _fetch, _stitch = _patch_tiles

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -515,6 +515,16 @@ class TestAddTilesIntegration:
         with pytest.raises(ValueError, match="max_tiles must be a positive int"):
             add_tiles(mock_ax, crs=3857, max_tiles=bad)
 
+    @pytest.mark.parametrize("bad", [0, -1, 2.5, True, "8", None])
+    def test_invalid_min_tiles_across_raises(self, mock_ax, bad):
+        """`min_tiles_across` must be a positive int, rejected at the boundary.
+
+        Args:
+            bad: A value that should be rejected.
+        """
+        with pytest.raises(ValueError, match="min_tiles_across must be a positive int"):
+            add_tiles(mock_ax, crs=3857, min_tiles_across=bad)
+
 
 class TestRequireTilesExtra:
     """Tests for `cleopatra.tiles._require_tiles_extra` guard."""

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -292,11 +292,12 @@ class TestAddTilesBehaviour:
         assert got != [10.0, 11.0, 50.0, 51.0], "extent must not be the raw data bounds"
 
     def test_nonmercator_falls_back_to_data_bounds_when_mosaic_overflows(self, mock_ax):
-        """A mosaic overflowing a limited-domain CRS falls back to the data bounds,
+        """A mosaic overflowing a singular projection falls back to the data bounds,
         rendering instead of raising (issue #176 regression guard)."""
         pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
-        mock_ax.get_xlim.return_value = (400000.0, 500000.0)  # UTM 33N metres
-        mock_ax.get_ylim.return_value = (5600000.0, 5700000.0)
+        ortho = "+proj=ortho +lat_0=0 +lon_0=0"  # undefined on the far hemisphere
+        mock_ax.get_xlim.return_value = (0.0, 100000.0)  # ortho metres near centre
+        mock_ax.get_ylim.return_value = (0.0, 100000.0)
         world = 20037508.342789244  # half the Web Mercator world extent (metres)
         with (
             patch.object(tiles_mod, "auto_zoom", return_value=0),
@@ -312,10 +313,10 @@ class TestAddTilesBehaviour:
                 ),
             ),
         ):
-            add_tiles(mock_ax, crs=32633)  # UTM zone 33N: limited domain
+            add_tiles(mock_ax, crs=ortho)
         mock_ax.imshow.assert_called_once()
         got = mock_ax.imshow.call_args.kwargs["extent"]
-        assert got == [400000.0, 500000.0, 5600000.0, 5700000.0], (
+        assert got == [0.0, 100000.0, 0.0, 100000.0], (
             f"overflow should fall back to the data bounds, got {got}"
         )
 

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -291,6 +291,34 @@ class TestAddTilesBehaviour:
         )
         assert got != [10.0, 11.0, 50.0, 51.0], "extent must not be the raw data bounds"
 
+    def test_nonmercator_falls_back_to_data_bounds_when_mosaic_overflows(self, mock_ax):
+        """A mosaic overflowing a limited-domain CRS falls back to the data bounds,
+        rendering instead of raising (issue #176 regression guard)."""
+        pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+        mock_ax.get_xlim.return_value = (400000.0, 500000.0)  # UTM 33N metres
+        mock_ax.get_ylim.return_value = (5600000.0, 5700000.0)
+        world = 20037508.342789244  # half the Web Mercator world extent (metres)
+        with (
+            patch.object(tiles_mod, "auto_zoom", return_value=0),
+            patch.object(
+                tiles_mod, "fetch_tiles", return_value={Tile(0, 0, 0): _make_tile_png()}
+            ),
+            patch.object(
+                tiles_mod,
+                "stitch_tiles",
+                return_value=(
+                    np.zeros((256, 256, 4), dtype=np.uint8),
+                    (-world, -world, world, world),  # whole-world mosaic
+                ),
+            ),
+        ):
+            add_tiles(mock_ax, crs=32633)  # UTM zone 33N: limited domain
+        mock_ax.imshow.assert_called_once()
+        got = mock_ax.imshow.call_args.kwargs["extent"]
+        assert got == [400000.0, 500000.0, 5600000.0, 5700000.0], (
+            f"overflow should fall back to the data bounds, got {got}"
+        )
+
     def test_axes_limits_are_restored(self, mock_ax, _patch_tiles):
         """`set_xlim` / `set_ylim` are called with the original limits."""
         add_tiles(mock_ax, crs=3857)


### PR DESCRIPTION
# Description

Fixes the web-tile basemap misalignment for non-EPSG:3857 (lon/lat) data, plus a resolution follow-up and the
review-round hardening.

- **Alignment fix.** For a non-3857 axis, `add_tiles` stretched the stitched Mercator mosaic onto the *data* bounds,
  discarding the mosaic's actual (tile-snapped, larger) coverage — offsetting the basemap by up to hundreds of km at
  coarse zoom (e.g. a curvilinear ROMS field over the Gulf of Mexico). Now the mosaic is placed at its **own**
  geographic footprint: its Web-Mercator bounds (`extent_3857`) are reprojected into the target CRS (edge-densified)
  and used as the `imshow` extent, while `set_xlim/ylim` stay at the data bounds. If a coarse mosaic overflows a
  limited-domain target CRS (e.g. a whole-world mosaic into a UTM zone / a singular projection), the reprojection is
  caught and the basemap falls back to the data bounds with a warning, so a figure is still produced.
- **Auto-zoom floor.** `auto_zoom` targeted ~1 tile across the extent, so a 6–11° region collapsed onto 2 coarse
  tiles. New `min_tiles_across` parameter (**default 2**, also exposed on `add_tiles`): pick the smallest zoom at
  which the larger extent spans at least that many tiles. Global `z0→z1`, Berlin `z10→z11`, Gulf `z6→z7`.
  `min_tiles_across=1` restores the old heuristic; `MAX_TILES` still steps the zoom down if a level needs too many
  tiles.

**Behaviour-change note:** the auto-zoom floor applies to **every** `zoom="auto"` call (all CRS, including EPSG:3857),
so the default basemap fetches a slightly higher zoom → a few more tiles from public tile servers (bounded by
`MAX_TILES=256`; a coarse 1–2 tile mosaic is equally undesirable in 3857). Residual: a Mercator-vs-linear-axis
nonlinearity remains for very large extents (documented) — reproject the data to EPSG:3857 for pixel-accurate tiles.
A full raster warp would need GDAL, against this module's no-GDAL design. No new dependencies.

# Issues
- Closes #176 — web-tile basemap misaligned for non-EPSG:3857 (lon/lat) data

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

- Alignment: regression test asserting the `imshow` extent equals the mosaic's reprojected bounds (independent
  precomputed value) and is **not** the raw data bounds; an "envelope" test asserting a mosaic larger than the data
  is placed enveloping the data bounds; an overflow test (`+proj=ortho`) asserting the data-bounds fallback renders
  instead of raising.
- `auto_zoom`: default-floor values (global→z1, Berlin→z11), `min_tiles_across=1` restores the old zoom, the Gulf
  regional extent goes z6→z7, clamping of `< 1`, and boundary validation (`min_tiles_across` rejected like
  `max_tiles`); forwarding from `add_tiles` (and explicit-`zoom=` bypass).
- Verified numerically against the issue's Gulf case: the reprojected mosaic bounds
  (`W -95.625 E -84.375 S 27.059 N 31.952`) match the issue's stated true coverage, vs the old (wrong) data-bounds
  placement.
- `tiles.py` doctests pass; `tiles.py` at 99% line+branch (the one miss is a pre-existing attribution branch).
- Full non-e2e suite (run against the worktree's own `src`): **1118 passed**.
- Two review rounds (`/review-rounds`) completed; all findings resolved (see
  `planning/basemap/pr-diff-review-fix-tiles-nonmercator-basemap-alignment-2026-06-26*.md`).

- [x] Test A — alignment (reprojected mosaic extent, envelope, overflow fallback)
- [x] Test B — `auto_zoom` floor, tunable/validated `min_tiles_across`, forwarding

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
