### PR TITLE
feat(animation): add save_animation quality controls, WebP, and bundled ffmpeg

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -97,8 +97,12 @@ colorbars, ticks, classification, and animation.
   forecasting, hypothesis tests — Cleopatra *displays* results, it doesn't
   compute models. (KDE is the deliberate, self-contained exception.)
 - **Heavy new hard dependencies:** keep the core to `numpy` + `matplotlib`
-  (plus `ffmpeg-python`, `hpc-utils`). Anything bigger must be an optional
-  extra like `tiles`, and only with strong justification.
+  (plus `imageio-ffmpeg`, `hpc-utils`). Anything bigger must be an optional
+  extra like `tiles`, and only with strong justification. `imageio-ffmpeg` is
+  the deliberate exception: it replaces the pure-Python-but-unused
+  `ffmpeg-python` and bundles a static FFmpeg binary so `save_animation` can
+  export MP4/MOV/AVI out of the box (issue #185), which pure-Python packaging
+  cannot provide.
 - **3D rendering** (mplot3d surfaces/volumes), networked data sources other
   than the `tiles` / `reference` basemap helpers, and general-purpose plotting
   that matplotlib already does well without added value.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,12 +7,15 @@
 - Python (3.11 or later)
 - [numpy](https://www.numpy.org/) (2.0.0 or later)
 - [matplotlib](https://matplotlib.org/) (3.9 or later)
-- [ffmpeg-python](https://github.com/kkroening/ffmpeg-python/) — for animation export to MP4 / MOV / AVI
+- [imageio-ffmpeg](https://github.com/imageio/imageio-ffmpeg) — ships a static FFmpeg binary used for animation
+  export to MP4 / MOV / AVI
 - [hpc-utils](https://github.com/serapeum-org/hpc) (0.1.4 or later)
 
 !!! note
-    Writing animations to `mp4` / `mov` / `avi` also needs an **FFmpeg** binary on
-    your `PATH`. GIF export uses matplotlib's `PillowWriter` and needs no FFmpeg.
+    Writing animations to `mp4` / `mov` / `avi` needs an **FFmpeg** binary.
+    `imageio-ffmpeg` bundles one, so export works out of the box; a system FFmpeg
+    on your `PATH` is used in preference when present. GIF and WebP export use
+    Pillow and need no FFmpeg.
 
 ### Optional dependencies — the `tiles` extra
 

--- a/docs/notebooks/animation/animation_examples.ipynb
+++ b/docs/notebooks/animation/animation_examples.ipynb
@@ -1,0 +1,615 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d9865e16",
+   "metadata": {},
+   "source": [
+    "# Saving and embedding animations with `save_animation`\n",
+    "\n",
+    "Cleopatra turns any in-memory NumPy time-series into a matplotlib animation, and the helpers in\n",
+    "[`cleopatra.animation`](../../reference/animation.md) write or embed that animation with real control over\n",
+    "**format, quality, and size**.\n",
+    "\n",
+    "This notebook teaches the animation-export surface refreshed in issue #185. By the end you can:\n",
+    "\n",
+    "- save an animation to GIF, MP4, MOV, AVI, or **animated WebP** from a single call;\n",
+    "- trade file size against quality with `crf` / `bitrate` / `preset`;\n",
+    "- rely on **odd figure dimensions** and universal playback working automatically;\n",
+    "- export MP4 with **no manual ffmpeg install**; and\n",
+    "- render an animation straight to **bytes** or an **inline image** with `to_gif` / `to_mp4` /\n",
+    "  `to_bytes` / `embed_gif`.\n",
+    "\n",
+    "Everything runs on small synthetic arrays generated in the notebook — no data files needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d94b583c",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "Import the pieces we need and define a couple of tiny helpers. `save_animation` and the `to_*` helpers all\n",
+    "live in `cleopatra.animation`; `ArrayGlyph` builds the animation from an array stack."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51502b85",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:40.631753Z",
+     "iopub.status.busy": "2026-07-07T23:34:40.631753Z",
+     "iopub.status.idle": "2026-07-07T23:34:41.080453Z",
+     "shell.execute_reply": "2026-07-07T23:34:41.080453Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import base64\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.animation import FuncAnimation\n",
+    "from IPython.display import HTML, Image\n",
+    "\n",
+    "from cleopatra.array_glyph import ArrayGlyph\n",
+    "from cleopatra.animation import (\n",
+    "    SUPPORTED_VIDEO_FORMAT,\n",
+    "    save_animation,\n",
+    "    to_gif,\n",
+    "    to_mp4,\n",
+    "    to_bytes,\n",
+    "    embed_gif,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "061b1749",
+   "metadata": {},
+   "source": [
+    "A scratch directory for the files we write, and a helper to show an animated **WebP** inline (browsers render\n",
+    "it, but `IPython.display.Image` does not sniff the WebP format, so we embed it as a data URI)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7bd4ca2c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:41.082965Z",
+     "iopub.status.busy": "2026-07-07T23:34:41.082965Z",
+     "iopub.status.idle": "2026-07-07T23:34:41.087153Z",
+     "shell.execute_reply": "2026-07-07T23:34:41.087153Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "out_dir = Path(tempfile.mkdtemp(prefix='cleopatra_anim_'))\n",
+    "\n",
+    "def show_webp(path):\n",
+    "    \"\"\"Embed an animated .webp inline as a data URI.\"\"\"\n",
+    "    encoded = base64.b64encode(Path(path).read_bytes()).decode()\n",
+    "    return HTML(f'<img src=\"data:image/webp;base64,{encoded}\" alt=\"animated webp\">')\n",
+    "\n",
+    "def kib(path):\n",
+    "    \"\"\"File size in kibibytes, rounded for display.\"\"\"\n",
+    "    return round(Path(path).stat().st_size / 1024, 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61d700ae",
+   "metadata": {},
+   "source": [
+    "### A synthetic time-lapse\n",
+    "\n",
+    "We animate a Gaussian blob drifting across a 60&times;60 grid over 12 frames — a stand-in for any scalar field\n",
+    "that evolves in time (rainfall, flow accumulation, temperature). `ArrayGlyph` accepts a `(time, rows, cols)`\n",
+    "stack directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca934dcd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:41.090160Z",
+     "iopub.status.busy": "2026-07-07T23:34:41.089158Z",
+     "iopub.status.idle": "2026-07-07T23:34:41.098758Z",
+     "shell.execute_reply": "2026-07-07T23:34:41.098758Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "n_frames, height, width = 12, 60, 60\n",
+    "rows, cols = np.mgrid[0:height, 0:width]\n",
+    "\n",
+    "blob_stack = np.zeros((n_frames, height, width))\n",
+    "for t in range(n_frames):\n",
+    "    cx = width * (t + 1) / (n_frames + 1)\n",
+    "    cy = height * (t + 1) / (n_frames + 1)\n",
+    "    blob_stack[t] = np.exp(-((cols - cx) ** 2 + (rows - cy) ** 2) / (2 * (height / 6) ** 2))\n",
+    "\n",
+    "frame_labels = [f't{t}' for t in range(n_frames)]\n",
+    "blob_stack.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae3359f5",
+   "metadata": {},
+   "source": [
+    "## Quickstart — animate, then save\n",
+    "\n",
+    "Build the animation with `ArrayGlyph.animate`, preview it inline, then write it to a GIF with the simplest\n",
+    "possible `save_animation(anim, path)` call. `save_animation` returns the path it wrote, so it chains nicely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edc50132",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:41.100762Z",
+     "iopub.status.busy": "2026-07-07T23:34:41.100762Z",
+     "iopub.status.idle": "2026-07-07T23:34:41.887056Z",
+     "shell.execute_reply": "2026-07-07T23:34:41.887056Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "glyph = ArrayGlyph(blob_stack, figsize=(4, 4), title='Drifting blob')\n",
+    "anim = glyph.animate(frame_labels, interval=150)\n",
+    "HTML(anim.to_jshtml())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "721d2cd9",
+   "metadata": {},
+   "source": [
+    "The interactive player above shows exactly what will be saved. Now write it to disk as a GIF:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df73ae5e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:41.890061Z",
+     "iopub.status.busy": "2026-07-07T23:34:41.889061Z",
+     "iopub.status.idle": "2026-07-07T23:34:42.687029Z",
+     "shell.execute_reply": "2026-07-07T23:34:42.687029Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "gif_path = save_animation(anim, str(out_dir / 'blob.gif'), fps=6)\n",
+    "print('wrote', gif_path, '->', kib(gif_path), 'KiB')\n",
+    "Image(gif_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdc0b2c0",
+   "metadata": {},
+   "source": [
+    "## Supported formats\n",
+    "\n",
+    "The output format comes from the file extension. GIF and WebP are written by Pillow (no external tools);\n",
+    "MP4/MOV/AVI use ffmpeg.\n",
+    "\n",
+    "| extension | writer | needs ffmpeg | notes |\n",
+    "| --- | --- | --- | --- |\n",
+    "| `gif` | Pillow | no | universal, but large for photographic frames |\n",
+    "| `webp` | Pillow | no | animated; ~3-5&times; smaller than GIF |\n",
+    "| `mp4` | ffmpeg | yes (bundled) | H.264, best for sharing |\n",
+    "| `mov` / `avi` | ffmpeg | yes (bundled) | other containers |"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "216317a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:42.690066Z",
+     "iopub.status.busy": "2026-07-07T23:34:42.690066Z",
+     "iopub.status.idle": "2026-07-07T23:34:42.694053Z",
+     "shell.execute_reply": "2026-07-07T23:34:42.694053Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "sorted(SUPPORTED_VIDEO_FORMAT)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d50a7486",
+   "metadata": {},
+   "source": [
+    "## Out-of-the-box MP4\n",
+    "\n",
+    "MP4 export uses ffmpeg. Cleopatra resolves the binary automatically — a system ffmpeg if one is on your\n",
+    "`PATH`, otherwise the static binary bundled with `imageio-ffmpeg` — so this call needs **no manual ffmpeg**\n",
+    "**install**. The frame is auto-padded to even dimensions and encoded `yuv420p` for universal playback."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e6254df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:42.696057Z",
+     "iopub.status.busy": "2026-07-07T23:34:42.696057Z",
+     "iopub.status.idle": "2026-07-07T23:34:43.354723Z",
+     "shell.execute_reply": "2026-07-07T23:34:43.354723Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "mp4_path = save_animation(anim, str(out_dir / 'blob.mp4'), fps=6)\n",
+    "print('wrote', Path(mp4_path).name, '->', kib(mp4_path), 'KiB')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "751c7c60",
+   "metadata": {},
+   "source": [
+    "## Quality vs size — `crf`, `bitrate`, `preset`\n",
+    "\n",
+    "The most useful new knobs. **CRF** (Constant Rate Factor) is the constant-quality control: lower = higher\n",
+    "quality and larger files, higher = smaller. It is usually the best single dial for \"smallest file that still\n",
+    "looks right\".\n",
+    "\n",
+    "| argument | meaning | typical value |\n",
+    "| --- | --- | --- |\n",
+    "| `crf` | constant-quality factor (x264) | 18-28 (23 default) |\n",
+    "| `bitrate` | target kbit/s (mutually exclusive with `crf`) | 1500-8000 |\n",
+    "| `preset` | encoder speed/size trade-off | `veryfast` &hellip; `slow` |\n",
+    "\n",
+    "Let's encode the same clip three ways and compare the resulting file sizes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea2cb9ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:43.357729Z",
+     "iopub.status.busy": "2026-07-07T23:34:43.356728Z",
+     "iopub.status.idle": "2026-07-07T23:34:45.376016Z",
+     "shell.execute_reply": "2026-07-07T23:34:45.376016Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "variants = {\n",
+    "    'default': {},\n",
+    "    'crf=28': {'crf': 28},\n",
+    "    'crf=36': {'crf': 36},\n",
+    "}\n",
+    "sizes_kib = {}\n",
+    "for name, kwargs in variants.items():\n",
+    "    p = save_animation(anim, str(out_dir / f'blob_{name}.mp4'), fps=6, **kwargs)\n",
+    "    sizes_kib[name] = kib(p)\n",
+    "sizes_kib"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acbf1c20",
+   "metadata": {},
+   "source": [
+    "A higher CRF visibly shrinks the file. Plotting it makes the trade-off obvious:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2971acff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:45.378026Z",
+     "iopub.status.busy": "2026-07-07T23:34:45.378026Z",
+     "iopub.status.idle": "2026-07-07T23:34:45.390045Z",
+     "shell.execute_reply": "2026-07-07T23:34:45.390045Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(5, 3))\n",
+    "ax.bar(list(sizes_kib), list(sizes_kib.values()), color='#4C72B0')\n",
+    "ax.set_ylabel('file size (KiB)')\n",
+    "ax.set_title('MP4 size by rate control')\n",
+    "for i, v in enumerate(sizes_kib.values()):\n",
+    "    ax.text(i, v, f'{v}', ha='center', va='bottom')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6928dbd1",
+   "metadata": {},
+   "source": [
+    "Passing both `crf` and `bitrate` is rejected, because they are competing rate-control modes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c77b8991",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:45.392051Z",
+     "iopub.status.busy": "2026-07-07T23:34:45.392051Z",
+     "iopub.status.idle": "2026-07-07T23:34:45.395714Z",
+     "shell.execute_reply": "2026-07-07T23:34:45.395714Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    save_animation(anim, str(out_dir / 'bad.mp4'), fps=6, crf=20, bitrate=4000)\n",
+    "except ValueError as err:\n",
+    "    print('ValueError:', err)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89f54e87",
+   "metadata": {},
+   "source": [
+    "## Odd dimensions just work\n",
+    "\n",
+    "H.264 requires even width and height, so a figure whose pixel size is odd used to crash the encoder. Cleopatra\n",
+    "now pads the frame up to the next even size automatically. Here is a deliberately odd 335&times;255 figure\n",
+    "animated straight through the ffmpeg path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef27f65a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:45.397725Z",
+     "iopub.status.busy": "2026-07-07T23:34:45.397725Z",
+     "iopub.status.idle": "2026-07-07T23:34:45.547866Z",
+     "shell.execute_reply": "2026-07-07T23:34:45.547362Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "odd_fig = plt.figure(figsize=(3.35, 2.55), dpi=100)  # 335 x 255 px (both odd)\n",
+    "odd_ax = odd_fig.add_subplot(111)\n",
+    "odd_im = odd_ax.imshow(blob_stack[0], cmap='viridis')\n",
+    "odd_ax.axis('off')\n",
+    "odd_anim = FuncAnimation(odd_fig, lambda i: (odd_im.set_data(blob_stack[i]) or odd_im,), frames=n_frames)\n",
+    "\n",
+    "px_w = int(round(odd_fig.get_figwidth() * odd_fig.dpi))\n",
+    "px_h = int(round(odd_fig.get_figheight() * odd_fig.dpi))\n",
+    "odd_path = save_animation(odd_anim, str(out_dir / 'odd.mp4'), fps=6, crf=28)\n",
+    "plt.close(odd_fig)\n",
+    "print(f'{px_w}x{px_h} (odd) encoded fine -> {kib(odd_path)} KiB')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52c81a1a",
+   "metadata": {},
+   "source": [
+    "## Smaller, looping GIF and animated WebP\n",
+    "\n",
+    "For notebook embeds and the web, GIF is convenient but heavy. `save_animation` writes **optimised** GIFs and\n",
+    "lets you control the **loop count** (`loop=0` loops forever). For photographic content, **animated WebP** is\n",
+    "typically several times smaller than the equivalent GIF."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b5283c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:45.549868Z",
+     "iopub.status.busy": "2026-07-07T23:34:45.548869Z",
+     "iopub.status.idle": "2026-07-07T23:34:47.038426Z",
+     "shell.execute_reply": "2026-07-07T23:34:47.038426Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "gif_loop = save_animation(anim, str(out_dir / 'loop3.gif'), fps=6, loop=3)\n",
+    "webp_path = save_animation(anim, str(out_dir / 'blob.webp'), fps=6)\n",
+    "\n",
+    "comparison = {'gif': kib(gif_path), 'webp': kib(webp_path)}\n",
+    "print('GIF vs WebP (KiB):', comparison)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75538365",
+   "metadata": {},
+   "source": [
+    "The WebP renders inline just like the GIF, at a fraction of the size:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac7cfaae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:47.041436Z",
+     "iopub.status.busy": "2026-07-07T23:34:47.040436Z",
+     "iopub.status.idle": "2026-07-07T23:34:47.046578Z",
+     "shell.execute_reply": "2026-07-07T23:34:47.046074Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "show_webp(webp_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6689f053",
+   "metadata": {},
+   "source": [
+    "## Render straight to bytes — `to_gif`, `to_mp4`, `to_bytes`, `embed_gif`\n",
+    "\n",
+    "Sometimes you want the encoded animation **in memory** — to serve it over HTTP, attach it, or embed it —\n",
+    "without leaving a file on disk. These helpers wrap `save_animation` and return `bytes` (or, for `embed_gif`,\n",
+    "an inline image). They accept the same quality kwargs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "301a066b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:47.048580Z",
+     "iopub.status.busy": "2026-07-07T23:34:47.048580Z",
+     "iopub.status.idle": "2026-07-07T23:34:49.267285Z",
+     "shell.execute_reply": "2026-07-07T23:34:49.267285Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "gif_bytes = to_gif(anim, fps=6)\n",
+    "mp4_bytes = to_mp4(anim, fps=6, crf=30)\n",
+    "webp_bytes = to_bytes(anim, fmt='webp', fps=6)\n",
+    "\n",
+    "for name, data in [('gif', gif_bytes), ('mp4', mp4_bytes), ('webp', webp_bytes)]:\n",
+    "    print(f'{name:4} {len(data):>7,d} bytes  magic={data[:4]!r}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46e0909b",
+   "metadata": {},
+   "source": [
+    "`embed_gif` returns an `IPython.display.Image` ready to be the last expression of a cell — the one-liner for\n",
+    "showing an animation inline in a notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac0f1c3b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:49.269321Z",
+     "iopub.status.busy": "2026-07-07T23:34:49.269321Z",
+     "iopub.status.idle": "2026-07-07T23:34:50.137783Z",
+     "shell.execute_reply": "2026-07-07T23:34:50.137783Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "embed_gif(anim, fps=6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20c419fa",
+   "metadata": {},
+   "source": [
+    "## The same controls from a glyph\n",
+    "\n",
+    "`ArrayGlyph.save_animation` (inherited by every glyph) forwards these keyword arguments to\n",
+    "`cleopatra.animation.save_animation`, so you get the full quality surface without reaching for the free\n",
+    "function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25da5900",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:50.140791Z",
+     "iopub.status.busy": "2026-07-07T23:34:50.139790Z",
+     "iopub.status.idle": "2026-07-07T23:34:50.785207Z",
+     "shell.execute_reply": "2026-07-07T23:34:50.785207Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "glyph_out = out_dir / 'from_glyph.mp4'\n",
+    "glyph.save_animation(str(glyph_out), fps=6, crf=32, preset='veryfast')\n",
+    "print('ArrayGlyph.save_animation(crf=32, preset=\"veryfast\") ->', kib(glyph_out), 'KiB')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "785ca566",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T23:34:50.788212Z",
+     "iopub.status.busy": "2026-07-07T23:34:50.787212Z",
+     "iopub.status.idle": "2026-07-07T23:34:50.790227Z",
+     "shell.execute_reply": "2026-07-07T23:34:50.790227Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "plt.close('all')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4762ef0",
+   "metadata": {},
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "- One call, many formats: `save_animation(anim, path)` picks GIF / WebP / MP4 / MOV / AVI from the extension.\n",
+    "- `crf` (or `bitrate`) + `preset` trade size against quality; `crf` is the go-to dial.\n",
+    "- Odd figure sizes, `pix_fmt=yuv420p`, and ffmpeg resolution are handled for you — MP4 export needs no setup.\n",
+    "- WebP is a much smaller alternative to GIF for embeds; GIFs are optimised and loop-controllable.\n",
+    "- `to_gif` / `to_mp4` / `to_bytes` / `embed_gif` give you the animation in memory or inline.\n",
+    "\n",
+    "See the [`cleopatra.animation` API reference](../../reference/animation.md) for the full signature."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/array_plot_examples.py
+++ b/examples/array_plot_examples.py
@@ -148,4 +148,3 @@ import matplotlib as mpl
 fps = 2
 
 path = "examples/animation.mp4"
-import ffmpeg

--- a/examples/array_plot_examples.py
+++ b/examples/array_plot_examples.py
@@ -133,18 +133,10 @@ anim = array.animate(
     animate_time_list, title="Flow Accumulation", display_cell_value=True
 )
 
-import sys
-from pathlib import Path
-
-# path = Path(sys.executable)
-# f"{path.parent}/{}"
 # %%
-
-# amin.save('examples/animation.gif', fps=2)
-video_format = "mp4"
-
-import matplotlib as mpl
-
-fps = 2
-
-path = "examples/animation.mp4"
+# Save the animation. GIF (and WebP) need no extra tooling; MP4 uses ffmpeg,
+# which ships bundled via imageio-ffmpeg so this works out of the box. The
+# keyword-only quality controls (crf/preset/...) tune the MP4 encode, and odd
+# figure dimensions are padded automatically.
+array.save_animation("examples/animation.gif", fps=2)
+array.save_animation("examples/animation.mp4", fps=2, crf=26, preset="slow")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
     - ArrayGlyph: notebooks/array_glyph/array_glyph_examples.ipynb
     - ArrayGlyph RGB animation: notebooks/array_glyph/rgb_animation.ipynb
     - ArrayGlyph reference map: notebooks/array_glyph/reference_map.ipynb
+    - Saving animations: notebooks/animation/animation_examples.ipynb
     - MeshGlyph: notebooks/mesh_glyph/mesh_glyph_examples.ipynb
     - ScatterGlyph: notebooks/scatter_glyph/scatter_glyph_examples.ipynb
     - VectorGlyph: notebooks/vector_glyph/vector_glyph_examples.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = [
     "numpy>=2.0.0",
     "matplotlib>=3.9",
-    "ffmpeg-python",
+    "imageio-ffmpeg>=0.4.9",
     "hpc-utils>=0.1.4",
 ]
 

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -58,6 +58,36 @@ def _ensure_ffmpeg_available() -> None:
     mpl.rcParams["animation.ffmpeg_path"] = imageio_ffmpeg.get_ffmpeg_exe()
 
 
+class _OptimizedPillowWriter(PillowWriter):
+    """`PillowWriter` that writes optimised GIFs with a configurable loop.
+
+    matplotlib's stock `PillowWriter` hardcodes ``loop=0`` and never passes
+    ``optimize`` to `PIL.Image.save`, so GIFs come out unoptimised — needlessly
+    large for photographic/satellite frames. This subclass forwards ``optimize``
+    and ``loop`` while reusing the parent's frame-grabbing logic.
+
+    Args:
+        optimize: Run Pillow's GIF optimisation pass (palette + delta frames).
+        loop: Number of times the GIF loops; ``0`` means loop forever (Pillow's
+            convention).
+    """
+
+    def __init__(self, *args, optimize: bool = True, loop: int = 0, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._optimize = optimize
+        self._loop = loop
+
+    def finish(self):
+        self._frames[0].save(
+            self.outfile,
+            save_all=True,
+            append_images=self._frames[1:],
+            duration=int(1000 / self.fps),
+            loop=self._loop,
+            optimize=self._optimize,
+        )
+
+
 def save_animation(
     anim: FuncAnimation, path: str | os.PathLike, fps: int = 2
 ) -> str:
@@ -165,7 +195,7 @@ def save_animation(
         )
 
     if video_format == "gif":
-        anim.save(path, writer=PillowWriter(fps=fps))
+        anim.save(path, writer=_OptimizedPillowWriter(fps=fps))
     else:
         _ensure_ffmpeg_available()
         # libx264 requires even width/height, so a figure whose pixel size is

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -168,8 +168,15 @@ def save_animation(
         anim.save(path, writer=PillowWriter(fps=fps))
     else:
         _ensure_ffmpeg_available()
+        # libx264 requires even width/height, so a figure whose pixel size is
+        # odd otherwise dies with "height not divisible by 2". Pad the frame up
+        # to the next even size so any figure encodes.
+        extra_args = ["-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2"]
         try:
-            anim.save(path, writer=FFMpegWriter(fps=fps, bitrate=1800))
+            anim.save(
+                path,
+                writer=FFMpegWriter(fps=fps, bitrate=1800, extra_args=extra_args),
+            )
         except FileNotFoundError as e:
             raise FileNotFoundError(
                 "FFmpeg not found. Please visit https://ffmpeg.org/ "

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -170,8 +170,15 @@ def save_animation(
         _ensure_ffmpeg_available()
         # libx264 requires even width/height, so a figure whose pixel size is
         # odd otherwise dies with "height not divisible by 2". Pad the frame up
-        # to the next even size so any figure encodes.
-        extra_args = ["-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2"]
+        # to the next even size so any figure encodes. Set pix_fmt=yuv420p
+        # explicitly so the output plays everywhere (browsers, QuickTime); it
+        # is otherwise one matplotlib default away from an unplayable file.
+        extra_args = [
+            "-vf",
+            "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+            "-pix_fmt",
+            "yuv420p",
+        ]
         try:
             anim.save(
                 path,

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -67,8 +67,12 @@ def _ensure_ffmpeg_available() -> None:
     # Only the matplotlib default (``"ffmpeg"``) is overridden silently; an
     # explicit path the user configured is theirs, so warn before replacing it.
     if configured not in ("ffmpeg", "ffmpeg.exe"):
-        # stacklevel=3: warn() -> _ensure_ffmpeg_available -> save_animation ->
-        # user call site, so the warning is attributed to the caller's code.
+        # stacklevel=3 targets the common direct ``save_animation`` call
+        # (warn -> _ensure_ffmpeg_available -> save_animation -> caller). The
+        # depth differs when reached via to_bytes/to_mp4/Glyph.save_animation,
+        # so attribution is best-effort; the message is self-contained. There is
+        # no single correct stacklevel across those entry points, and
+        # ``skip_file_prefixes`` is Python 3.12+ while this package targets 3.11.
         warnings.warn(
             f"Configured ffmpeg binary {configured!r} was not found; falling "
             f"back to the imageio-ffmpeg bundled binary at {bundled!r}.",
@@ -100,6 +104,9 @@ class _OptimizedPillowWriter(PillowWriter):
         self._loop = loop
 
     def finish(self):
+        # Mirrors matplotlib's PillowWriter.finish body (it cannot be delegated
+        # because the parent hardcodes loop=0 and passes no optimize). Re-check
+        # against matplotlib.animation.PillowWriter.finish on version bumps.
         self._frames[0].save(
             self.outfile,
             save_all=True,

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -88,8 +88,95 @@ class _OptimizedPillowWriter(PillowWriter):
         )
 
 
+#: ffmpeg video filter that rounds the frame up to an even width/height.
+#: libx264 refuses odd dimensions, so this is always applied to video output.
+_EVEN_PAD_FILTER = "pad=ceil(iw/2)*2:ceil(ih/2)*2"
+
+
+def _build_ffmpeg_extra_args(
+    pix_fmt: str,
+    crf: int | None,
+    preset: str | None,
+    extra_args: list[str] | None,
+) -> list[str]:
+    """Assemble the ffmpeg ``extra_args`` list for a video export.
+
+    Combines the mandatory even-dimension pad filter with an explicit pixel
+    format and any caller-supplied CRF, preset, or raw ffmpeg flags. A caller
+    ``-vf`` filter is merged into a single chain — ffmpeg honours only the last
+    ``-vf`` — with the pad applied last so the frame ends up even whatever the
+    caller's filters produce.
+
+    Args:
+        pix_fmt: Pixel format passed as ``-pix_fmt`` (e.g. ``"yuv420p"``).
+        crf: Constant Rate Factor; appended as ``-crf`` when not ``None``.
+        preset: libx264 speed/size preset; appended as ``-preset`` when set.
+        extra_args: Extra ffmpeg flags. A ``-vf`` pair here is merged into the
+            pad chain; everything else is passed through unchanged.
+
+    Returns:
+        The assembled argument list, always starting with the merged ``-vf``
+        chain followed by ``-pix_fmt``.
+
+    Examples:
+        - Defaults produce just the pad filter and pixel format:
+            ```python
+            >>> from cleopatra.animation import _build_ffmpeg_extra_args
+            >>> _build_ffmpeg_extra_args("yuv420p", None, None, None)
+            ['-vf', 'pad=ceil(iw/2)*2:ceil(ih/2)*2', '-pix_fmt', 'yuv420p']
+
+            ```
+        - A CRF and preset are appended after the pixel format:
+            ```python
+            >>> from cleopatra.animation import _build_ffmpeg_extra_args
+            >>> _build_ffmpeg_extra_args("yuv420p", 26, "slow", None)[4:]
+            ['-crf', '26', '-preset', 'slow']
+
+            ```
+        - A caller ``-vf`` is merged into one chain with the pad applied last:
+            ```python
+            >>> from cleopatra.animation import _build_ffmpeg_extra_args
+            >>> _build_ffmpeg_extra_args("yuv420p", None, None, ["-vf", "scale=320:-1"])[:2]
+            ['-vf', 'scale=320:-1,pad=ceil(iw/2)*2:ceil(ih/2)*2']
+
+            ```
+    """
+    user_args = list(extra_args) if extra_args else []
+    vf_filters: list[str] = []
+    passthrough: list[str] = []
+    i = 0
+    while i < len(user_args):
+        if user_args[i] == "-vf" and i + 1 < len(user_args):
+            vf_filters.append(user_args[i + 1])
+            i += 2
+        else:
+            passthrough.append(user_args[i])
+            i += 1
+    vf_filters.append(_EVEN_PAD_FILTER)
+
+    built = ["-vf", ",".join(vf_filters), "-pix_fmt", pix_fmt]
+    if crf is not None:
+        built += ["-crf", str(crf)]
+    if preset is not None:
+        built += ["-preset", preset]
+    built += passthrough
+    return built
+
+
 def save_animation(
-    anim: FuncAnimation, path: str | os.PathLike, fps: int = 2
+    anim: FuncAnimation,
+    path: str | os.PathLike,
+    fps: int = 2,
+    *,
+    crf: int | None = None,
+    bitrate: int | None = None,
+    codec: str | None = None,
+    preset: str | None = None,
+    pix_fmt: str = "yuv420p",
+    dpi: int | None = None,
+    optimize: bool = True,
+    loop: int = 0,
+    extra_args: list[str] | None = None,
 ) -> str:
     """Save any `FuncAnimation` to a file.
 
@@ -109,6 +196,23 @@ def save_animation(
             `pathlib.Path`). Extension determines format.
             Supported: gif, mov, avi, mp4.
         fps: Frames per second. Default is 2.
+        crf: Constant Rate Factor for the ffmpeg formats (lower is higher
+            quality/larger; ~18-28 is typical). Mutually exclusive with
+            ``bitrate``. Ignored for GIF. ``None`` uses the encoder default.
+        bitrate: Target bitrate in kbit/s for the ffmpeg formats. Mutually
+            exclusive with ``crf``. Ignored for GIF. ``None`` lets the encoder
+            choose.
+        codec: ffmpeg codec (e.g. ``"libx264"``). ``None`` uses matplotlib's
+            default. Ignored for GIF.
+        preset: libx264 speed/size preset (e.g. ``"slow"``). Ignored for GIF.
+        pix_fmt: Pixel format for the ffmpeg formats. Defaults to
+            ``"yuv420p"`` for universal playback. Ignored for GIF.
+        dpi: Resolution in dots per inch. ``None`` uses the figure's dpi.
+        optimize: GIF only — run Pillow's palette optimisation pass. Default
+            ``True``.
+        loop: GIF only — number of times to loop; ``0`` loops forever.
+        extra_args: Extra ffmpeg flags. A ``-vf`` filter here is merged with
+            the automatic even-dimension pad. Ignored for GIF.
 
     Returns:
         The output path as a `str` (the `os.fspath` of `path`),
@@ -116,9 +220,10 @@ def save_animation(
         back as its string form, not the original object.
 
     Raises:
-        ValueError: If the file format is not supported.
-        FileNotFoundError: If a video format is requested but FFmpeg is
-            not installed.
+        ValueError: If the file format is not supported, or if both ``crf``
+            and ``bitrate`` are given (competing rate-control modes).
+        FileNotFoundError: If a video format is requested but neither a system
+            FFmpeg nor imageio-ffmpeg's bundled binary can be found.
 
     Examples:
         - Save a tiny animation to a GIF; the call returns the path it wrote:
@@ -201,26 +306,31 @@ def save_animation(
             f"not supported, only {SUPPORTED_VIDEO_FORMAT} are supported"
         )
 
+    save_kwargs = {} if dpi is None else {"dpi": dpi}
+
     if video_format == "gif":
-        anim.save(path, writer=_OptimizedPillowWriter(fps=fps))
+        anim.save(
+            path,
+            writer=_OptimizedPillowWriter(fps=fps, optimize=optimize, loop=loop),
+            **save_kwargs,
+        )
     else:
-        _ensure_ffmpeg_available()
-        # libx264 requires even width/height, so a figure whose pixel size is
-        # odd otherwise dies with "height not divisible by 2". Pad the frame up
-        # to the next even size so any figure encodes. Set pix_fmt=yuv420p
-        # explicitly so the output plays everywhere (browsers, QuickTime); it
-        # is otherwise one matplotlib default away from an unplayable file.
-        extra_args = [
-            "-vf",
-            "pad=ceil(iw/2)*2:ceil(ih/2)*2",
-            "-pix_fmt",
-            "yuv420p",
-        ]
-        try:
-            anim.save(
-                path,
-                writer=FFMpegWriter(fps=fps, bitrate=1800, extra_args=extra_args),
+        if crf is not None and bitrate is not None:
+            raise ValueError(
+                "Pass either crf or bitrate, not both: they are competing "
+                "rate-control modes for the encoder."
             )
+        _ensure_ffmpeg_available()
+        writer_kwargs = {
+            "fps": fps,
+            "extra_args": _build_ffmpeg_extra_args(pix_fmt, crf, preset, extra_args),
+        }
+        if bitrate is not None:
+            writer_kwargs["bitrate"] = bitrate
+        if codec is not None:
+            writer_kwargs["codec"] = codec
+        try:
+            anim.save(path, writer=FFMpegWriter(**writer_kwargs), **save_kwargs)
         except FileNotFoundError as e:
             raise FileNotFoundError(
                 "FFmpeg not found. Please visit https://ffmpeg.org/ "

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -25,9 +25,13 @@ from matplotlib.animation import FFMpegWriter, FuncAnimation, PillowWriter
 if TYPE_CHECKING:  # import only for type checkers; IPython stays optional
     from IPython.display import Image
 
-#: Container formats `save_animation` can write. GIF uses `PillowWriter`;
-#: the rest require FFmpeg (`FFMpegWriter`).
-SUPPORTED_VIDEO_FORMAT = ["gif", "mov", "avi", "mp4"]
+#: Container formats `save_animation` can write. GIF and (animated) WebP use
+#: Pillow (`_OptimizedPillowWriter`); mov/avi/mp4 require FFmpeg (`FFMpegWriter`).
+#: WebP is typically 3-5x smaller than GIF for photographic/satellite frames.
+SUPPORTED_VIDEO_FORMAT = ["gif", "mov", "avi", "mp4", "webp"]
+
+#: Formats written by Pillow rather than FFmpeg.
+_PILLOW_FORMATS = {"gif", "webp"}
 
 
 def _ensure_ffmpeg_available() -> None:
@@ -180,39 +184,41 @@ def save_animation(
 ) -> str:
     """Save any `FuncAnimation` to a file.
 
-    The output format is determined by the file extension. GIF uses an
-    optimising `PillowWriter`; mov/avi/mp4 use FFmpeg. FFmpeg is located on
-    `PATH` when present and otherwise falls back to the binary bundled with
-    `imageio-ffmpeg`, so video export works with no separate install.
+    The output format is determined by the file extension. GIF and animated
+    WebP use an optimising Pillow writer; mov/avi/mp4 use FFmpeg. FFmpeg is
+    located on `PATH` when present and otherwise falls back to the binary
+    bundled with `imageio-ffmpeg`, so video export works with no separate
+    install. WebP is typically 3-5x smaller than GIF for photographic frames.
 
     For the FFmpeg formats the frame is automatically padded up to an even
     width/height (libx264 rejects odd dimensions) and encoded with
-    ``pix_fmt=yuv420p`` for universal playback. GIF output is written with
+    ``pix_fmt=yuv420p`` for universal playback. GIF/WebP output is written with
     Pillow's ``optimize`` pass enabled and loops forever.
 
     Args:
         anim: The animation to save.
         path: Output file path, as a `str` or `os.PathLike` (e.g. a
             `pathlib.Path`). Extension determines format.
-            Supported: gif, mov, avi, mp4.
+            Supported: gif, mov, avi, mp4, webp.
         fps: Frames per second. Default is 2.
         crf: Constant Rate Factor for the ffmpeg formats (lower is higher
             quality/larger; ~18-28 is typical). Mutually exclusive with
-            ``bitrate``. Ignored for GIF. ``None`` uses the encoder default.
+            ``bitrate``. Ignored for GIF/WebP. ``None`` uses the encoder default.
         bitrate: Target bitrate in kbit/s for the ffmpeg formats. Mutually
-            exclusive with ``crf``. Ignored for GIF. ``None`` lets the encoder
-            choose.
+            exclusive with ``crf``. Ignored for GIF/WebP. ``None`` lets the
+            encoder choose.
         codec: ffmpeg codec (e.g. ``"libx264"``). ``None`` uses matplotlib's
-            default. Ignored for GIF.
-        preset: libx264 speed/size preset (e.g. ``"slow"``). Ignored for GIF.
+            default. Ignored for GIF/WebP.
+        preset: libx264 speed/size preset (e.g. ``"slow"``). Ignored for
+            GIF/WebP.
         pix_fmt: Pixel format for the ffmpeg formats. Defaults to
-            ``"yuv420p"`` for universal playback. Ignored for GIF.
+            ``"yuv420p"`` for universal playback. Ignored for GIF/WebP.
         dpi: Resolution in dots per inch. ``None`` uses the figure's dpi.
-        optimize: GIF only — run Pillow's palette optimisation pass. Default
+        optimize: GIF/WebP only — run Pillow's optimisation pass. Default
             ``True``.
-        loop: GIF only — number of times to loop; ``0`` loops forever.
+        loop: GIF/WebP only — number of times to loop; ``0`` loops forever.
         extra_args: Extra ffmpeg flags. A ``-vf`` filter here is merged with
-            the automatic even-dimension pad. Ignored for GIF.
+            the automatic even-dimension pad. Ignored for GIF/WebP.
 
     Returns:
         The output path as a `str` (the `os.fspath` of `path`),
@@ -308,7 +314,7 @@ def save_animation(
 
     save_kwargs = {} if dpi is None else {"dpi": dpi}
 
-    if video_format == "gif":
+    if video_format in _PILLOW_FORMATS:
         anim.save(
             path,
             writer=_OptimizedPillowWriter(fps=fps, optimize=optimize, loop=loop),

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+import warnings
 from typing import TYPE_CHECKING
 
 import matplotlib as mpl
@@ -42,6 +43,9 @@ def _ensure_ffmpeg_available() -> None:
     resolved on `PATH`). If that binary is not found, fall back to the static
     ffmpeg that `imageio-ffmpeg` bundles, so mp4/mov/avi export works with no
     separate system install. A system ffmpeg on `PATH` still takes precedence.
+    If the rcParam was set to an explicit path that no longer resolves, a
+    `RuntimeWarning` is emitted before falling back, so an overridden user
+    choice is never discarded silently.
 
     Raises:
         FileNotFoundError: If neither a system ffmpeg nor `imageio-ffmpeg`'s
@@ -59,7 +63,17 @@ def _ensure_ffmpeg_available() -> None:
             "Install imageio-ffmpeg (ships a bundled ffmpeg) or download "
             "ffmpeg from https://ffmpeg.org/ and add it to your PATH."
         ) from e
-    mpl.rcParams["animation.ffmpeg_path"] = imageio_ffmpeg.get_ffmpeg_exe()
+    bundled = imageio_ffmpeg.get_ffmpeg_exe()
+    # Only the matplotlib default (``"ffmpeg"``) is overridden silently; an
+    # explicit path the user configured is theirs, so warn before replacing it.
+    if configured not in ("ffmpeg", "ffmpeg.exe"):
+        warnings.warn(
+            f"Configured ffmpeg binary {configured!r} was not found; falling "
+            f"back to the imageio-ffmpeg bundled binary at {bundled!r}.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    mpl.rcParams["animation.ffmpeg_path"] = bundled
 
 
 class _OptimizedPillowWriter(PillowWriter):

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -352,6 +352,14 @@ def save_animation(
             f"not supported, only {SUPPORTED_VIDEO_FORMAT} are supported"
         )
 
+    # Validate the rate-control contract uniformly, before the format branch,
+    # so crf+bitrate is rejected for every format rather than only for video.
+    if crf is not None and bitrate is not None:
+        raise ValueError(
+            "Pass either crf or bitrate, not both: they are competing "
+            "rate-control modes for the encoder."
+        )
+
     save_kwargs = {} if dpi is None else {"dpi": dpi}
 
     if video_format in _PILLOW_FORMATS:
@@ -361,11 +369,6 @@ def save_animation(
             **save_kwargs,
         )
     else:
-        if crf is not None and bitrate is not None:
-            raise ValueError(
-                "Pass either crf or bitrate, not both: they are competing "
-                "rate-control modes for the encoder."
-            )
         _ensure_ffmpeg_available()
         writer_kwargs = {
             "fps": fps,

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -77,17 +77,19 @@ def _ensure_ffmpeg_available() -> None:
 
 
 class _OptimizedPillowWriter(PillowWriter):
-    """`PillowWriter` that writes optimised GIFs with a configurable loop.
+    """`PillowWriter` that writes optimised, loop-configurable GIF/WebP output.
 
+    This is the writer for both Pillow-backed formats (``gif`` and ``webp``).
     matplotlib's stock `PillowWriter` hardcodes ``loop=0`` and never passes
     ``optimize`` to `PIL.Image.save`, so GIFs come out unoptimised — needlessly
     large for photographic/satellite frames. This subclass forwards ``optimize``
     and ``loop`` while reusing the parent's frame-grabbing logic.
 
     Args:
-        optimize: Run Pillow's GIF optimisation pass (palette + delta frames).
-        loop: Number of times the GIF loops; ``0`` means loop forever (Pillow's
-            convention).
+        optimize: Run Pillow's optimisation pass. Effective for GIF (palette
+            compression); the WebP encoder ignores it, so it is a no-op there.
+        loop: Number of times the animation loops; ``0`` means loop forever
+            (Pillow's convention). Honoured by both GIF and WebP.
     """
 
     def __init__(self, *args, optimize: bool = True, loop: int = 0, **kwargs):
@@ -222,8 +224,12 @@ def save_animation(
 
     For the FFmpeg formats the frame is automatically padded up to an even
     width/height (libx264 rejects odd dimensions) and encoded with
-    ``pix_fmt=yuv420p`` for universal playback. GIF/WebP output is written with
-    Pillow's ``optimize`` pass enabled and loops forever.
+    ``pix_fmt=yuv420p`` for universal playback. By default no fixed bitrate is
+    requested (unlike older versions, which forced 1800 kbit/s), so libx264
+    uses its constant-quality default of roughly CRF 23 — pass ``crf`` or
+    ``bitrate`` to trade size against quality. GIF output is written with
+    Pillow's ``optimize`` pass enabled; both GIF and WebP loop forever by
+    default.
 
     Args:
         anim: The animation to save.
@@ -232,23 +238,27 @@ def save_animation(
             Supported: gif, mov, avi, mp4, webp.
         fps: Frames per second. Default is 2.
         crf: Constant Rate Factor for the ffmpeg formats (lower is higher
-            quality/larger; ~18-28 is typical). Mutually exclusive with
-            ``bitrate``. Ignored for GIF/WebP. ``None`` uses the encoder default.
+            quality/larger; ~18-28 is typical). Assumes an x264/x265-family
+            ``codec``. Mutually exclusive with ``bitrate``. Ignored for
+            GIF/WebP. ``None`` uses the encoder default.
         bitrate: Target bitrate in kbit/s for the ffmpeg formats. Mutually
             exclusive with ``crf``. Ignored for GIF/WebP. ``None`` lets the
             encoder choose.
         codec: ffmpeg codec (e.g. ``"libx264"``). ``None`` uses matplotlib's
             default. Ignored for GIF/WebP.
-        preset: libx264 speed/size preset (e.g. ``"slow"``). Ignored for
-            GIF/WebP.
+        preset: libx264/libx265 speed/size preset (e.g. ``"slow"``); ignored by
+            codecs that don't accept it. Ignored for GIF/WebP.
         pix_fmt: Pixel format for the ffmpeg formats. Defaults to
             ``"yuv420p"`` for universal playback. Ignored for GIF/WebP.
         dpi: Resolution in dots per inch. ``None`` uses the figure's dpi.
-        optimize: GIF/WebP only — run Pillow's optimisation pass. Default
-            ``True``.
+        optimize: GIF only — run Pillow's palette optimisation pass (a no-op
+            for WebP, whose encoder ignores it). Default ``True``.
         loop: GIF/WebP only — number of times to loop; ``0`` loops forever.
         extra_args: Extra ffmpeg flags. A ``-vf`` filter here is merged with
-            the automatic even-dimension pad. Ignored for GIF/WebP.
+            the automatic even-dimension pad and a ``-pix_fmt`` overrides
+            ``pix_fmt``. Note these flags bypass the ``crf``/``bitrate``
+            exclusivity check, so don't smuggle a conflicting ``-b:v``/``-crf``
+            through here. Ignored for GIF/WebP.
 
     Returns:
         The output path as a `str` (the `os.fspath` of `path`),

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -225,6 +225,11 @@ def save_animation(
     bundled with `imageio-ffmpeg`, so video export works with no separate
     install. WebP is typically 3-5x smaller than GIF for photographic frames.
 
+    Note: when no system FFmpeg is found, the first video export sets
+    matplotlib's global ``rcParams["animation.ffmpeg_path"]`` to the bundled
+    binary — a process-wide side effect that then applies to any later
+    matplotlib animation in the same process.
+
     For the FFmpeg formats the frame is automatically padded up to an even
     width/height (libx264 rejects odd dimensions) and encoded with
     ``pix_fmt=yuv420p`` for universal playback. By default no fixed bitrate is

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -15,9 +15,11 @@ writer/format logic has a single source of truth.
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 from typing import TYPE_CHECKING
 
+import matplotlib as mpl
 from matplotlib.animation import FFMpegWriter, FuncAnimation, PillowWriter
 
 if TYPE_CHECKING:  # import only for type checkers; IPython stays optional
@@ -26,6 +28,34 @@ if TYPE_CHECKING:  # import only for type checkers; IPython stays optional
 #: Container formats `save_animation` can write. GIF uses `PillowWriter`;
 #: the rest require FFmpeg (`FFMpegWriter`).
 SUPPORTED_VIDEO_FORMAT = ["gif", "mov", "avi", "mp4"]
+
+
+def _ensure_ffmpeg_available() -> None:
+    """Make sure matplotlib can find an ffmpeg binary to shell out to.
+
+    matplotlib's `FFMpegWriter` runs the ffmpeg *binary* named by
+    `matplotlib.rcParams["animation.ffmpeg_path"]` (default ``"ffmpeg"``,
+    resolved on `PATH`). If that binary is not found, fall back to the static
+    ffmpeg that `imageio-ffmpeg` bundles, so mp4/mov/avi export works with no
+    separate system install. A system ffmpeg on `PATH` still takes precedence.
+
+    Raises:
+        FileNotFoundError: If neither a system ffmpeg nor `imageio-ffmpeg`'s
+            bundled binary can be located.
+    """
+    configured = mpl.rcParams["animation.ffmpeg_path"]
+    # Already usable: an absolute path that exists, or a name found on PATH.
+    if os.path.isfile(configured) or shutil.which(configured):
+        return
+    try:
+        import imageio_ffmpeg
+    except ModuleNotFoundError as e:  # pragma: no cover - imageio-ffmpeg is a dep
+        raise FileNotFoundError(
+            "FFmpeg not found on PATH and imageio-ffmpeg is not installed. "
+            "Install imageio-ffmpeg (ships a bundled ffmpeg) or download "
+            "ffmpeg from https://ffmpeg.org/ and add it to your PATH."
+        ) from e
+    mpl.rcParams["animation.ffmpeg_path"] = imageio_ffmpeg.get_ffmpeg_exe()
 
 
 def save_animation(
@@ -137,6 +167,7 @@ def save_animation(
     if video_format == "gif":
         anim.save(path, writer=PillowWriter(fps=fps))
     else:
+        _ensure_ffmpeg_available()
         try:
             anim.save(path, writer=FFMpegWriter(fps=fps, bitrate=1800))
         except FileNotFoundError as e:

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -378,9 +378,15 @@ def save_animation(
         try:
             anim.save(path, writer=FFMpegWriter(**writer_kwargs), **save_kwargs)
         except FileNotFoundError as e:
+            # _ensure_ffmpeg_available() already resolved a binary, so this is
+            # rare (e.g. a pinned animation.ffmpeg_path was removed between the
+            # check and the encode). Keep the wording consistent with the
+            # bundled-binary story rather than pointing at a manual install.
             raise FileNotFoundError(
-                "FFmpeg not found. Please visit https://ffmpeg.org/ "
-                "and download a version compatible with your OS."
+                "FFmpeg could not be run. imageio-ffmpeg's bundled binary "
+                "normally makes this work out of the box; if you pinned a custom "
+                "ffmpeg via matplotlib's animation.ffmpeg_path, make sure it still "
+                "exists, or install a system ffmpeg from https://ffmpeg.org/."
             ) from e
     return path
 

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -345,15 +345,107 @@ def save_animation(
     return path
 
 
-def to_gif(anim: FuncAnimation, fps: int = 2) -> bytes:
+def to_bytes(anim: FuncAnimation, fmt: str = "gif", fps: int = 2, **kwargs) -> bytes:
+    """Render a `FuncAnimation` to in-memory bytes in any supported format.
+
+    Renders to a temporary file (the writers need a real path) and reads it
+    back, leaving nothing on disk. Handy for embedding in a notebook or
+    serving over HTTP.
+
+    Args:
+        anim: The animation to render.
+        fmt: Output format — any member of ``SUPPORTED_VIDEO_FORMAT`` (e.g.
+            ``"gif"``, ``"mp4"``, ``"webp"``). A leading dot is tolerated.
+        fps: Frames per second. Default is 2.
+        **kwargs: Extra keyword arguments forwarded to `save_animation`
+            (e.g. ``crf``, ``codec``, ``loop``).
+
+    Returns:
+        The encoded bytes of the animation in the requested format.
+
+    Raises:
+        ValueError: If ``fmt`` is not a supported format.
+
+    Examples:
+        - Render to GIF bytes and inspect the payload:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import to_bytes
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> data = to_bytes(anim, fmt="gif")
+            >>> data[:6] in (b"GIF87a", b"GIF89a")
+            True
+            >>> plt.close(fig)
+
+            ```
+        - Render to animated WebP and confirm the container magic bytes:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import to_bytes
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> data = to_bytes(anim, fmt="webp")
+            >>> data[:4] == b"RIFF" and data[8:12] == b"WEBP"
+            True
+            >>> plt.close(fig)
+
+            ```
+        - An unsupported format raises ``ValueError``:
+            ```python
+            >>> from unittest.mock import MagicMock
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import to_bytes
+            >>> to_bytes(MagicMock(spec=FuncAnimation), fmt="webm")  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: ...not supported...
+
+            ```
+
+    See Also:
+        to_gif: Convenience wrapper for GIF bytes.
+        to_mp4: Convenience wrapper for MP4 bytes.
+        save_animation: Write an animation directly to a file path.
+    """
+    fmt = fmt.lstrip(".").lower()
+    if fmt not in SUPPORTED_VIDEO_FORMAT:
+        raise ValueError(
+            f"The format {fmt!r} is not supported, only "
+            f"{SUPPORTED_VIDEO_FORMAT} are supported"
+        )
+    # Close our handle immediately so the writer can reopen the path; this
+    # makes the handle lifecycle explicit (no reliance on GC) and avoids a
+    # PermissionError when reopening on Windows.
+    fd, tmp = tempfile.mkstemp(suffix=f".{fmt}")
+    os.close(fd)
+    try:
+        save_animation(anim, tmp, fps=fps, **kwargs)
+        with open(tmp, "rb") as fh:
+            return fh.read()
+    finally:
+        os.remove(tmp)
+
+
+def to_gif(anim: FuncAnimation, fps: int = 2, **kwargs) -> bytes:
     """Render a `FuncAnimation` to in-memory GIF bytes.
 
     Handy for embedding in a notebook or serving over HTTP without leaving
-    a file on disk.
+    a file on disk. Thin wrapper around `to_bytes` with ``fmt="gif"``.
 
     Args:
         anim: The animation to render.
         fps: Frames per second. Default is 2.
+        **kwargs: Extra keyword arguments forwarded to `save_animation`
+            (e.g. ``optimize``, ``loop``).
 
     Returns:
         The GIF-encoded bytes of the animation.
@@ -396,20 +488,74 @@ def to_gif(anim: FuncAnimation, fps: int = 2) -> bytes:
             ```
 
     See Also:
+        to_bytes: Render to bytes in any supported format.
         save_animation: Write an animation directly to a file path.
         embed_gif: Wrap these bytes as an ``IPython.display.Image``.
     """
-    # Close our handle immediately so the writer can reopen the path; this
-    # makes the handle lifecycle explicit (no reliance on GC) and avoids a
-    # PermissionError when reopening on Windows.
-    fd, tmp = tempfile.mkstemp(suffix=".gif")
-    os.close(fd)
-    try:
-        save_animation(anim, tmp, fps=fps)
-        with open(tmp, "rb") as fh:
-            return fh.read()
-    finally:
-        os.remove(tmp)
+    return to_bytes(anim, fmt="gif", fps=fps, **kwargs)
+
+
+def to_mp4(anim: FuncAnimation, fps: int = 2, **kwargs) -> bytes:
+    """Render a `FuncAnimation` to in-memory MP4 (H.264) bytes.
+
+    Handy for embedding a compact, universally-playable clip or serving it
+    over HTTP without leaving a file on disk. Thin wrapper around `to_bytes`
+    with ``fmt="mp4"``; the frame is auto-padded to even dimensions and
+    encoded ``yuv420p`` like every other MP4 export.
+
+    Args:
+        anim: The animation to render.
+        fps: Frames per second. Default is 2.
+        **kwargs: Extra keyword arguments forwarded to `save_animation`
+            (e.g. ``crf``, ``bitrate``, ``codec``, ``preset``).
+
+    Returns:
+        The MP4-encoded bytes of the animation.
+
+    Raises:
+        FileNotFoundError: If neither a system FFmpeg nor imageio-ffmpeg's
+            bundled binary can be found.
+
+    Examples:
+        - Render to MP4 bytes and confirm the ISO base-media ``ftyp`` box:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import to_mp4
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> data = to_mp4(anim)
+            >>> data[4:8] == b"ftyp"
+            True
+            >>> plt.close(fig)
+
+            ```
+        - Trade size for quality with a CRF and confirm non-empty output:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import matplotlib.pyplot as plt
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.animation import to_mp4
+            >>> fig, ax = plt.subplots()
+            >>> (line,) = ax.plot([0, 1], [0, 0])
+            >>> anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+            >>> data = to_mp4(anim, crf=30, preset="veryfast")
+            >>> len(data) > 0
+            True
+            >>> plt.close(fig)
+
+            ```
+
+    See Also:
+        to_bytes: Render to bytes in any supported format.
+        to_gif: Render an animation to in-memory GIF bytes.
+        save_animation: Write an animation directly to a file path.
+    """
+    return to_bytes(anim, fmt="mp4", fps=fps, **kwargs)
 
 
 def embed_gif(anim: FuncAnimation, fps: int = 2) -> Image:

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -93,8 +93,15 @@ def save_animation(
 ) -> str:
     """Save any `FuncAnimation` to a file.
 
-    The output format is determined by the file extension. GIF uses
-    `PillowWriter`; mov/avi/mp4 require FFmpeg to be installed.
+    The output format is determined by the file extension. GIF uses an
+    optimising `PillowWriter`; mov/avi/mp4 use FFmpeg. FFmpeg is located on
+    `PATH` when present and otherwise falls back to the binary bundled with
+    `imageio-ffmpeg`, so video export works with no separate install.
+
+    For the FFmpeg formats the frame is automatically padded up to an even
+    width/height (libx264 rejects odd dimensions) and encoded with
+    ``pix_fmt=yuv420p`` for universal playback. GIF output is written with
+    Pillow's ``optimize`` pass enabled and loops forever.
 
     Args:
         anim: The animation to save.

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -130,11 +130,16 @@ def _build_ffmpeg_extra_args(
         crf: Constant Rate Factor; appended as ``-crf`` when not ``None``.
         preset: libx264 speed/size preset; appended as ``-preset`` when set.
         extra_args: Extra ffmpeg flags. A ``-vf`` pair here is merged into the
-            pad chain; everything else is passed through unchanged.
+            pad chain and a ``-pix_fmt`` pair overrides ``pix_fmt`` (rather than
+            duplicating the flag); everything else is passed through unchanged.
 
     Returns:
         The assembled argument list, always starting with the merged ``-vf``
-        chain followed by ``-pix_fmt``.
+        chain followed by a single ``-pix_fmt``.
+
+    Raises:
+        ValueError: If ``extra_args`` ends with a valueless ``-vf`` or
+            ``-pix_fmt`` flag.
 
     Examples:
         - Defaults produce just the pad filter and pixel format:
@@ -162,17 +167,28 @@ def _build_ffmpeg_extra_args(
     user_args = list(extra_args) if extra_args else []
     vf_filters: list[str] = []
     passthrough: list[str] = []
+    caller_pix_fmt: str | None = None
     i = 0
     while i < len(user_args):
-        if user_args[i] == "-vf" and i + 1 < len(user_args):
-            vf_filters.append(user_args[i + 1])
+        arg = user_args[i]
+        if arg in ("-vf", "-pix_fmt"):
+            if i + 1 >= len(user_args):
+                raise ValueError(
+                    f"Malformed extra_args: {arg!r} must be followed by a value."
+                )
+            if arg == "-vf":
+                vf_filters.append(user_args[i + 1])
+            else:
+                # A caller-supplied pixel format replaces the default rather than
+                # duplicating the flag (ffmpeg would otherwise carry both).
+                caller_pix_fmt = user_args[i + 1]
             i += 2
         else:
-            passthrough.append(user_args[i])
+            passthrough.append(arg)
             i += 1
     vf_filters.append(_EVEN_PAD_FILTER)
 
-    built = ["-vf", ",".join(vf_filters), "-pix_fmt", pix_fmt]
+    built = ["-vf", ",".join(vf_filters), "-pix_fmt", caller_pix_fmt or pix_fmt]
     if crf is not None:
         built += ["-crf", str(crf)]
     if preset is not None:

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -67,11 +67,13 @@ def _ensure_ffmpeg_available() -> None:
     # Only the matplotlib default (``"ffmpeg"``) is overridden silently; an
     # explicit path the user configured is theirs, so warn before replacing it.
     if configured not in ("ffmpeg", "ffmpeg.exe"):
+        # stacklevel=3: warn() -> _ensure_ffmpeg_available -> save_animation ->
+        # user call site, so the warning is attributed to the caller's code.
         warnings.warn(
             f"Configured ffmpeg binary {configured!r} was not found; falling "
             f"back to the imageio-ffmpeg bundled binary at {bundled!r}.",
             RuntimeWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
     mpl.rcParams["animation.ffmpeg_path"] = bundled
 

--- a/src/cleopatra/animation.py
+++ b/src/cleopatra/animation.py
@@ -190,7 +190,8 @@ def _build_ffmpeg_extra_args(
             i += 1
     vf_filters.append(_EVEN_PAD_FILTER)
 
-    built = ["-vf", ",".join(vf_filters), "-pix_fmt", caller_pix_fmt or pix_fmt]
+    chosen_pix_fmt = caller_pix_fmt if caller_pix_fmt is not None else pix_fmt
+    built = ["-vf", ",".join(vf_filters), "-pix_fmt", chosen_pix_fmt]
     if crf is not None:
         built += ["-crf", str(crf)]
     if preset is not None:

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1089,9 +1089,9 @@ class Glyph:
         """Save this glyph's animation (`self.anim`) to a file.
 
         Thin wrapper around `cleopatra.animation.save_animation`; the output
-        format is determined by the file extension. GIF uses an optimising
-        Pillow writer; mov/avi/mp4 use FFmpeg (a system binary if present,
-        otherwise the one bundled with imageio-ffmpeg).
+        format is determined by the file extension. GIF and WebP use an
+        optimising Pillow writer; mov/avi/mp4 use FFmpeg (a system binary if
+        present, otherwise the one bundled with imageio-ffmpeg).
 
         Args:
             path: Output file path, as a `str` or `os.PathLike` (e.g. a

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1096,7 +1096,7 @@ class Glyph:
         Args:
             path: Output file path, as a `str` or `os.PathLike` (e.g. a
                 `pathlib.Path`). Extension determines format.
-                Supported: gif, mov, avi, mp4.
+                Supported: gif, mov, avi, mp4, webp.
             fps: Frames per second. Default is 2.
             **kwargs: Additional keyword arguments forwarded to
                 `cleopatra.animation.save_animation`, e.g. ``crf``, ``bitrate``,
@@ -1115,7 +1115,7 @@ class Glyph:
                 ```python
                 >>> from cleopatra.glyph import SUPPORTED_VIDEO_FORMAT
                 >>> sorted(SUPPORTED_VIDEO_FORMAT)
-                ['avi', 'gif', 'mov', 'mp4']
+                ['avi', 'gif', 'mov', 'mp4', 'webp']
 
                 ```
         """

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1085,24 +1085,30 @@ class Glyph:
         )
         return list(map(write_points, point_table))
 
-    def save_animation(self, path: str | os.PathLike, fps: int = 2) -> None:
+    def save_animation(self, path: str | os.PathLike, fps: int = 2, **kwargs) -> None:
         """Save this glyph's animation (`self.anim`) to a file.
 
         Thin wrapper around `cleopatra.animation.save_animation`; the output
-        format is determined by the file extension. GIF uses `PillowWriter`;
-        mov/avi/mp4 require FFmpeg to be installed.
+        format is determined by the file extension. GIF uses an optimising
+        Pillow writer; mov/avi/mp4 use FFmpeg (a system binary if present,
+        otherwise the one bundled with imageio-ffmpeg).
 
         Args:
             path: Output file path, as a `str` or `os.PathLike` (e.g. a
                 `pathlib.Path`). Extension determines format.
                 Supported: gif, mov, avi, mp4.
             fps: Frames per second. Default is 2.
+            **kwargs: Additional keyword arguments forwarded to
+                `cleopatra.animation.save_animation`, e.g. ``crf``, ``bitrate``,
+                ``codec``, ``preset``, ``pix_fmt``, ``dpi`` (ffmpeg formats) or
+                ``optimize`` and ``loop`` (GIF).
 
         Raises:
-            ValueError: If `animate()` has not been called yet, or if the
-                file format is not supported.
-            FileNotFoundError: If a video format is requested but FFmpeg is
-                not installed.
+            ValueError: If `animate()` has not been called yet, if the file
+                format is not supported, or if both ``crf`` and ``bitrate``
+                are given.
+            FileNotFoundError: If a video format is requested but neither a
+                system FFmpeg nor imageio-ffmpeg's bundled binary is found.
 
         Examples:
             - Check the supported video formats:
@@ -1113,4 +1119,4 @@ class Glyph:
 
                 ```
         """
-        _save_animation(self.anim, path, fps=fps)
+        _save_animation(self.anim, path, fps=fps, **kwargs)

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -870,6 +870,23 @@ class TestQualityControls:
         assert args.count("-pix_fmt") == 1, f"duplicate -pix_fmt emitted: {args}"
         assert args[args.index("-pix_fmt") + 1] == "rgb24", f"override lost: {args}"
 
+    def test_explicit_empty_pix_fmt_override_is_honoured(self, monkeypatch):
+        """An explicit (even empty) ``-pix_fmt`` in extra_args is authoritative.
+
+        Test scenario:
+            ``extra_args=["-pix_fmt", ""]`` yields an empty ``-pix_fmt`` value
+            rather than silently reverting to the default (a present flag+value
+            is treated as the caller's choice via an ``is not None`` sentinel).
+        """
+        ffmpeg = self._mock_ffmpeg(monkeypatch)
+
+        save_animation(
+            MagicMock(spec=FuncAnimation), "clip.mp4", extra_args=["-pix_fmt", ""]
+        )
+
+        args = ffmpeg.call_args.kwargs["extra_args"]
+        assert args[args.index("-pix_fmt") + 1] == "", f"empty override dropped: {args}"
+
     @pytest.mark.parametrize("bad", [["-vf"], ["-crf", "20", "-pix_fmt"]])
     def test_dangling_flag_in_extra_args_raises(self, bad, monkeypatch):
         """A trailing valueless ``-vf``/``-pix_fmt`` raises instead of corrupting args.

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -109,7 +109,7 @@ class TestSaveAnimation:
 
         result = save_animation(anim, "clip.gif", fps=7)
 
-        pillow.assert_called_once_with(fps=7)
+        pillow.assert_called_once_with(fps=7, optimize=True, loop=0)
         anim.save.assert_called_once_with("clip.gif", writer=pillow.return_value)
         assert result == "clip.gif", f"should return the path, got {result!r}"
 
@@ -138,7 +138,6 @@ class TestSaveAnimation:
 
         ffmpeg.assert_called_once_with(
             fps=5,
-            bitrate=1800,
             extra_args=["-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2", "-pix_fmt", "yuv420p"],
         )
         anim.save.assert_called_once_with(f"clip.{ext}", writer=ffmpeg.return_value)
@@ -180,7 +179,7 @@ class TestSaveAnimation:
         """
 
         anim = MagicMock(spec=FuncAnimation)
-        monkeypatch.setattr(anim_mod, "PillowWriter", MagicMock())
+        monkeypatch.setattr(anim_mod, "_OptimizedPillowWriter", MagicMock())
 
         result = save_animation(anim, "my.movie.v2.gif", fps=2)
 
@@ -199,7 +198,7 @@ class TestSaveAnimation:
 
         save_animation(MagicMock(spec=FuncAnimation), "clip.gif")
 
-        pillow.assert_called_once_with(fps=2)
+        pillow.assert_called_once_with(fps=2, optimize=True, loop=0)
 
 
 class TestToGif:
@@ -529,6 +528,128 @@ class TestOptimizedPillowWriter:
         assert captured.get("optimize") is False, (
             f"optimize flag not forwarded to Pillow: {captured}"
         )
+
+
+class TestQualityControls:
+    """Tests for the crf/bitrate/codec/preset/dpi/gif controls of `save_animation`."""
+
+    def _mock_ffmpeg(self, monkeypatch):
+        """Patch the ffmpeg writer and availability check; return the writer mock."""
+        ffmpeg = MagicMock(name="FFMpegWriter")
+        monkeypatch.setattr(anim_mod, "FFMpegWriter", ffmpeg)
+        monkeypatch.setattr(anim_mod, "_ensure_ffmpeg_available", lambda: None)
+        return ffmpeg
+
+    def test_crf_and_preset_reach_writer(self, monkeypatch):
+        """`crf` and `preset` are appended to the ffmpeg extra_args.
+
+        Test scenario:
+            Requesting ``crf=26, preset="slow"`` puts ``-crf 26 -preset slow``
+            at the tail of the writer's ``extra_args``.
+        """
+        ffmpeg = self._mock_ffmpeg(monkeypatch)
+
+        save_animation(MagicMock(spec=FuncAnimation), "clip.mp4", crf=26, preset="slow")
+
+        _, kwargs = ffmpeg.call_args
+        assert kwargs["extra_args"][-4:] == ["-crf", "26", "-preset", "slow"], (
+            f"crf/preset not in extra_args: {kwargs['extra_args']}"
+        )
+
+    def test_bitrate_and_codec_reach_writer(self, monkeypatch):
+        """`bitrate` and `codec` are forwarded to the FFMpegWriter constructor.
+
+        Test scenario:
+            ``bitrate=2500, codec="libx264"`` appear as constructor kwargs.
+        """
+        ffmpeg = self._mock_ffmpeg(monkeypatch)
+
+        save_animation(
+            MagicMock(spec=FuncAnimation), "clip.mp4", bitrate=2500, codec="libx264"
+        )
+
+        _, kwargs = ffmpeg.call_args
+        assert kwargs["bitrate"] == 2500, f"bitrate not forwarded: {kwargs}"
+        assert kwargs["codec"] == "libx264", f"codec not forwarded: {kwargs}"
+
+    def test_crf_and_bitrate_together_raises(self):
+        """Passing both `crf` and `bitrate` is rejected as competing modes.
+
+        Test scenario:
+            crf and bitrate are mutually exclusive rate-control modes, so
+            supplying both raises ``ValueError`` before any encode.
+        """
+        with pytest.raises(ValueError, match="either crf or bitrate"):
+            save_animation(
+                MagicMock(spec=FuncAnimation), "clip.mp4", crf=20, bitrate=2000
+            )
+
+    def test_dpi_forwarded_to_save(self, monkeypatch):
+        """`dpi` is forwarded to ``anim.save`` for the ffmpeg path.
+
+        Test scenario:
+            ``dpi=150`` reaches the underlying save call.
+        """
+        self._mock_ffmpeg(monkeypatch)
+        anim = MagicMock(spec=FuncAnimation)
+
+        save_animation(anim, "clip.mp4", dpi=150)
+
+        _, kwargs = anim.save.call_args
+        assert kwargs.get("dpi") == 150, f"dpi not forwarded: {kwargs}"
+
+    def test_dpi_omitted_when_none(self, monkeypatch):
+        """With no `dpi`, ``anim.save`` is called without a dpi kwarg.
+
+        Test scenario:
+            Backward compatibility — the default call must not inject a dpi.
+        """
+        self._mock_ffmpeg(monkeypatch)
+        anim = MagicMock(spec=FuncAnimation)
+
+        save_animation(anim, "clip.mp4")
+
+        _, kwargs = anim.save.call_args
+        assert "dpi" not in kwargs, f"dpi should be omitted when None: {kwargs}"
+
+    def test_caller_vf_is_merged_with_pad(self, monkeypatch):
+        """A caller ``-vf`` filter is merged into one chain, pad applied last.
+
+        Test scenario:
+            ``extra_args=["-vf", "scale=320:-1", "-tune", "film"]`` yields a
+            single ``-vf scale=320:-1,pad=...`` chain and preserves the other
+            flags.
+        """
+        ffmpeg = self._mock_ffmpeg(monkeypatch)
+
+        save_animation(
+            MagicMock(spec=FuncAnimation),
+            "clip.mp4",
+            extra_args=["-vf", "scale=320:-1", "-tune", "film"],
+        )
+
+        _, kwargs = ffmpeg.call_args
+        args = kwargs["extra_args"]
+        assert args[0] == "-vf", f"first flag should be -vf: {args}"
+        assert args[1] == "scale=320:-1,pad=ceil(iw/2)*2:ceil(ih/2)*2", (
+            f"caller filter not merged with pad: {args}"
+        )
+        assert args[-2:] == ["-tune", "film"], f"passthrough flags lost: {args}"
+
+    def test_gif_loop_and_optimize_forwarded(self, monkeypatch):
+        """GIF `optimize` and `loop` reach the `_OptimizedPillowWriter`.
+
+        Test scenario:
+            ``optimize=False, loop=3`` are passed through to the GIF writer.
+        """
+        pillow = MagicMock(name="_OptimizedPillowWriter")
+        monkeypatch.setattr(anim_mod, "_OptimizedPillowWriter", pillow)
+
+        save_animation(
+            MagicMock(spec=FuncAnimation), "clip.gif", optimize=False, loop=3
+        )
+
+        pillow.assert_called_once_with(fps=2, optimize=False, loop=3)
 
 
 class TestSupportedVideoFormat:

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -876,7 +876,7 @@ class TestSupportedVideoFormat:
     """Tests for the module-level `SUPPORTED_VIDEO_FORMAT` constant."""
 
     def test_contains_expected_formats(self):
-        """The constant lists exactly the four supported container formats."""
+        """The constant lists exactly the five supported container formats."""
         assert set(SUPPORTED_VIDEO_FORMAT) == {"gif", "mov", "avi", "mp4", "webp"}
 
     def test_is_single_source_of_truth(self):

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -393,6 +393,44 @@ class TestOddDimensionAutoPad:
         assert out.stat().st_size > 0, "odd-dimension mp4 is empty"
 
 
+class TestWebP:
+    """Tests for animated WebP output (issue #185)."""
+
+    def test_writes_animated_webp(self, tiny_anim, tmp_path):
+        """A ``.webp`` path is written by Pillow as a multi-frame WebP.
+
+        Test scenario:
+            WebP routes to the Pillow writer (not FFmpeg); the output has the
+            RIFF/WEBP magic bytes and more than one frame.
+        """
+        out = tmp_path / "out.webp"
+
+        returned = save_animation(tiny_anim, str(out), fps=3)
+
+        assert returned == str(out), "should return the written path"
+        raw = out.read_bytes()
+        assert raw[:4] == b"RIFF" and raw[8:12] == b"WEBP", "not a WebP file"
+        assert getattr(Image.open(out), "n_frames", 1) > 1, "WebP is not animated"
+
+    def test_webp_routes_to_pillow_writer(self, monkeypatch):
+        """WebP uses `_OptimizedPillowWriter`, never the FFmpeg writer.
+
+        Test scenario:
+            The ``.webp`` branch builds the Pillow writer with the loop/optimize
+            settings and does not touch ``FFMpegWriter``.
+        """
+        anim = MagicMock(spec=FuncAnimation)
+        pillow = MagicMock(name="_OptimizedPillowWriter")
+        ffmpeg = MagicMock(name="FFMpegWriter")
+        monkeypatch.setattr(anim_mod, "_OptimizedPillowWriter", pillow)
+        monkeypatch.setattr(anim_mod, "FFMpegWriter", ffmpeg)
+
+        save_animation(anim, "clip.webp", fps=4, loop=1)
+
+        pillow.assert_called_once_with(fps=4, optimize=True, loop=1)
+        ffmpeg.assert_not_called()
+
+
 class TestEnsureFfmpegAvailable:
     """Tests for `_ensure_ffmpeg_available` (ffmpeg binary resolution)."""
 
@@ -657,7 +695,7 @@ class TestSupportedVideoFormat:
 
     def test_contains_expected_formats(self):
         """The constant lists exactly the four supported container formats."""
-        assert set(SUPPORTED_VIDEO_FORMAT) == {"gif", "mov", "avi", "mp4"}
+        assert set(SUPPORTED_VIDEO_FORMAT) == {"gif", "mov", "avi", "mp4", "webp"}
 
     def test_is_single_source_of_truth(self):
         """`cleopatra.glyph` re-exports the same object, not a copy."""

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -572,6 +572,51 @@ class TestEnsureFfmpegAvailable:
             "resolver should fall back to the imageio-ffmpeg binary"
         )
 
+    def test_warns_when_overriding_explicit_path(self, monkeypatch):
+        """Overriding a non-default, unresolved ffmpeg_path emits a RuntimeWarning.
+
+        Test scenario:
+            A user who set an explicit path that no longer resolves should be
+            told their choice was replaced by the bundled binary, not have it
+            discarded silently.
+        """
+        import imageio_ffmpeg
+
+        monkeypatch.setitem(
+            mpl.rcParams, "animation.ffmpeg_path", "C:/nope/custom-ffmpeg.exe"
+        )
+        monkeypatch.setattr(anim_mod.os.path, "isfile", lambda path: False)
+        monkeypatch.setattr(anim_mod.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            imageio_ffmpeg, "get_ffmpeg_exe", lambda: "C:/bundled/ffmpeg.exe"
+        )
+
+        with pytest.warns(RuntimeWarning, match="custom-ffmpeg"):
+            anim_mod._ensure_ffmpeg_available()
+
+        assert mpl.rcParams["animation.ffmpeg_path"] == "C:/bundled/ffmpeg.exe", (
+            "should still fall back after warning"
+        )
+
+    def test_default_path_override_is_silent(self, monkeypatch, recwarn):
+        """Falling back from the default ``"ffmpeg"`` emits no warning.
+
+        Test scenario:
+            The unconfigured default is expected to be replaced quietly.
+        """
+        import imageio_ffmpeg
+
+        monkeypatch.setitem(mpl.rcParams, "animation.ffmpeg_path", "ffmpeg")
+        monkeypatch.setattr(anim_mod.os.path, "isfile", lambda path: False)
+        monkeypatch.setattr(anim_mod.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            imageio_ffmpeg, "get_ffmpeg_exe", lambda: "C:/bundled/ffmpeg.exe"
+        )
+
+        anim_mod._ensure_ffmpeg_available()
+
+        assert len(recwarn) == 0, f"default fallback should not warn: {list(recwarn)}"
+
     def test_raises_when_no_ffmpeg_available(self, monkeypatch):
         """When neither system ffmpeg nor imageio-ffmpeg exist, raise FileNotFoundError.
 

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -8,6 +8,7 @@ animation is rendered on the Agg backend (set globally via `MPLBACKEND`).
 from __future__ import annotations
 
 import builtins
+import doctest
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -886,3 +887,23 @@ class TestSupportedVideoFormat:
         assert glyph_constant is SUPPORTED_VIDEO_FORMAT, (
             "glyph should re-import the constant, not redefine it"
         )
+
+
+def test_module_doctests_execute():
+    """Run the module's docstring examples so they are exercised in CI.
+
+    Pytest is not configured with ``--doctest-modules``, so docstring examples in
+    ``src/`` would otherwise never run. This test executes them for
+    ``cleopatra.animation`` (including the ``to_bytes``/``to_mp4`` magic-byte checks
+    and the ``_build_ffmpeg_extra_args`` flag-merge examples) and fails if any
+    example's output no longer matches.
+    """
+    try:
+        results = doctest.testmod(anim_mod, verbose=False)
+    finally:
+        plt.close("all")
+    assert results.failed == 0, f"{results.failed} doctest example(s) failed in animation"
+    assert results.attempted > 0, (
+        "no doctest examples were collected from animation; the module's docstring "
+        "examples may have been moved or removed, silently dropping this coverage"
+    )

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -22,7 +22,9 @@ from cleopatra.animation import (
     SUPPORTED_VIDEO_FORMAT,
     embed_gif,
     save_animation,
+    to_bytes,
     to_gif,
+    to_mp4,
 )
 
 
@@ -268,6 +270,94 @@ class TestToGif:
 
         assert captured["fps"] == 9, f"fps not forwarded, got {captured.get('fps')!r}"
         assert data == b"GIF89a-data", f"unexpected bytes: {data!r}"
+
+
+class TestToBytes:
+    """Tests for `to_bytes` (in-memory render in any supported format)."""
+
+    def test_gif_bytes(self, tiny_anim):
+        """A ``fmt="gif"`` render returns GIF-magic bytes."""
+        data = to_bytes(tiny_anim, fmt="gif", fps=2)
+
+        assert data[:6] in (b"GIF87a", b"GIF89a"), f"not GIF bytes: {data[:6]!r}"
+
+    def test_webp_bytes(self, tiny_anim):
+        """A ``fmt="webp"`` render returns RIFF/WEBP bytes."""
+        data = to_bytes(tiny_anim, fmt="webp", fps=2)
+
+        assert data[:4] == b"RIFF" and data[8:12] == b"WEBP", "not WebP bytes"
+
+    def test_leading_dot_and_case_tolerated(self, tiny_anim):
+        """``fmt`` accepts a leading dot and mixed case (e.g. ``".GIF"``)."""
+        data = to_bytes(tiny_anim, fmt=".GIF")
+
+        assert data[:6] in (b"GIF87a", b"GIF89a"), "dot/case fmt not normalised"
+
+    def test_unsupported_format_raises(self):
+        """An unsupported ``fmt`` raises a clear ValueError before rendering."""
+        with pytest.raises(ValueError, match="not supported"):
+            to_bytes(MagicMock(spec=FuncAnimation), fmt="webm")
+
+    def test_forwards_kwargs_to_save_animation(self, tmp_path, monkeypatch):
+        """``fps`` and extra kwargs are forwarded to ``save_animation``.
+
+        Test scenario:
+            ``save_animation`` is patched to record what it receives; ``to_bytes``
+            must forward ``fps`` and any quality kwargs and return the written
+            bytes.
+        """
+        monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
+        captured = {}
+
+        def fake_save(anim, path, fps, **kwargs):
+            captured["fps"] = fps
+            captured.update(kwargs)
+            Path(path).write_bytes(b"payload")
+            return path
+
+        monkeypatch.setattr(anim_mod, "save_animation", fake_save)
+
+        data = to_bytes(MagicMock(spec=FuncAnimation), fmt="mp4", fps=6, crf=24)
+
+        assert captured == {"fps": 6, "crf": 24}, f"kwargs not forwarded: {captured}"
+        assert data == b"payload", f"unexpected bytes: {data!r}"
+
+    def test_leaves_no_temp_file(self, tiny_anim, tmp_path, monkeypatch):
+        """The temp file used for rendering is cleaned up afterwards."""
+        monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
+        before = set(tmp_path.iterdir())
+
+        to_bytes(tiny_anim, fmt="gif")
+
+        assert set(tmp_path.iterdir()) == before, "to_bytes left a temp file behind"
+
+
+class TestToMp4:
+    """Tests for `to_mp4`."""
+
+    def test_returns_mp4_bytes(self, tiny_anim):
+        """`to_mp4` returns a non-empty ISO base-media (MP4) payload."""
+        data = to_mp4(tiny_anim, fps=2)
+
+        assert data[4:8] == b"ftyp", f"not an MP4/ISO-BMFF payload: {data[:12]!r}"
+        assert len(data) > 0, "MP4 bytes are empty"
+
+    def test_delegates_to_to_bytes(self, monkeypatch):
+        """`to_mp4` delegates to `to_bytes` with ``fmt="mp4"`` and forwards kwargs.
+
+        Test scenario:
+            ``to_bytes`` is patched to return known bytes; ``to_mp4`` must call
+            it with ``fmt="mp4"``, the same ``fps``, and any extra kwargs, and
+            return its result.
+        """
+        spy = MagicMock(return_value=b"MP4-bytes")
+        monkeypatch.setattr(anim_mod, "to_bytes", spy)
+        anim = MagicMock(spec=FuncAnimation)
+
+        result = anim_mod.to_mp4(anim, fps=5, crf=20)
+
+        spy.assert_called_once_with(anim, fmt="mp4", fps=5, crf=20)
+        assert result == b"MP4-bytes", f"unexpected bytes: {result!r}"
 
 
 class TestEmbedGif:

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -758,6 +758,35 @@ class TestQualityControls:
                 MagicMock(spec=FuncAnimation), "clip.mp4", crf=20, bitrate=2000
             )
 
+    def test_crf_and_bitrate_together_raises_for_gif(self):
+        """crf+bitrate is rejected uniformly, even for the GIF/Pillow path.
+
+        Test scenario:
+            The mutual-exclusion check runs before the format branch, so a GIF
+            with both raises rather than silently ignoring them.
+        """
+        with pytest.raises(ValueError, match="either crf or bitrate"):
+            save_animation(
+                MagicMock(spec=FuncAnimation), "clip.gif", crf=20, bitrate=2000
+            )
+
+    def test_ffmpeg_only_kwargs_ignored_for_gif(self, monkeypatch):
+        """A lone ffmpeg-only kwarg is accepted (and ignored) on the GIF path.
+
+        Test scenario:
+            ``crf`` alone on a ``.gif`` does not raise and never touches the
+            FFmpeg writer — GIF goes through the Pillow writer.
+        """
+        pillow = MagicMock(name="_OptimizedPillowWriter")
+        ffmpeg = MagicMock(name="FFMpegWriter")
+        monkeypatch.setattr(anim_mod, "_OptimizedPillowWriter", pillow)
+        monkeypatch.setattr(anim_mod, "FFMpegWriter", ffmpeg)
+
+        save_animation(MagicMock(spec=FuncAnimation), "clip.gif", crf=20)
+
+        pillow.assert_called_once()
+        ffmpeg.assert_not_called()
+
     def test_dpi_forwarded_to_save(self, monkeypatch):
         """`dpi` is forwarded to ``anim.save`` for the ffmpeg path.
 

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -809,6 +809,53 @@ class TestQualityControls:
         )
         assert args[-2:] == ["-tune", "film"], f"passthrough flags lost: {args}"
 
+    def test_custom_pix_fmt_reaches_writer(self, monkeypatch):
+        """A custom ``pix_fmt`` param replaces the default in the writer args.
+
+        Test scenario:
+            ``pix_fmt="yuv444p"`` is emitted as the single ``-pix_fmt`` value.
+        """
+        ffmpeg = self._mock_ffmpeg(monkeypatch)
+
+        save_animation(MagicMock(spec=FuncAnimation), "clip.mp4", pix_fmt="yuv444p")
+
+        args = ffmpeg.call_args.kwargs["extra_args"]
+        assert args.count("-pix_fmt") == 1, f"expected one -pix_fmt: {args}"
+        assert args[args.index("-pix_fmt") + 1] == "yuv444p", f"pix_fmt wrong: {args}"
+
+    def test_caller_pix_fmt_in_extra_args_overrides_default(self, monkeypatch):
+        """A ``-pix_fmt`` in ``extra_args`` overrides the default without duplication.
+
+        Test scenario:
+            ``extra_args=["-pix_fmt", "rgb24"]`` yields exactly one ``-pix_fmt``
+            equal to ``rgb24`` (the forced ``yuv420p`` is not also emitted).
+        """
+        ffmpeg = self._mock_ffmpeg(monkeypatch)
+
+        save_animation(
+            MagicMock(spec=FuncAnimation), "clip.mp4", extra_args=["-pix_fmt", "rgb24"]
+        )
+
+        args = ffmpeg.call_args.kwargs["extra_args"]
+        assert args.count("-pix_fmt") == 1, f"duplicate -pix_fmt emitted: {args}"
+        assert args[args.index("-pix_fmt") + 1] == "rgb24", f"override lost: {args}"
+
+    @pytest.mark.parametrize("bad", [["-vf"], ["-crf", "20", "-pix_fmt"]])
+    def test_dangling_flag_in_extra_args_raises(self, bad, monkeypatch):
+        """A trailing valueless ``-vf``/``-pix_fmt`` raises instead of corrupting args.
+
+        Args:
+            bad: An ``extra_args`` list ending in a flag with no value.
+
+        Test scenario:
+            The merge helper rejects malformed input rather than appending a
+            dangling flag that would break the ffmpeg command line.
+        """
+        self._mock_ffmpeg(monkeypatch)
+
+        with pytest.raises(ValueError, match="must be followed by a value"):
+            save_animation(MagicMock(spec=FuncAnimation), "clip.mp4", extra_args=bad)
+
     def test_gif_loop_and_optimize_forwarded(self, monkeypatch):
         """GIF `optimize` and `loop` reach the `_OptimizedPillowWriter`.
 

--- a/tests/test_animation.py
+++ b/tests/test_animation.py
@@ -11,9 +11,11 @@ import builtins
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import pytest
 from matplotlib.animation import FuncAnimation
+from PIL import Image
 
 import cleopatra.animation as anim_mod
 from cleopatra.animation import (
@@ -93,17 +95,17 @@ class TestSaveAnimation:
             save_animation(anim, str(tmp_path / "movie.mp4"))
 
     def test_routes_gif_to_pillow_writer(self, monkeypatch):
-        """The `.gif` branch builds a `PillowWriter(fps=...)` and saves with it.
+        """The `.gif` branch builds an `_OptimizedPillowWriter` and saves with it.
 
         Test scenario:
-            A mocked animation and a patched `PillowWriter` confirm the GIF
-            branch is taken, the writer receives the requested ``fps``, and
-            ``anim.save`` is called once with that writer.
+            A mocked animation and a patched `_OptimizedPillowWriter` confirm
+            the GIF branch is taken, the writer receives the requested ``fps``,
+            and ``anim.save`` is called once with that writer.
         """
 
         anim = MagicMock(spec=FuncAnimation)
-        pillow = MagicMock(name="PillowWriter")
-        monkeypatch.setattr(anim_mod, "PillowWriter", pillow)
+        pillow = MagicMock(name="_OptimizedPillowWriter")
+        monkeypatch.setattr(anim_mod, "_OptimizedPillowWriter", pillow)
 
         result = save_animation(anim, "clip.gif", fps=7)
 
@@ -113,25 +115,32 @@ class TestSaveAnimation:
 
     @pytest.mark.parametrize("ext", ["mov", "avi", "mp4"])
     def test_routes_video_to_ffmpeg_writer(self, ext, monkeypatch):
-        """Non-GIF formats build an `FFMpegWriter(fps=, bitrate=1800)`.
+        """Non-GIF formats build an `FFMpegWriter` with the even-pad + pix_fmt args.
 
         Args:
             ext: A supported video container extension.
 
         Test scenario:
-            For each video extension the else-branch is taken, the writer is
-            constructed with the expected ``fps``/``bitrate``, ``anim.save``
-            is invoked with it, and the written path is returned. Exercises
-            the video success path without requiring FFmpeg.
+            For each video extension the else-branch is taken, ffmpeg
+            availability is resolved, the writer is constructed with the
+            expected ``fps``/``bitrate`` plus the odd-dimension pad filter and
+            an explicit ``yuv420p`` pixel format, ``anim.save`` is invoked with
+            it, and the written path is returned. Exercises the video success
+            path without requiring a real FFmpeg run.
         """
 
         anim = MagicMock(spec=FuncAnimation)
         ffmpeg = MagicMock(name="FFMpegWriter")
         monkeypatch.setattr(anim_mod, "FFMpegWriter", ffmpeg)
+        monkeypatch.setattr(anim_mod, "_ensure_ffmpeg_available", lambda: None)
 
         result = save_animation(anim, f"clip.{ext}", fps=5)
 
-        ffmpeg.assert_called_once_with(fps=5, bitrate=1800)
+        ffmpeg.assert_called_once_with(
+            fps=5,
+            bitrate=1800,
+            extra_args=["-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2", "-pix_fmt", "yuv420p"],
+        )
         anim.save.assert_called_once_with(f"clip.{ext}", writer=ffmpeg.return_value)
         assert result == f"clip.{ext}", f"should return the path, got {result!r}"
 
@@ -185,8 +194,8 @@ class TestSaveAnimation:
             Calling without ``fps`` builds ``PillowWriter(fps=2)``.
         """
 
-        pillow = MagicMock(name="PillowWriter")
-        monkeypatch.setattr(anim_mod, "PillowWriter", pillow)
+        pillow = MagicMock(name="_OptimizedPillowWriter")
+        monkeypatch.setattr(anim_mod, "_OptimizedPillowWriter", pillow)
 
         save_animation(MagicMock(spec=FuncAnimation), "clip.gif")
 
@@ -353,6 +362,172 @@ class TestEmbedGif:
 
         assert not hasattr(anim_mod, "Image"), (
             "IPython Image must not be imported at module load time"
+        )
+
+
+class TestOddDimensionAutoPad:
+    """Regression tests for odd pixel dimensions crashing mp4 export (issue #185)."""
+
+    def test_odd_dimension_mp4_encodes(self, tmp_path):
+        """A figure with odd pixel width/height encodes to mp4 without crashing.
+
+        Test scenario:
+            libx264 rejects odd dimensions, so a 335x335 px figure previously
+            died with "height not divisible by 2". The auto-pad video filter
+            must let it encode to a real, non-empty mp4.
+        """
+        fig = plt.figure(figsize=(3.35, 3.35), dpi=100)
+        ax = fig.add_subplot(111)
+        (line,) = ax.plot([0, 1], [0, 0])
+        width = int(round(fig.get_figwidth() * fig.dpi))
+        height = int(round(fig.get_figheight() * fig.dpi))
+        assert width % 2 == 1 and height % 2 == 1, (
+            f"fixture must be odd-sized to exercise the pad, got {width}x{height}"
+        )
+        anim = FuncAnimation(fig, lambda i: (line,), frames=2)
+        out = tmp_path / "odd.mp4"
+
+        save_animation(anim, str(out), fps=2)
+        plt.close(fig)
+
+        assert out.exists(), "odd-dimension mp4 was not written"
+        assert out.stat().st_size > 0, "odd-dimension mp4 is empty"
+
+
+class TestEnsureFfmpegAvailable:
+    """Tests for `_ensure_ffmpeg_available` (ffmpeg binary resolution)."""
+
+    def test_keeps_system_ffmpeg_on_path(self, monkeypatch):
+        """A resolvable ffmpeg on PATH is kept and imageio-ffmpeg is not consulted.
+
+        Test scenario:
+            When ``shutil.which`` finds the configured binary, the rcParam is
+            left untouched and the bundled-binary fallback is never invoked.
+        """
+        import imageio_ffmpeg
+
+        monkeypatch.setitem(mpl.rcParams, "animation.ffmpeg_path", "ffmpeg")
+        monkeypatch.setattr(anim_mod.shutil, "which", lambda name: "C:/bin/ffmpeg.exe")
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            imageio_ffmpeg,
+            "get_ffmpeg_exe",
+            lambda: calls.__setitem__("n", calls["n"] + 1),
+        )
+
+        anim_mod._ensure_ffmpeg_available()
+
+        assert mpl.rcParams["animation.ffmpeg_path"] == "ffmpeg", (
+            "system ffmpeg path should be left unchanged"
+        )
+        assert calls["n"] == 0, "bundled binary must not be consulted when PATH resolves"
+
+    def test_falls_back_to_bundled_binary(self, monkeypatch):
+        """With no system ffmpeg, the rcParam is pointed at imageio-ffmpeg's binary.
+
+        Test scenario:
+            When neither an absolute path nor a PATH lookup resolves, the
+            resolver sets ``animation.ffmpeg_path`` to
+            ``imageio_ffmpeg.get_ffmpeg_exe()`` so export still works.
+        """
+        import imageio_ffmpeg
+
+        monkeypatch.setitem(mpl.rcParams, "animation.ffmpeg_path", "ffmpeg")
+        monkeypatch.setattr(anim_mod.os.path, "isfile", lambda path: False)
+        monkeypatch.setattr(anim_mod.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            imageio_ffmpeg, "get_ffmpeg_exe", lambda: "C:/bundled/ffmpeg.exe"
+        )
+
+        anim_mod._ensure_ffmpeg_available()
+
+        assert mpl.rcParams["animation.ffmpeg_path"] == "C:/bundled/ffmpeg.exe", (
+            "resolver should fall back to the imageio-ffmpeg binary"
+        )
+
+    def test_raises_when_no_ffmpeg_available(self, monkeypatch):
+        """When neither system ffmpeg nor imageio-ffmpeg exist, raise FileNotFoundError.
+
+        Test scenario:
+            The bundled-binary import is forced to fail; the resolver must
+            surface an actionable ``FileNotFoundError`` naming imageio-ffmpeg.
+        """
+        monkeypatch.setattr(anim_mod.os.path, "isfile", lambda path: False)
+        monkeypatch.setattr(anim_mod.shutil, "which", lambda name: None)
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "imageio_ffmpeg":
+                raise ModuleNotFoundError("no imageio_ffmpeg", name="imageio_ffmpeg")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        with pytest.raises(FileNotFoundError, match="imageio-ffmpeg"):
+            anim_mod._ensure_ffmpeg_available()
+
+
+class TestOptimizedPillowWriter:
+    """Tests for `_OptimizedPillowWriter` (optimised, loopable GIF writer)."""
+
+    def test_stores_optimize_and_loop(self):
+        """The constructor records the ``optimize`` and ``loop`` settings.
+
+        Test scenario:
+            Non-default values are stored on the instance so ``finish`` can
+            forward them to Pillow.
+        """
+        writer = anim_mod._OptimizedPillowWriter(fps=5, optimize=False, loop=3)
+
+        assert writer._optimize is False, "optimize flag not stored"
+        assert writer._loop == 3, "loop count not stored"
+
+    def test_writes_gif_with_configured_loop(self, tiny_anim, tmp_path):
+        """A finite loop count is embedded in the written GIF's metadata.
+
+        Test scenario:
+            Saving with ``loop=2`` yields a GIF whose Pillow ``loop`` info is 2.
+        """
+        out = tmp_path / "loop.gif"
+        tiny_anim.save(str(out), writer=anim_mod._OptimizedPillowWriter(fps=3, loop=2))
+
+        assert Image.open(out).info.get("loop") == 2, "loop count not written to GIF"
+
+    def test_default_loops_forever(self, tiny_anim, tmp_path):
+        """The default ``loop=0`` produces a GIF that loops forever.
+
+        Test scenario:
+            Saving without a loop override yields Pillow's forever-loop marker
+            (``loop == 0``).
+        """
+        out = tmp_path / "forever.gif"
+        tiny_anim.save(str(out), writer=anim_mod._OptimizedPillowWriter(fps=3))
+
+        assert Image.open(out).info.get("loop") == 0, "default GIF should loop forever"
+
+    def test_forwards_optimize_flag_to_pillow(self, tiny_anim, tmp_path, monkeypatch):
+        """The ``optimize`` flag reaches ``PIL.Image.Image.save``.
+
+        Test scenario:
+            A save spy captures the keyword arguments Pillow receives; writing
+            with ``optimize=False`` must forward that exact value.
+        """
+        captured = {}
+        real_save = Image.Image.save
+
+        def spy_save(self, fp, *args, **kwargs):
+            captured.update(kwargs)
+            return real_save(self, fp, *args, **kwargs)
+
+        monkeypatch.setattr(Image.Image, "save", spy_save)
+        out = tmp_path / "opt.gif"
+
+        tiny_anim.save(
+            str(out), writer=anim_mod._OptimizedPillowWriter(fps=3, optimize=False)
+        )
+
+        assert captured.get("optimize") is False, (
+            f"optimize flag not forwarded to Pillow: {captured}"
         )
 
 

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -639,6 +639,26 @@ class TestSaveAnimation:
 
         spy.assert_called_once_with(anim, "movie.gif", fps=5)
 
+    def test_forwards_quality_kwargs(self, monkeypatch):
+        """Extra quality kwargs are forwarded verbatim to the free function.
+
+        Test scenario:
+            ``crf``/``preset``/``dpi`` passed to the wrapper must reach
+            ``cleopatra.animation.save_animation`` unchanged so callers get the
+            full quality-control surface through the glyph.
+        """
+        g = Glyph(default_options=_make_options())
+        anim = MagicMock(spec=FuncAnimation)
+        g._anim = anim
+
+        spy = MagicMock()
+        monkeypatch.setattr(glyph_mod, "_save_animation", spy)
+        g.save_animation("movie.mp4", fps=2, crf=24, preset="slow", dpi=150)
+
+        spy.assert_called_once_with(
+            anim, "movie.mp4", fps=2, crf=24, preset="slow", dpi=150
+        )
+
 
 class TestSupportedVideoFormat:
     """Tests for module-level SUPPORTED_VIDEO_FORMAT constant."""

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -665,7 +665,7 @@ class TestSupportedVideoFormat:
 
     def test_contains_expected_formats(self):
         """Test that all expected formats are present."""
-        expected = {"gif", "mov", "avi", "mp4"}
+        expected = {"gif", "mov", "avi", "mp4", "webp"}
         assert set(SUPPORTED_VIDEO_FORMAT) == expected, (
             f"Expected {expected}, got {set(SUPPORTED_VIDEO_FORMAT)}"
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11, <4"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -362,8 +362,8 @@ name = "cleopatra"
 version = "0.21.0"
 source = { editable = "." }
 dependencies = [
-    { name = "ffmpeg-python" },
     { name = "hpc-utils" },
+    { name = "imageio-ffmpeg" },
     { name = "matplotlib" },
     { name = "numpy" },
 ]
@@ -410,8 +410,8 @@ notebook = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ffmpeg-python" },
     { name = "hpc-utils", specifier = ">=0.1.4" },
+    { name = "imageio-ffmpeg", specifier = ">=0.4.9" },
     { name = "matplotlib", specifier = ">=3.9" },
     { name = "mercantile", marker = "extra == 'tiles'", specifier = ">=1.2.1" },
     { name = "numpy", specifier = ">=2.0.0" },
@@ -811,18 +811,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ffmpeg-python"
-version = "0.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "future" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/5e/d5f9105d59c1325759d838af4e973695081fbbc97182baf73afc78dec266/ffmpeg-python-0.2.0.tar.gz", hash = "sha256:65225db34627c578ef0e11c8b1eb528bb35e024752f6f10b78c011f6f64c4127", size = 21543, upload-time = "2019-07-06T00:19:08.989Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl", hash = "sha256:ac441a0404e053f8b6a1113a77c0f452f1cfc62f6344a769475ffdc0f56c23c5", size = 25024, upload-time = "2019-07-06T00:19:07.215Z" },
-]
-
-[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -887,15 +875,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
-]
-
-[[package]]
-name = "future"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/b2/4140c69c6a66432916b26158687e821ba631a4c9273c474343badf84d3ba/future-1.0.0.tar.gz", hash = "sha256:bd2968309307861edae1458a4f8a4f3598c03be43b97521076aebf5d94c07b05", size = 1228490, upload-time = "2024-02-21T11:52:38.461Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/71/ae30dadffc90b9006d77af76b393cb9dfbfc9629f339fc1574a1c52e6806/future-1.0.0-py3-none-any.whl", hash = "sha256:929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216", size = 491326, upload-time = "2024-02-21T11:52:35.956Z" },
 ]
 
 [[package]]
@@ -996,6 +975,20 @@ wheels = [
 ]
 
 [[package]]
+name = "imageio-ffmpeg"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/bd/c3343c721f2a1b0c9fc71c1aebf1966a3b7f08c2eea8ed5437a2865611d6/imageio_ffmpeg-0.6.0.tar.gz", hash = "sha256:e2556bed8e005564a9f925bb7afa4002d82770d6b08825078b7697ab88ba1755", size = 25210, upload-time = "2025-01-16T21:34:32.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/58/87ef68ac83f4c7690961bce288fd8e382bc5f1513860fc7f90a9c1c1c6bf/imageio_ffmpeg-0.6.0-py3-none-macosx_10_9_intel.macosx_10_9_x86_64.whl", hash = "sha256:9d2baaf867088508d4a3458e61eeb30e945c4ad8016025545f66c4b5aaef0a61", size = 24932969, upload-time = "2025-01-16T21:34:20.464Z" },
+    { url = "https://files.pythonhosted.org/packages/40/5c/f3d8a657d362cc93b81aab8feda487317da5b5d31c0e1fdfd5e986e55d17/imageio_ffmpeg-0.6.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b1ae3173414b5fc5f538a726c4e48ea97edc0d2cdc11f103afee655c463fa742", size = 21113891, upload-time = "2025-01-16T21:34:00.277Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e7/1925bfbc563c39c1d2e82501d8372734a5c725e53ac3b31b4c2d081e895b/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1d47bebd83d2c5fc770720d211855f208af8a596c82d17730aa51e815cdee6dc", size = 25632706, upload-time = "2025-01-16T21:33:53.475Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/2d/43c8522a2038e9d0e7dbdf3a61195ecc31ca576fb1527a528c877e87d973/imageio_ffmpeg-0.6.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c7e46fcec401dd990405049d2e2f475e2b397779df2519b544b8aab515195282", size = 29498237, upload-time = "2025-01-16T21:34:13.726Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/13/59da54728351883c3c1d9fca1710ab8eee82c7beba585df8f25ca925f08f/imageio_ffmpeg-0.6.0-py3-none-win32.whl", hash = "sha256:196faa79366b4a82f95c0f4053191d2013f4714a715780f0ad2a68ff37483cc2", size = 19652251, upload-time = "2025-01-16T21:34:06.812Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c6/fa760e12a2483469e2bf5058c5faff664acf66cadb4df2ad6205b016a73d/imageio_ffmpeg-0.6.0-py3-none-win_amd64.whl", hash = "sha256:02fa47c83703c37df6bfe4896aab339013f62bf02c5ebf2dce6da56af04ffc0a", size = 31246824, upload-time = "2025-01-16T21:34:28.6Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1039,17 +1032,17 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.12'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
+    { name = "jedi", marker = "python_full_version < '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
+    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
+    { name = "pygments", marker = "python_full_version < '3.12'" },
+    { name = "stack-data", marker = "python_full_version < '3.12'" },
+    { name = "traitlets", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -1069,16 +1062,16 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.12'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
+    { name = "jedi", marker = "python_full_version >= '3.12'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
+    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "stack-data", marker = "python_full_version >= '3.12'" },
+    { name = "traitlets", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -2486,7 +2479,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
# Description

Reworks `cleopatra.animation.save_animation` (and the `Glyph.save_animation` wrapper) from a minimal two-line
writer into a configurable, robust exporter, resolving the rough edges surfaced in #185:

- **Out-of-the-box ffmpeg.** Replaces the declared-but-unused `ffmpeg-python` dependency with `imageio-ffmpeg`,
  and falls back to its bundled static binary when no system ffmpeg is on `PATH`, so MP4/MOV/AVI export works with
  no separate install. A system ffmpeg still takes precedence; a warning is emitted before overriding an explicit,
  now-missing `animation.ffmpeg_path`.
- **Odd-dimension safety + universal playback.** Auto-pads odd frame dimensions (`-vf pad=...`) so libx264 no
  longer crashes on odd-sized figures, and sets `pix_fmt=yuv420p` explicitly.
- **Quality controls.** Adds keyword-only `crf`, `bitrate`, `codec`, `preset`, `pix_fmt`, `dpi`, `optimize`,
  `loop`, and `extra_args`, with `crf`/`bitrate` mutually exclusive and a caller `-vf`/`-pix_fmt` merged into the
  built arguments.
- **New output surface.** Adds animated WebP output and optimise/loop-configurable GIF output via an
  `_OptimizedPillowWriter`, plus in-memory `to_bytes` / `to_mp4` helpers (`to_gif` now delegates to `to_bytes`).
  These new controls are forwarded through `Glyph.save_animation`, so `ArrayGlyph`/`MeshGlyph` inherit them.

**Behavior note (non-breaking API):** the public signature stays backward-compatible (`fps` remains third-
positional; everything new is keyword-only). The previously hardcoded `bitrate=1800` default is dropped in favour
of libx264's constant-quality default, so existing 3-arg MP4 calls still work but encode smaller, better files.

**Dependencies:** adds `imageio-ffmpeg` (core dep — the deliberate SCOPE.md exception, since it bundles the ffmpeg
binary that pure-Python packaging cannot); removes `ffmpeg-python`. `uv.lock` regenerated to match.

# Issues

- Closes #185

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Ran against the external uv env (`C:\python-environments\uv\cleopatra`) with `MPLBACKEND=Agg`.

- [x] Full test suite green: `pytest -q` → **1193 passed**.
- [x] `cleopatra.animation` at **100% line + branch** coverage
      (`--cov=cleopatra.animation --cov-branch`).
- [x] Real-encode checks: 335×335 (odd) figure now encodes to MP4; animated WebP round-trips (multi-frame,
      RIFF/WEBP, honours `loop`); `crf`/`bitrate`/`preset` reach the writer; `pix_fmt=yuv420p` confirmed via
      ffprobe.
- [x] Module doctests exercised in CI via a new `doctest.testmod` runner test.

Test configuration: Windows 11, Python 3.12, matplotlib 3.10.8, Pillow, imageio-ffmpeg 0.6.0.

# Checklist:

- [ ] updated version number in pyproject.toml — release commits are handled separately
- [ ] added changes to History.rst — N/A; the changelog is auto-generated in CI by commitizen from the
      Conventional Commit history
- [ ] updated the latest version in README file — N/A
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
