### PR TITLE
feat(glyphs): data-style preset option across ArrayGlyph, MeshGlyph, KDEGlyph

### DIFF
--- a/docs/notebooks/array_glyph/array_glyph_examples.ipynb
+++ b/docs/notebooks/array_glyph/array_glyph_examples.ipynb
@@ -837,6 +837,51 @@
   },
   {
    "cell_type": "markdown",
+   "id": "553e74cd",
+   "metadata": {},
+   "source": [
+    "## 10. Data-style presets via the `style=` option\n",
+    "\n",
+    "Instead of choosing a colormap and scale by hand, pass `style=` a named preset from `cleopatra.colors.DATA_STYLES`. The preset owns the colormap, the norm (linear / log / symlog / diverging), the transparent nodata, any value-linked opacity, and — for categorical presets — a discrete legend. The same `style=` option works on `MeshGlyph` and `KDEGlyph` too, and composes with `hillshade`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5966fab6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# A DEM styled by the 'topography' preset, and the same DEM relief-shaded (style + hillshade compose)\n",
+    "ArrayGlyph(dem, style='topography').plot(title=\"style='topography'\")\n",
+    "ArrayGlyph(dem, style='topography', hillshade={'vert_exag': 8}).plot(title=\"style='topography' + hillshade\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e60d331",
+   "metadata": {},
+   "source": [
+    "Hydrology rasters have dedicated presets: `flow_accumulation` (symlog Blues, low cells fade) and the categorical `flow_direction_d8` (the eight D8 class codes with a discrete legend)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "629e6851",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "# a synthetic flow-accumulation field and a D8 direction raster\n",
+    "accum = np.abs(np.random.default_rng(0).normal(size=(80, 100))).cumsum(axis=1) * 80\n",
+    "d8 = np.random.default_rng(1).choice([1, 2, 4, 8, 16, 32, 64, 128], size=(40, 40)).astype(float)\n",
+    "ArrayGlyph(accum, style='flow_accumulation').plot(title=\"style='flow_accumulation'\")\n",
+    "ArrayGlyph(d8, style='flow_direction_d8').plot(title=\"style='flow_direction_d8'\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "45",
    "metadata": {},
    "source": [

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -3195,10 +3195,12 @@ class ArrayGlyph(GeoMixin, Glyph):
                 self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
             # Named data-style preset for animation: continuous presets drive
-            # the frames through the preset's cmap + norm (resolved across the
-            # whole stack so the colour range is stable across frames), and the
-            # colorbar is refreshed to match. Categorical presets need per-frame
-            # masking + a discrete legend and are not animated yet -- use plot().
+            # the frames through the preset's cmap + norm and refresh the
+            # colorbar to match. The norm range is resolved across the eager
+            # stack so it is stable across frames; under a lazy `data_getter`
+            # only frame 0 is available, so its range is used (later frames that
+            # exceed it are clipped). Categorical presets need per-frame masking
+            # + a discrete legend and are not animated yet -- use plot().
             style = self.default_options.get("style")
             if style is not None:
                 layer = self._resolve_style_layer(style)

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -3191,12 +3191,27 @@ class ArrayGlyph(GeoMixin, Glyph):
                         "categorical data-style presets are not supported in "
                         "animate yet; use plot() for categorical styles"
                     )
+                # A `style` takes precedence over `hillshade` (aligned with
+                # plot()); warn and drop the relief rather than compose it.
+                if resolve_hillshade(self.default_options.get("hillshade")) is not None:
+                    warnings.warn(
+                        "hillshade is not composed with a data-style preset yet; "
+                        "the 'style' preset is applied and 'hillshade' is ignored.",
+                        stacklevel=2,
+                    )
                 stack = array if data_getter is None else frame_0
                 # Cast to float before filling (integer masked arrays reject a
                 # NaN fill value -- see `_plot_with_style`).
                 style_norm, _, _ = _resolve_style_norm(
                     np.asarray(ma.filled(ma.asarray(stack).astype(float), np.nan), dtype=float),
                     cfg,
+                )
+                # The initial render may have baked an RGBA hillshade into `im`;
+                # reset it to a scalar frame so the colorbar can autoscale over
+                # scalar data -- applying a scale norm (Log/SymLog) to an RGBA
+                # array raises "Input values must have shape (N, 1) or (1,)".
+                im.set_data(
+                    np.asarray(ma.filled(ma.asarray(frame_0).astype(float), np.nan), dtype=float)
                 )
                 im.set_cmap(cfg["cmap"])
                 im.set_norm(style_norm)
@@ -3289,9 +3304,12 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         # Relief-shade each frame when `hillshade` is set: the initial render
         # shaded `frame_0`, but `init`/`animate_a` overwrite `im` with the raw
-        # scalar frame, so shading is re-applied per frame through this wrapper
-        # (using the artist's live cmap/norm, so it composes with a `style`).
+        # scalar frame, so shading is re-applied per frame through this wrapper.
+        # A `style` preset takes precedence over hillshade (aligned with plot()),
+        # so shading is disabled when a style is active.
         hillshade_opts = resolve_hillshade(self.default_options.get("hillshade"))
+        if self.default_options.get("style") is not None:
+            hillshade_opts = None
 
         def _display_frame(frame):
             """Return the frame's image data, relief-shaded when requested."""

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -35,16 +35,23 @@ from hpc.indexing import get_indices2
 from matplotlib.animation import FuncAnimation
 from matplotlib.axes import Axes
 from matplotlib.colorbar import Colorbar
-from matplotlib.colors import Colormap, Normalize
+from matplotlib.colors import BoundaryNorm, Colormap, ListedColormap, Normalize
 from matplotlib.figure import Figure
 from PIL import Image
 
-from cleopatra.colors import DATA_STYLES, alpha_rgba, apply_data_style, resolve_style_norm
+from cleopatra.colors import (
+    DATA_STYLES,
+    alpha_rgba,
+    apply_data_style,
+    category_boundaries,
+    resolve_style_norm,
+)
 from cleopatra.geo import GeoMixin
 from cleopatra.hillshade import resolve_hillshade, shade_grid, shade_rgb
 from cleopatra.glyph import Glyph, _root_figure
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale  # re-exported for convenience  # noqa: F401
+from cleopatra.styles import disjoint_legend
 
 ARRAY_DEFAULT_OPTIONS = {
     "vmin": None,
@@ -2997,14 +3004,15 @@ class ArrayGlyph(GeoMixin, Glyph):
                 Data-style preset / relief options:
                     style : str, optional
                         Name of a `cleopatra.colors.DATA_STYLES` preset applied
-                        to every frame through the preset's cmap + norm (valid
-                        names: `sorted(cleopatra.colors.DATA_STYLES)`). Only
-                        **continuous** single-layer presets are supported in
-                        `animate`; a categorical preset raises
-                        `NotImplementedError`. Under a lazy `data_getter` the
-                        colour range is taken from frame 0. Takes precedence over
-                        `hillshade` (the preset wins; hillshade is warned and
-                        dropped). By default None.
+                        to every frame (valid names:
+                        `sorted(cleopatra.colors.DATA_STYLES)`). Continuous
+                        presets drive the frames through the preset's cmap +
+                        norm + value-linked opacity; categorical presets remap
+                        the class codes through a discrete colormap and draw a
+                        legend (no colorbar). Under a lazy `data_getter` the
+                        continuous colour range is taken from frame 0. Takes
+                        precedence over `hillshade` (the preset wins; hillshade
+                        is warned and dropped). By default None.
                     hillshade : bool or dict, optional
                         Relief-shade every frame of a regular-grid DEM (same
                         options as `plot`). Not composed with `style`. By
@@ -3247,59 +3255,79 @@ class ArrayGlyph(GeoMixin, Glyph):
             if self.default_options["add_colorbar"]:
                 self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
-            # Named data-style preset for animation: continuous presets drive
-            # the frames through the preset's cmap + norm and refresh the
-            # colorbar to match. The norm range is resolved across the eager
-            # stack so it is stable across frames; under a lazy `data_getter`
-            # only frame 0 is available, so its range is used (later frames that
-            # exceed it are clipped). Categorical presets need per-frame masking
-            # + a discrete legend and are not animated yet -- use plot().
+            # Named data-style preset for animation. `_display_frame` bakes each
+            # frame's RGBA from `style_render`; continuous presets reproduce the
+            # cmap/norm + value-linked opacity, categorical presets remap class
+            # codes through a ListedColormap/BoundaryNorm with a discrete legend.
+            frame_0_scalar = np.asarray(
+                ma.filled(ma.asarray(frame_0).astype(float), np.nan), dtype=float
+            )
             style = self.default_options.get("style")
             if style is not None:
                 layer = self._resolve_style_layer(style)
                 cfg = DATA_STYLES[style][layer]
-                if cfg.get("categories") is not None:
-                    raise NotImplementedError(
-                        "categorical data-style presets are not supported in "
-                        "animate yet; use plot() for categorical styles"
-                    )
-                # A `style` takes precedence over `hillshade` (aligned with
-                # plot()); warn and drop the relief rather than compose it.
+                # A `style` takes precedence over `hillshade`; warn and drop the
+                # relief rather than compose it in animate.
                 if resolve_hillshade(self.default_options.get("hillshade")) is not None:
                     warnings.warn(
-                        "hillshade is not composed with a data-style preset yet; "
-                        "the 'style' preset is applied and 'hillshade' is ignored.",
+                        "hillshade is not composed with a data-style preset in "
+                        "animate; the 'style' preset is applied and hillshade "
+                        "ignored.",
                         stacklevel=2,
                     )
-                stack = array if data_getter is None else frame_0
-                # Cast to float before filling (integer masked arrays reject a
-                # NaN fill value -- see `_plot_with_style`).
-                style_norm, _, _ = resolve_style_norm(
-                    np.asarray(ma.filled(ma.asarray(stack).astype(float), np.nan), dtype=float),
-                    cfg,
-                )
-                # The initial render may have baked an RGBA hillshade into `im`;
-                # reset it to a scalar frame so the colorbar can autoscale over
-                # scalar data -- applying a scale norm (Log/SymLog) to an RGBA
-                # array raises "Input values must have shape (N, 1) or (1,)".
-                im.set_data(
-                    np.asarray(ma.filled(ma.asarray(frame_0).astype(float), np.nan), dtype=float)
-                )
-                im.set_cmap(cfg["cmap"])
-                im.set_norm(style_norm)
-                if self.cbar is not None:
-                    self.cbar.update_normal(im)
-                # Reproduce apply_data_style's per-frame RGBA (colour + the
-                # preset's value-linked opacity) so animate matches plot; the
-                # colorbar stays driven off the scalar norm/cmap installed above.
-                alpha_vmin = cfg.get("alpha_vmin")
-                alpha_vmax = cfg.get("alpha_vmax")
-                style_alpha_norm = (
-                    Normalize(vmin=alpha_vmin, vmax=alpha_vmax)
-                    if alpha_vmin is not None or alpha_vmax is not None
-                    else None
-                )
-                style_render = (cfg["cmap"], style_norm, style_alpha_norm, cfg.get("alpha"))
+                categories = cfg.get("categories")
+                if categories is not None:
+                    # Categorical: a discrete legend replaces the colorbar and is
+                    # drawn once; frames only remap the class codes.
+                    cats = sorted(categories, key=lambda c: c[0])
+                    cat_values = np.array([float(c[0]) for c in cats])
+                    cat_colors = [c[1] for c in cats]
+                    cat_labels = [c[2] for c in cats]
+                    cat_cmap = ListedColormap(cat_colors)
+                    cat_norm = BoundaryNorm(
+                        category_boundaries(list(cat_values)), len(cat_colors)
+                    )
+                    if self.cbar is not None:
+                        self.cbar.remove()
+                        self.cbar = None
+                    im.set_data(frame_0_scalar)
+                    im.set_cmap(cat_cmap)
+                    im.set_norm(cat_norm)
+                    if self.default_options["add_colorbar"]:
+                        disjoint_legend(
+                            ax, cat_colors, cat_labels, title=cfg["label"],
+                            loc="upper right",
+                        )
+                    style_render = ("categorical", cat_cmap, cat_norm, cat_values)
+                else:
+                    # Continuous: cmap + norm, range resolved over the eager
+                    # stack (frame 0 only under a lazy data_getter), colorbar
+                    # refreshed to match.
+                    stack = array if data_getter is None else frame_0
+                    style_norm, _, _ = resolve_style_norm(
+                        np.asarray(ma.filled(ma.asarray(stack).astype(float), np.nan), dtype=float),
+                        cfg,
+                    )
+                    # The initial render may have baked an RGBA hillshade into
+                    # `im`; reset it to a scalar frame so the colorbar autoscales
+                    # over scalar data -- a scale norm (Log/SymLog) applied to an
+                    # RGBA array raises "Input values must have shape (N, 1)...".
+                    im.set_data(frame_0_scalar)
+                    im.set_cmap(cfg["cmap"])
+                    im.set_norm(style_norm)
+                    if self.cbar is not None:
+                        self.cbar.update_normal(im)
+                    alpha_vmin = cfg.get("alpha_vmin")
+                    alpha_vmax = cfg.get("alpha_vmax")
+                    style_alpha_norm = (
+                        Normalize(vmin=alpha_vmin, vmax=alpha_vmax)
+                        if alpha_vmin is not None or alpha_vmax is not None
+                        else None
+                    )
+                    style_render = (
+                        "continuous", cfg["cmap"], style_norm, style_alpha_norm,
+                        cfg.get("alpha"),
+                    )
 
         ax.set_title(
             self.default_options["title"], fontsize=self.default_options["title_size"]
@@ -3397,13 +3425,21 @@ class ArrayGlyph(GeoMixin, Glyph):
         def _display_frame(frame):
             """Return the frame's image data: preset RGBA, relief-shaded, or raw."""
             if style_render is not None:
-                # Bake the preset RGBA (colour + value-linked opacity) so animate
-                # matches plot()'s apply_data_style rendering.
-                cmap_, norm_, alpha_norm_, const_ = style_render
-                return alpha_rgba(
-                    np.asarray(ma.filled(ma.asarray(frame).astype(float), np.nan), dtype=float),
-                    cmap_, norm_, alpha_norm_, const_,
+                filled = np.asarray(
+                    ma.filled(ma.asarray(frame).astype(float), np.nan), dtype=float
                 )
+                if style_render[0] == "categorical":
+                    # Remap only the declared class codes; everything else
+                    # (nodata, out-of-range) is drawn transparent.
+                    _, cat_cmap, cat_norm, cat_values = style_render
+                    masked = np.where(np.isin(filled, cat_values), filled, np.nan)
+                    rgba = np.asarray(cat_cmap(cat_norm(masked)), dtype=float)
+                    rgba[~np.isfinite(masked)] = 0.0
+                    return rgba
+                # Continuous: bake the preset RGBA (colour + value-linked
+                # opacity) so animate matches plot()'s apply_data_style output.
+                _, cmap_, norm_, alpha_norm_, const_ = style_render
+                return alpha_rgba(filled, cmap_, norm_, alpha_norm_, const_)
             if hillshade_opts is not None and not rgb_frames:
                 # Cast before filling: integer masked frames reject a NaN fill.
                 elevation = np.asarray(ma.filled(ma.asarray(frame).astype(float), np.nan), dtype=float)

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1608,6 +1608,13 @@ class ArrayGlyph(GeoMixin, Glyph):
         # Presets present their scale via a swatch / categorical legend, not a
         # matplotlib colorbar.
         self.cbar = None
+        # Match the imshow path: with no extent (and no curvilinear coords) hide
+        # the pixel-index tick labels.
+        if self.extent is None and coords is None:
+            self.ax.set_xticklabels([])
+            self.ax.set_yticklabels([])
+            self.ax.set_xticks([])
+            self.ax.set_yticks([])
         self.ax.set_title(
             self.default_options["title"], fontsize=self.default_options["title_size"]
         )

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -2396,8 +2396,25 @@ class ArrayGlyph(GeoMixin, Glyph):
         # to `cleopatra.colors.apply_data_style`, so the full preset semantics
         # (log/symlog norms, transparent nodata, disjoint categorical legend)
         # are reproduced rather than lossily mapped onto `color_scale`.
-        if self.default_options.get("style") is not None and not self.rgb:
-            return self._plot_with_style(self.default_options["style"])
+        style = self.default_options.get("style")
+        if style is not None:
+            if self.rgb:
+                warnings.warn(
+                    "data-style presets do not apply to RGB arrays; 'style' is "
+                    "ignored and the RGB image is drawn as-is.",
+                    stacklevel=2,
+                )
+            else:
+                # The preset owns the colour mapping and draws its own legend, so
+                # point / cell-value overlays are bypassed -- make that visible
+                # rather than dropping them silently.
+                if points is not None or self.default_options.get("display_cell_value"):
+                    warnings.warn(
+                        "data-style presets bypass point and cell-value overlays; "
+                        "'points' and 'display_cell_value' are ignored with 'style'.",
+                        stacklevel=2,
+                    )
+                return self._plot_with_style(style)
 
         if self.rgb:
             self.im = ax.imshow(arr, extent=self.extent)

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -44,6 +44,7 @@ from cleopatra.colors import (
     alpha_rgba,
     apply_data_style,
     category_boundaries,
+    resolve_single_layer_style,
     resolve_style_norm,
 )
 from cleopatra.geo import GeoMixin
@@ -1545,19 +1546,7 @@ class ArrayGlyph(GeoMixin, Glyph):
             ValueError: If `style` is unknown, or names a multi-layer preset
                 (which cannot be applied to a single raster band).
         """
-        if style not in DATA_STYLES:
-            raise ValueError(
-                f"unknown data style {style!r}; valid styles are "
-                f"{sorted(DATA_STYLES)}"
-            )
-        layers = DATA_STYLES[style]
-        if len(layers) != 1:
-            raise ValueError(
-                f"data style {style!r} defines multiple layers {sorted(layers)}; "
-                "ArrayGlyph applies single-layer presets to a single band. Use "
-                "cleopatra.colors.apply_data_style directly for multi-layer styles."
-            )
-        return next(iter(layers))
+        return resolve_single_layer_style(style)[0]
 
     def _plot_with_style(self, style: str) -> tuple[Figure, Axes]:
         """Render the array with a named `DATA_STYLES` preset.

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1574,20 +1574,24 @@ class ArrayGlyph(GeoMixin, Glyph):
                 "the 'style' preset is applied and 'hillshade' is ignored.",
                 stacklevel=2,
             )
+        if self._coords is not None:
+            # apply_data_style's curvilinear path forces shading="flat", which
+            # needs cell-EDGE coordinates, but ArrayGlyph stores cell CENTRES.
+            # Fail with a clear cleopatra message instead of a downstream
+            # matplotlib "Dimensions of C should be one smaller than X/Y" error.
+            raise ValueError(
+                "data-style presets do not support curvilinear 'coords' yet: "
+                "apply_data_style needs cell-edge coordinates, but ArrayGlyph "
+                "stores cell centres. Plot without coords, or call "
+                "cleopatra.colors.apply_data_style directly with edge coordinates."
+            )
         layer = self._resolve_style_layer(style)
         data = np.asarray(ma.filled(self.arr, np.nan), dtype=float)
         legend = bool(self.default_options.get("add_colorbar", True))
-        coords = self._coords
-        if coords is not None:
-            images = apply_data_style(
-                self.ax, {layer: data}, style=style, x=coords[0], y=coords[1],
-                legend=legend,
-            )
-        else:
-            render_kwargs = {"extent": self.extent} if self.extent is not None else {}
-            images = apply_data_style(
-                self.ax, {layer: data}, style=style, legend=legend, **render_kwargs
-            )
+        render_kwargs = {"extent": self.extent} if self.extent is not None else {}
+        images = apply_data_style(
+            self.ax, {layer: data}, style=style, legend=legend, **render_kwargs
+        )
         self.im = images[layer]
         # Presets present their scale via a swatch / categorical legend, not a
         # matplotlib colorbar.

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -3270,6 +3270,18 @@ class ArrayGlyph(GeoMixin, Glyph):
             )
             style = self.default_options.get("style")
             if style is not None:
+                # The preset owns the colour mapping and draws its own legend, so
+                # point / cell-value overlays are bypassed -- warn (mirroring
+                # plot()) rather than drawing them silently over the preset.
+                if points is not None or show_cell_value:
+                    warnings.warn(
+                        "data-style presets bypass point and cell-value "
+                        "overlays; 'points' and 'display_cell_value' are ignored "
+                        "with 'style'.",
+                        stacklevel=2,
+                    )
+                    points = None
+                    show_cell_value = False
                 layer = self._resolve_style_layer(style)
                 cfg = DATA_STYLES[style][layer]
                 hillshade_active = (

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -41,7 +41,7 @@ from PIL import Image
 
 from cleopatra.colors import DATA_STYLES, alpha_rgba, apply_data_style, resolve_style_norm
 from cleopatra.geo import GeoMixin
-from cleopatra.hillshade import resolve_hillshade, shade_grid
+from cleopatra.hillshade import resolve_hillshade, shade_grid, shade_rgb
 from cleopatra.glyph import Glyph, _root_figure
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale  # re-exported for convenience  # noqa: F401
@@ -1568,27 +1568,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         Returns:
             tuple[Figure, Axes]: The figure and axes drawn on.
         """
-        # Validate the style name first, then the coords contract, and only
-        # warn about hillshade on the path that actually proceeds -- so an
-        # aborting call reports the right error and emits no spurious warning.
         layer = self._resolve_style_layer(style)
-        if self._coords is not None:
-            # apply_data_style's curvilinear path forces shading="flat", which
-            # needs cell-EDGE coordinates, but ArrayGlyph stores cell CENTRES.
-            # Fail with a clear cleopatra message instead of a downstream
-            # matplotlib "Dimensions of C should be one smaller than X/Y" error.
-            raise ValueError(
-                "data-style presets do not support curvilinear 'coords' yet: "
-                "apply_data_style needs cell-edge coordinates, but ArrayGlyph "
-                "stores cell centres. Plot without coords, or call "
-                "cleopatra.colors.apply_data_style directly with edge coordinates."
-            )
-        if self.default_options.get("hillshade"):
-            warnings.warn(
-                "hillshade is not composed with a data-style preset yet; "
-                "the 'style' preset is applied and 'hillshade' is ignored.",
-                stacklevel=2,
-            )
         # Cast to float BEFORE filling: `ma.filled(int_array, np.nan)` raises
         # `TypeError: Cannot convert fill_value nan to dtype int64` for an
         # integer masked array -- exactly the integer-coded categorical raster
@@ -1596,11 +1576,35 @@ class ArrayGlyph(GeoMixin, Glyph):
         # presets target.
         data = np.asarray(ma.filled(ma.asarray(self.arr).astype(float), np.nan), dtype=float)
         legend = bool(self.default_options.get("add_colorbar", True))
-        render_kwargs = {"extent": self.extent} if self.extent is not None else {}
-        images = apply_data_style(
-            self.ax, {layer: data}, style=style, legend=legend, **render_kwargs
-        )
+        coords = self._coords
+        if coords is not None:
+            # apply_data_style's curvilinear path defaults to shading="flat"
+            # (needs cell EDGES) via setdefault; ArrayGlyph stores cell CENTRES,
+            # so pass shading="nearest", which trusts the centres.
+            images = apply_data_style(
+                self.ax, {layer: data}, style=style, x=coords[0], y=coords[1],
+                legend=legend, shading="nearest",
+            )
+        else:
+            render_kwargs = {"extent": self.extent} if self.extent is not None else {}
+            images = apply_data_style(
+                self.ax, {layer: data}, style=style, legend=legend, **render_kwargs
+            )
         self.im = images[layer]
+
+        # Relief shading composes with the preset: blend the terrain hillshade
+        # into the drawn preset colours (regular-grid `imshow` only -- a
+        # curvilinear `QuadMesh` has no 2D RGBA grid to light).
+        hillshade = resolve_hillshade(self.default_options.get("hillshade"))
+        if hillshade is not None:
+            if coords is None:
+                self.im.set_data(shade_rgb(self.im.get_array(), data, **hillshade))
+            else:
+                warnings.warn(
+                    "hillshade is not composed with a data-style preset on a "
+                    "curvilinear grid; the preset is applied and hillshade ignored.",
+                    stacklevel=2,
+                )
         # Presets present their scale via a swatch / categorical legend, not a
         # matplotlib colorbar.
         self.cbar = None

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -39,7 +39,7 @@ from matplotlib.colors import Colormap, Normalize
 from matplotlib.figure import Figure
 from PIL import Image
 
-from cleopatra.colors import DATA_STYLES, apply_data_style, _resolve_style_norm
+from cleopatra.colors import DATA_STYLES, apply_data_style, resolve_style_norm
 from cleopatra.geo import GeoMixin
 from cleopatra.hillshade import resolve_hillshade, shade_grid
 from cleopatra.glyph import Glyph, _root_figure
@@ -3221,7 +3221,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                 stack = array if data_getter is None else frame_0
                 # Cast to float before filling (integer masked arrays reject a
                 # NaN fill value -- see `_plot_with_style`).
-                style_norm, _, _ = _resolve_style_norm(
+                style_norm, _, _ = resolve_style_norm(
                     np.asarray(ma.filled(ma.asarray(stack).astype(float), np.nan), dtype=float),
                     cfg,
                 )

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1586,7 +1586,12 @@ class ArrayGlyph(GeoMixin, Glyph):
                 "cleopatra.colors.apply_data_style directly with edge coordinates."
             )
         layer = self._resolve_style_layer(style)
-        data = np.asarray(ma.filled(self.arr, np.nan), dtype=float)
+        # Cast to float BEFORE filling: `ma.filled(int_array, np.nan)` raises
+        # `TypeError: Cannot convert fill_value nan to dtype int64` for an
+        # integer masked array -- exactly the integer-coded categorical raster
+        # (e.g. `flow_direction_d8` with nodata masked via `exclude_value`) these
+        # presets target.
+        data = np.asarray(ma.filled(ma.asarray(self.arr).astype(float), np.nan), dtype=float)
         legend = bool(self.default_options.get("add_colorbar", True))
         render_kwargs = {"extent": self.extent} if self.extent is not None else {}
         images = apply_data_style(
@@ -3187,8 +3192,11 @@ class ArrayGlyph(GeoMixin, Glyph):
                         "animate yet; use plot() for categorical styles"
                     )
                 stack = array if data_getter is None else frame_0
+                # Cast to float before filling (integer masked arrays reject a
+                # NaN fill value -- see `_plot_with_style`).
                 style_norm, _, _ = _resolve_style_norm(
-                    np.asarray(ma.filled(stack, np.nan), dtype=float), cfg
+                    np.asarray(ma.filled(ma.asarray(stack).astype(float), np.nan), dtype=float),
+                    cfg,
                 )
                 im.set_cmap(cfg["cmap"])
                 im.set_norm(style_norm)

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -3338,9 +3338,16 @@ class ArrayGlyph(GeoMixin, Glyph):
                         self.cbar.remove()
                         self.cbar = None
                     if self.default_options["add_colorbar"]:
+                        # Remove a swatch inset from a previous render so
+                        # repeated animate() calls don't stack legends.
+                        for _inset in list(ax.child_axes):
+                            _inset.remove()
+                        # Same bounds as apply_data_style's swatch (plot path),
+                        # so a plot and its animation align exactly.
                         swatch_legend(
                             ax, cfg["cmap"], cfg["label"],
                             vmin=style_vmin, vmax=style_vmax, norm=style_norm,
+                            bounds=(0.02, 0.92, 0.32, 0.06),
                         )
                     alpha_vmin = cfg.get("alpha_vmin")
                     alpha_vmax = cfg.get("alpha_vmax")

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -2008,6 +2008,31 @@ class ArrayGlyph(GeoMixin, Glyph):
                         If cell value > threshold, text is black; otherwise, text is white.
                         If None, uses max(array)/2 as the threshold.
 
+                Data-style preset / relief options:
+                    style : str, optional
+                        Name of a `cleopatra.colors.DATA_STYLES` preset (e.g.
+                        `"flow_accumulation"`, `"flow_direction_d8"`,
+                        `"topography"`; valid names are
+                        `sorted(cleopatra.colors.DATA_STYLES)`). When set, the
+                        preset's colormap, norm (linear/log/symlog/diverging
+                        `center`), transparent nodata, alpha glow, and — for
+                        categorical presets — a discrete legend are applied via
+                        `cleopatra.colors.apply_data_style`. Only single-layer
+                        presets apply to a single band. The preset owns the
+                        colour mapping, so it takes precedence over `cmap` /
+                        `color_scale` / `vmin` / `vmax` / `center`, presents its
+                        scale via a legend rather than a colorbar (`self.cbar`
+                        is `None`), and bypasses `points` / `display_cell_value`
+                        overlays (which warn). Ignored for RGB arrays and not
+                        composed with `hillshade` (the preset wins). By default
+                        None.
+                    hillshade : bool or dict, optional
+                        Relief-shade a regular-grid DEM so wide-range terrain
+                        reads by form. `True` uses defaults; a dict tunes
+                        `vert_exag`, `azimuth`, `altitude`, `blend_mode`, or
+                        `multidirectional`. Applied only to `kind="imshow"`
+                        (warns otherwise). By default False.
+
         Returns:
             tuple[matplotlib.figure.Figure, matplotlib.axes.Axes]: A tuple containing:
                 - fig: The matplotlib Figure object
@@ -2961,6 +2986,22 @@ class ArrayGlyph(GeoMixin, Glyph):
                         Threshold for cell value text color, by default None.
                         If cell value > threshold, text is black; otherwise, text is white.
                         If None, uses max(array)/2 as the threshold.
+
+                Data-style preset / relief options:
+                    style : str, optional
+                        Name of a `cleopatra.colors.DATA_STYLES` preset applied
+                        to every frame through the preset's cmap + norm (valid
+                        names: `sorted(cleopatra.colors.DATA_STYLES)`). Only
+                        **continuous** single-layer presets are supported in
+                        `animate`; a categorical preset raises
+                        `NotImplementedError`. Under a lazy `data_getter` the
+                        colour range is taken from frame 0. Takes precedence over
+                        `hillshade` (the preset wins; hillshade is warned and
+                        dropped). By default None.
+                    hillshade : bool or dict, optional
+                        Relief-shade every frame of a regular-grid DEM (same
+                        options as `plot`). Not composed with `style`. By
+                        default False.
 
         Returns:
             matplotlib.animation.FuncAnimation: The animation object that can be displayed

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1588,19 +1588,23 @@ class ArrayGlyph(GeoMixin, Glyph):
             )
         self.im = images[layer]
 
-        # Relief shading composes with the preset: blend the terrain hillshade
-        # into the drawn preset colours (regular-grid `imshow` only -- a
-        # curvilinear `QuadMesh` has no 2D RGBA grid to light).
+        # Relief shading composes with a CONTINUOUS preset: blend the terrain
+        # hillshade into the drawn colours (regular-grid `imshow` only). It is
+        # NOT applied to a categorical preset -- shading nominal class colours
+        # is meaningless (a darkened "N" can read as another class), matching
+        # MeshGlyph -- nor to a curvilinear `QuadMesh` (no 2D RGBA grid to light).
         hillshade = resolve_hillshade(self.default_options.get("hillshade"))
         if hillshade is not None:
-            if coords is None:
-                self.im.set_data(shade_rgb(self.im.get_array(), data, **hillshade))
-            else:
+            categorical = resolve_single_layer_style(style)[1].get("categories") is not None
+            if categorical or coords is not None:
+                kind = "categorical" if categorical else "curvilinear"
                 warnings.warn(
-                    "hillshade is not composed with a data-style preset on a "
-                    "curvilinear grid; the preset is applied and hillshade ignored.",
+                    f"hillshade is not composed with a {kind} data-style preset; "
+                    "the preset is applied and hillshade ignored.",
                     stacklevel=2,
                 )
+            else:
+                self.im.set_data(shade_rgb(self.im.get_array(), data, **hillshade))
         # Presets present their scale via a swatch / categorical legend, not a
         # matplotlib colorbar.
         self.cbar = None

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -52,7 +52,7 @@ from cleopatra.hillshade import resolve_hillshade, shade_grid, shade_rgb
 from cleopatra.glyph import Glyph, _root_figure
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale  # re-exported for convenience  # noqa: F401
-from cleopatra.styles import disjoint_legend
+from cleopatra.styles import disjoint_legend, swatch_legend
 
 ARRAY_DEFAULT_OPTIONS = {
     "vmin": None,
@@ -2037,9 +2037,11 @@ class ArrayGlyph(GeoMixin, Glyph):
                         `color_scale` / `vmin` / `vmax` / `center`, presents its
                         scale via a legend rather than a colorbar (`self.cbar`
                         is `None`), and bypasses `points` / `display_cell_value`
-                        overlays (which warn). Ignored for RGB arrays and not
-                        composed with `hillshade` (the preset wins). By default
-                        None.
+                        overlays (which warn). Ignored for RGB arrays. A
+                        **continuous** preset composes with `hillshade` (the
+                        relief is blended into the preset colours); a
+                        **categorical** preset is not shaded (shading class
+                        codes is meaningless) and warns. By default None.
                     hillshade : bool or dict, optional
                         Relief-shade a regular-grid DEM so wide-range terrain
                         reads by form. `True` uses defaults; a dict tunes
@@ -3007,16 +3009,17 @@ class ArrayGlyph(GeoMixin, Glyph):
                         to every frame (valid names:
                         `sorted(cleopatra.colors.DATA_STYLES)`). Continuous
                         presets drive the frames through the preset's cmap +
-                        norm + value-linked opacity; categorical presets remap
-                        the class codes through a discrete colormap and draw a
-                        legend (no colorbar). Under a lazy `data_getter` the
-                        continuous colour range is taken from frame 0. Takes
-                        precedence over `hillshade` (the preset wins; hillshade
-                        is warned and dropped). By default None.
+                        norm + value-linked opacity and present a swatch legend
+                        (matching `plot`); categorical presets remap the class
+                        codes through a discrete colormap and draw a legend (no
+                        colorbar). Under a lazy `data_getter` the continuous
+                        colour range is taken from frame 0. A continuous preset
+                        composes with `hillshade`; a categorical preset drops it
+                        (and warns). By default None.
                     hillshade : bool or dict, optional
                         Relief-shade every frame of a regular-grid DEM (same
-                        options as `plot`). Not composed with `style`. By
-                        default False.
+                        options as `plot`). Composes with a continuous `style`;
+                        dropped for a categorical `style`. By default False.
 
         Returns:
             matplotlib.animation.FuncAnimation: The animation object that can be displayed
@@ -3237,6 +3240,9 @@ class ArrayGlyph(GeoMixin, Glyph):
         # alpha norm, constant alpha), set in the style branch below and
         # consumed by `_display_frame`. `None` when no style is active.
         style_render = None
+        # True when the active preset is categorical (drops hillshade, which is
+        # meaningless for class codes); a continuous preset composes hillshade.
+        style_categorical = False
 
         if rgb_frames:
             # True-colour frames go straight through imshow — no norm,
@@ -3266,19 +3272,22 @@ class ArrayGlyph(GeoMixin, Glyph):
             if style is not None:
                 layer = self._resolve_style_layer(style)
                 cfg = DATA_STYLES[style][layer]
-                # A `style` takes precedence over `hillshade`; warn and drop the
-                # relief rather than compose it in animate.
-                if resolve_hillshade(self.default_options.get("hillshade")) is not None:
-                    warnings.warn(
-                        "hillshade is not composed with a data-style preset in "
-                        "animate; the 'style' preset is applied and hillshade "
-                        "ignored.",
-                        stacklevel=2,
-                    )
+                hillshade_active = (
+                    resolve_hillshade(self.default_options.get("hillshade")) is not None
+                )
                 categories = cfg.get("categories")
                 if categories is not None:
                     # Categorical: a discrete legend replaces the colorbar and is
-                    # drawn once; frames only remap the class codes.
+                    # drawn once; frames only remap the class codes. Hillshade is
+                    # meaningless for class codes, so warn and drop it.
+                    style_categorical = True
+                    if hillshade_active:
+                        warnings.warn(
+                            "hillshade is not composed with a categorical "
+                            "data-style preset; the preset is applied and "
+                            "hillshade ignored.",
+                            stacklevel=2,
+                        )
                     cats = sorted(categories, key=lambda c: c[0])
                     cat_values = np.array([float(c[0]) for c in cats])
                     cat_colors = [c[1] for c in cats]
@@ -3301,22 +3310,26 @@ class ArrayGlyph(GeoMixin, Glyph):
                     style_render = ("categorical", cat_cmap, cat_norm, cat_values)
                 else:
                     # Continuous: cmap + norm, range resolved over the eager
-                    # stack (frame 0 only under a lazy data_getter), colorbar
-                    # refreshed to match.
+                    # stack (frame 0 only under a lazy data_getter). A swatch
+                    # legend replaces the colorbar to match `plot()`'s
+                    # apply_data_style presentation, and hillshade composes into
+                    # the per-frame RGBA (see `_display_frame`).
                     stack = array if data_getter is None else frame_0
-                    style_norm, _, _ = resolve_style_norm(
+                    style_norm, style_vmin, style_vmax = resolve_style_norm(
                         np.asarray(ma.filled(ma.asarray(stack).astype(float), np.nan), dtype=float),
                         cfg,
                     )
-                    # The initial render may have baked an RGBA hillshade into
-                    # `im`; reset it to a scalar frame so the colorbar autoscales
-                    # over scalar data -- a scale norm (Log/SymLog) applied to an
-                    # RGBA array raises "Input values must have shape (N, 1)...".
                     im.set_data(frame_0_scalar)
                     im.set_cmap(cfg["cmap"])
                     im.set_norm(style_norm)
                     if self.cbar is not None:
-                        self.cbar.update_normal(im)
+                        self.cbar.remove()
+                        self.cbar = None
+                    if self.default_options["add_colorbar"]:
+                        swatch_legend(
+                            ax, cfg["cmap"], cfg["label"],
+                            vmin=style_vmin, vmax=style_vmax, norm=style_norm,
+                        )
                     alpha_vmin = cfg.get("alpha_vmin")
                     alpha_vmax = cfg.get("alpha_vmax")
                     style_alpha_norm = (
@@ -3416,10 +3429,10 @@ class ArrayGlyph(GeoMixin, Glyph):
         # Relief-shade each frame when `hillshade` is set: the initial render
         # shaded `frame_0`, but `init`/`animate_a` overwrite `im` with the raw
         # scalar frame, so shading is re-applied per frame through this wrapper.
-        # A `style` preset takes precedence over hillshade (aligned with plot()),
-        # so shading is disabled when a style is active.
+        # A continuous `style` composes hillshade into its RGBA (matching plot());
+        # a categorical `style` drops it (meaningless for class codes).
         hillshade_opts = resolve_hillshade(self.default_options.get("hillshade"))
-        if self.default_options.get("style") is not None:
+        if style_categorical:
             hillshade_opts = None
 
         def _display_frame(frame):
@@ -3437,9 +3450,13 @@ class ArrayGlyph(GeoMixin, Glyph):
                     rgba[~np.isfinite(masked)] = 0.0
                     return rgba
                 # Continuous: bake the preset RGBA (colour + value-linked
-                # opacity) so animate matches plot()'s apply_data_style output.
+                # opacity) so animate matches plot()'s apply_data_style output,
+                # then compose hillshade into it (matching plot's shade_rgb).
                 _, cmap_, norm_, alpha_norm_, const_ = style_render
-                return alpha_rgba(filled, cmap_, norm_, alpha_norm_, const_)
+                rgba = alpha_rgba(filled, cmap_, norm_, alpha_norm_, const_)
+                if hillshade_opts is not None:
+                    rgba = shade_rgb(rgba, filled, **hillshade_opts)
+                return rgba
             if hillshade_opts is not None and not rgb_frames:
                 # Cast before filling: integer masked frames reject a NaN fill.
                 elevation = np.asarray(ma.filled(ma.asarray(frame).astype(float), np.nan), dtype=float)

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -39,6 +39,7 @@ from matplotlib.colors import Colormap, Normalize
 from matplotlib.figure import Figure
 from PIL import Image
 
+from cleopatra.colors import DATA_STYLES, apply_data_style, _resolve_style_norm
 from cleopatra.geo import GeoMixin
 from cleopatra.hillshade import resolve_hillshade, shade_grid
 from cleopatra.glyph import Glyph, _root_figure
@@ -64,6 +65,7 @@ ARRAY_DEFAULT_OPTIONS = {
     "labels": False,
     "label_kw": None,
     "hillshade": False,
+    "style": None,
 }
 ARRAY_DEFAULT_OPTIONS = STYLE_DEFAULTS | ARRAY_DEFAULT_OPTIONS
 #: Backwards-compatible alias for the array glyph's default options
@@ -1518,6 +1520,83 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         return im, cbar_kw
 
+    def _resolve_style_layer(self, style: str) -> str:
+        """Validate a `DATA_STYLES` name and return its single layer key.
+
+        A raster band is one field, so only single-layer presets apply. The
+        style name is the layer name for every single-layer preset
+        (`flow_accumulation`, `flow_direction_d8`, topography, each Magics /
+        cmocean entry).
+
+        Args:
+            style: A key of `cleopatra.colors.DATA_STYLES`.
+
+        Returns:
+            The preset's single layer name.
+
+        Raises:
+            ValueError: If `style` is unknown, or names a multi-layer preset
+                (which cannot be applied to a single raster band).
+        """
+        if style not in DATA_STYLES:
+            raise ValueError(
+                f"unknown data style {style!r}; valid styles are "
+                f"{sorted(DATA_STYLES)}"
+            )
+        layers = DATA_STYLES[style]
+        if len(layers) != 1:
+            raise ValueError(
+                f"data style {style!r} defines multiple layers {sorted(layers)}; "
+                "ArrayGlyph applies single-layer presets to a single band. Use "
+                "cleopatra.colors.apply_data_style directly for multi-layer styles."
+            )
+        return next(iter(layers))
+
+    def _plot_with_style(self, style: str) -> tuple[Figure, Axes]:
+        """Render the array with a named `DATA_STYLES` preset.
+
+        Delegates the drawing to `cleopatra.colors.apply_data_style` so the
+        preset's colormap, norm (`linear`/`log`/`symlog`/diverging `center`),
+        transparent nodata, optional alpha glow, and — for categorical presets
+        — the discrete `disjoint_legend` are reproduced exactly. The preset's
+        swatch / categorical legend stands in for the colorbar, so `self.cbar`
+        is left `None`. `add_colorbar=False` suppresses that legend.
+
+        Args:
+            style: A `DATA_STYLES` name (see `_resolve_style_layer`).
+
+        Returns:
+            tuple[Figure, Axes]: The figure and axes drawn on.
+        """
+        if self.default_options.get("hillshade"):
+            warnings.warn(
+                "hillshade is not composed with a data-style preset yet; "
+                "the 'style' preset is applied and 'hillshade' is ignored.",
+                stacklevel=2,
+            )
+        layer = self._resolve_style_layer(style)
+        data = np.asarray(ma.filled(self.arr, np.nan), dtype=float)
+        legend = bool(self.default_options.get("add_colorbar", True))
+        coords = self._coords
+        if coords is not None:
+            images = apply_data_style(
+                self.ax, {layer: data}, style=style, x=coords[0], y=coords[1],
+                legend=legend,
+            )
+        else:
+            render_kwargs = {"extent": self.extent} if self.extent is not None else {}
+            images = apply_data_style(
+                self.ax, {layer: data}, style=style, legend=legend, **render_kwargs
+            )
+        self.im = images[layer]
+        # Presets present their scale via a swatch / categorical legend, not a
+        # matplotlib colorbar.
+        self.cbar = None
+        self.ax.set_title(
+            self.default_options["title"], fontsize=self.default_options["title_size"]
+        )
+        return self.fig, self.ax
+
     def apply_colormap(self, cmap: Colormap | str) -> np.ndarray:
         """Apply a matplotlib colormap to an array.
 
@@ -2303,6 +2382,14 @@ class ArrayGlyph(GeoMixin, Glyph):
         arr = self.arr
         fig, ax = self.fig, self.ax
 
+        # Named data-style preset: resolve the preset's cmap/norm/vmin/vmax/
+        # center/categories (and alpha glow / categorical legend) by delegating
+        # to `cleopatra.colors.apply_data_style`, so the full preset semantics
+        # (log/symlog norms, transparent nodata, disjoint categorical legend)
+        # are reproduced rather than lossily mapped onto `color_scale`.
+        if self.default_options.get("style") is not None and not self.rgb:
+            return self._plot_with_style(self.default_options["style"])
+
         if self.rgb:
             self.im = ax.imshow(arr, extent=self.extent)
             self.cbar = None
@@ -3081,6 +3168,29 @@ class ArrayGlyph(GeoMixin, Glyph):
             if self.default_options["add_colorbar"]:
                 self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
+            # Named data-style preset for animation: continuous presets drive
+            # the frames through the preset's cmap + norm (resolved across the
+            # whole stack so the colour range is stable across frames), and the
+            # colorbar is refreshed to match. Categorical presets need per-frame
+            # masking + a discrete legend and are not animated yet -- use plot().
+            style = self.default_options.get("style")
+            if style is not None:
+                layer = self._resolve_style_layer(style)
+                cfg = DATA_STYLES[style][layer]
+                if cfg.get("categories") is not None:
+                    raise NotImplementedError(
+                        "categorical data-style presets are not supported in "
+                        "animate yet; use plot() for categorical styles"
+                    )
+                stack = array if data_getter is None else frame_0
+                style_norm, _, _ = _resolve_style_norm(
+                    np.asarray(ma.filled(stack, np.nan), dtype=float), cfg
+                )
+                im.set_cmap(cfg["cmap"])
+                im.set_norm(style_norm)
+                if self.cbar is not None:
+                    self.cbar.update_normal(im)
+
         ax.set_title(
             self.default_options["title"], fontsize=self.default_options["title_size"]
         )
@@ -3165,9 +3275,22 @@ class ArrayGlyph(GeoMixin, Glyph):
                     )
             return frame
 
+        # Relief-shade each frame when `hillshade` is set: the initial render
+        # shaded `frame_0`, but `init`/`animate_a` overwrite `im` with the raw
+        # scalar frame, so shading is re-applied per frame through this wrapper
+        # (using the artist's live cmap/norm, so it composes with a `style`).
+        hillshade_opts = resolve_hillshade(self.default_options.get("hillshade"))
+
+        def _display_frame(frame):
+            """Return the frame's image data, relief-shaded when requested."""
+            if hillshade_opts is not None and not rgb_frames:
+                elevation = np.asarray(ma.filled(frame, np.nan), dtype=float)
+                return shade_grid(elevation, im.cmap, norm=im.norm, **hillshade_opts)
+            return frame
+
         def init():
             """initialize the plot with the cached first frame"""
-            im.set_data(frame_0)
+            im.set_data(_display_frame(frame_0))
             day_text.set_text("")
             output = [im, day_text]
 
@@ -3193,7 +3316,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         def animate_a(i):
             """plot for each element in the iterable."""
             frame = _fetch_frame(i)
-            im.set_data(frame)
+            im.set_data(_display_frame(frame))
             day_text.set_text("Date = " + str(time[i])[0:10])
             output = [im, day_text]
 

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -39,7 +39,7 @@ from matplotlib.colors import Colormap, Normalize
 from matplotlib.figure import Figure
 from PIL import Image
 
-from cleopatra.colors import DATA_STYLES, apply_data_style, resolve_style_norm
+from cleopatra.colors import DATA_STYLES, alpha_rgba, apply_data_style, resolve_style_norm
 from cleopatra.geo import GeoMixin
 from cleopatra.hillshade import resolve_hillshade, shade_grid
 from cleopatra.glyph import Glyph, _root_figure
@@ -1509,7 +1509,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         if hillshade is not None:
             if kind == "imshow":
                 hs_norm = norm if norm is not None else Normalize(vmin=vmin, vmax=vmax)
-                elevation = np.asarray(ma.filled(plot_arr, np.nan), dtype=float)
+                elevation = np.asarray(ma.filled(ma.asarray(plot_arr).astype(float), np.nan), dtype=float)
                 im.set_data(shade_grid(elevation, cmap, norm=hs_norm, **hillshade))
             else:
                 warnings.warn(
@@ -1568,12 +1568,10 @@ class ArrayGlyph(GeoMixin, Glyph):
         Returns:
             tuple[Figure, Axes]: The figure and axes drawn on.
         """
-        if self.default_options.get("hillshade"):
-            warnings.warn(
-                "hillshade is not composed with a data-style preset yet; "
-                "the 'style' preset is applied and 'hillshade' is ignored.",
-                stacklevel=2,
-            )
+        # Validate the style name first, then the coords contract, and only
+        # warn about hillshade on the path that actually proceeds -- so an
+        # aborting call reports the right error and emits no spurious warning.
+        layer = self._resolve_style_layer(style)
         if self._coords is not None:
             # apply_data_style's curvilinear path forces shading="flat", which
             # needs cell-EDGE coordinates, but ArrayGlyph stores cell CENTRES.
@@ -1585,7 +1583,12 @@ class ArrayGlyph(GeoMixin, Glyph):
                 "stores cell centres. Plot without coords, or call "
                 "cleopatra.colors.apply_data_style directly with edge coordinates."
             )
-        layer = self._resolve_style_layer(style)
+        if self.default_options.get("hillshade"):
+            warnings.warn(
+                "hillshade is not composed with a data-style preset yet; "
+                "the 'style' preset is applied and 'hillshade' is ignored.",
+                stacklevel=2,
+            )
         # Cast to float BEFORE filling: `ma.filled(int_array, np.nan)` raises
         # `TypeError: Cannot convert fill_value nan to dtype int64` for an
         # integer masked array -- exactly the integer-coded categorical raster
@@ -3218,6 +3221,11 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         fig, ax = self.fig, self.ax
 
+        # Per-frame RGBA recipe for a continuous `style` (cmap, colour norm,
+        # alpha norm, constant alpha), set in the style branch below and
+        # consumed by `_display_frame`. `None` when no style is active.
+        style_render = None
+
         if rgb_frames:
             # True-colour frames go straight through imshow — no norm,
             # colormap or colorbar (mirrors `plot`'s RGB branch).
@@ -3277,6 +3285,17 @@ class ArrayGlyph(GeoMixin, Glyph):
                 im.set_norm(style_norm)
                 if self.cbar is not None:
                     self.cbar.update_normal(im)
+                # Reproduce apply_data_style's per-frame RGBA (colour + the
+                # preset's value-linked opacity) so animate matches plot; the
+                # colorbar stays driven off the scalar norm/cmap installed above.
+                alpha_vmin = cfg.get("alpha_vmin")
+                alpha_vmax = cfg.get("alpha_vmax")
+                style_alpha_norm = (
+                    Normalize(vmin=alpha_vmin, vmax=alpha_vmax)
+                    if alpha_vmin is not None or alpha_vmax is not None
+                    else None
+                )
+                style_render = (cfg["cmap"], style_norm, style_alpha_norm, cfg.get("alpha"))
 
         ax.set_title(
             self.default_options["title"], fontsize=self.default_options["title_size"]
@@ -3372,9 +3391,18 @@ class ArrayGlyph(GeoMixin, Glyph):
             hillshade_opts = None
 
         def _display_frame(frame):
-            """Return the frame's image data, relief-shaded when requested."""
+            """Return the frame's image data: preset RGBA, relief-shaded, or raw."""
+            if style_render is not None:
+                # Bake the preset RGBA (colour + value-linked opacity) so animate
+                # matches plot()'s apply_data_style rendering.
+                cmap_, norm_, alpha_norm_, const_ = style_render
+                return alpha_rgba(
+                    np.asarray(ma.filled(ma.asarray(frame).astype(float), np.nan), dtype=float),
+                    cmap_, norm_, alpha_norm_, const_,
+                )
             if hillshade_opts is not None and not rgb_frames:
-                elevation = np.asarray(ma.filled(frame, np.nan), dtype=float)
+                # Cast before filling: integer masked frames reject a NaN fill.
+                elevation = np.asarray(ma.filled(ma.asarray(frame).astype(float), np.nan), dtype=float)
                 return shade_grid(elevation, im.cmap, norm=im.norm, **hillshade_opts)
             return frame
 

--- a/src/cleopatra/colors.py
+++ b/src/cleopatra/colors.py
@@ -570,7 +570,7 @@ def _category_boundaries(values: list[float]) -> list[float]:
     return [lower] + mids + [upper]
 
 
-def _resolve_style_norm(
+def resolve_style_norm(
     data: np.ndarray, cfg: dict[str, Any]
 ) -> tuple[mcolors.Normalize, float, float]:
     """Resolve the colour `Normalize` (and its concrete bounds) for one layer.
@@ -664,6 +664,10 @@ def _resolve_style_norm(
             f"data style 'norm' must be 'linear', 'log', or 'symlog', got {norm_kind!r}"
         )
     return norm, vmin, vmax
+
+
+#: Backward-compatible private alias for `resolve_style_norm` (its earlier name).
+_resolve_style_norm = resolve_style_norm
 
 
 def apply_data_style(
@@ -872,7 +876,7 @@ def apply_data_style(
                     ax.add_artist(prior_legend)
             continue
 
-        norm, resolved_vmin, resolved_vmax = _resolve_style_norm(data, cfg)
+        norm, resolved_vmin, resolved_vmax = resolve_style_norm(data, cfg)
 
         alpha_const = cfg.get("alpha")
         alpha_vmin = cfg.get("alpha_vmin")

--- a/src/cleopatra/colors.py
+++ b/src/cleopatra/colors.py
@@ -672,6 +672,37 @@ _alpha_rgba = alpha_rgba
 _category_boundaries = category_boundaries
 
 
+def resolve_single_layer_style(style: str) -> tuple[str, dict[str, Any]]:
+    """Resolve a single-layer `DATA_STYLES` preset to its `(layer, config)`.
+
+    A single glyph field (a raster band, a mesh's node/face values, a density)
+    maps to exactly one preset layer, so multi-layer presets are rejected. Used
+    by the glyph `style=` options to look up the preset's cmap/norm/categories.
+
+    Args:
+        style: A key of `DATA_STYLES`.
+
+    Returns:
+        tuple: `(layer_name, layer_config)` for the preset's single layer.
+
+    Raises:
+        ValueError: If `style` is unknown, or names a multi-layer preset.
+    """
+    if style not in DATA_STYLES:
+        raise ValueError(
+            f"unknown data style {style!r}; valid styles are {sorted(DATA_STYLES)}"
+        )
+    layers = DATA_STYLES[style]
+    if len(layers) != 1:
+        raise ValueError(
+            f"data style {style!r} defines multiple layers {sorted(layers)}; a "
+            "single glyph field maps to one layer. Use apply_data_style directly "
+            "for multi-layer styles."
+        )
+    name = next(iter(layers))
+    return name, layers[name]
+
+
 def apply_data_style(
     ax: Axes,
     layers: dict[str, np.ndarray],

--- a/src/cleopatra/colors.py
+++ b/src/cleopatra/colors.py
@@ -547,7 +547,7 @@ DATA_STYLES.update(_load_magics_presets())
 DATA_STYLES.update(_load_preset_asset("cmocean_presets.json", "cmocean"))
 
 
-def _category_boundaries(values: list[float]) -> list[float]:
+def category_boundaries(values: list[float]) -> list[float]:
     """Bin edges for a `BoundaryNorm` over discrete category values.
 
     Interior edges are the midpoints between consecutive (sorted) class
@@ -669,6 +669,7 @@ def resolve_style_norm(
 #: Backward-compatible private aliases for symbols that were renamed public.
 _resolve_style_norm = resolve_style_norm
 _alpha_rgba = alpha_rgba
+_category_boundaries = category_boundaries
 
 
 def apply_data_style(
@@ -835,7 +836,7 @@ def apply_data_style(
             cat_labels = [c[2] for c in cats]
             cat_cmap = mcolors.ListedColormap(cat_colors)
             cat_norm = mcolors.BoundaryNorm(
-                _category_boundaries(cat_values), len(cat_colors)
+                category_boundaries(cat_values), len(cat_colors)
             )
             # Only cells whose value is one of the declared class codes are
             # drawn; anything else (nodata sentinels, D8 sinks, out-of-range

--- a/src/cleopatra/colors.py
+++ b/src/cleopatra/colors.py
@@ -171,11 +171,11 @@ def alpha_scaled_image(
     if data.ndim != 2:
         raise ValueError(f"data must be 2-dimensional, got shape {data.shape}")
 
-    rgba = _alpha_rgba(data, cmap, norm, alpha_norm, constant_alpha)
+    rgba = alpha_rgba(data, cmap, norm, alpha_norm, constant_alpha)
     return ax.imshow(rgba, **imshow_kwargs)
 
 
-def _alpha_rgba(
+def alpha_rgba(
     data: np.ndarray,
     cmap: str | Colormap,
     norm: mcolors.Normalize | None,
@@ -295,7 +295,7 @@ def alpha_scaled_mesh(
         raise ValueError(f"data must be 2-dimensional, got shape {data.shape}")
 
     pcolormesh_kwargs.setdefault("shading", "auto")
-    rgba = _alpha_rgba(data, cmap, norm, alpha_norm, constant_alpha)
+    rgba = alpha_rgba(data, cmap, norm, alpha_norm, constant_alpha)
     mesh = ax.pcolormesh(x, y, data, **pcolormesh_kwargs)
     mesh.set_array(None)
     mesh.set_facecolor(rgba.reshape(-1, 4))
@@ -666,8 +666,9 @@ def resolve_style_norm(
     return norm, vmin, vmax
 
 
-#: Backward-compatible private alias for `resolve_style_norm` (its earlier name).
+#: Backward-compatible private aliases for symbols that were renamed public.
 _resolve_style_norm = resolve_style_norm
+_alpha_rgba = alpha_rgba
 
 
 def apply_data_style(

--- a/src/cleopatra/hillshade.py
+++ b/src/cleopatra/hillshade.py
@@ -108,6 +108,31 @@ def _azimuths(multidirectional: Any, azimuth: float) -> list[float]:
     return [float(a) for a in multidirectional]
 
 
+def _illumination(
+    elevation: np.ndarray,
+    azimuth: float,
+    altitude: float,
+    vert_exag: float,
+    multidirectional: Any,
+    fraction: float,
+    dx: float,
+    dy: float,
+) -> np.ndarray:
+    """Terrain illumination in `[0, 1]`, averaged over `multidirectional` azimuths.
+
+    A cell adjacent to NaN gets a NaN gradient, mapped to neutral (mid, 0.5)
+    illumination so it neither brightens nor darkens.
+    """
+    intensities = [
+        LightSource(azdeg=az, altdeg=altitude).hillshade(
+            elevation, vert_exag=vert_exag, dx=dx, dy=dy, fraction=fraction
+        )
+        for az in _azimuths(multidirectional, azimuth)
+    ]
+    intensity = np.mean(intensities, axis=0)
+    return np.where(np.isfinite(intensity), intensity, 0.5)
+
+
 def shade_grid(
     elevation: np.ndarray,
     cmap: str | Colormap,
@@ -160,17 +185,9 @@ def shade_grid(
 
     rgb = cmap_obj(norm(elevation))[..., :3]
 
-    intensities = [
-        LightSource(azdeg=az, altdeg=altitude).hillshade(
-            elevation, vert_exag=vert_exag, dx=dx, dy=dy, fraction=fraction
-        )
-        for az in _azimuths(multidirectional, azimuth)
-    ]
-    intensity = np.mean(intensities, axis=0)
-    # A cell adjacent to NaN gets a NaN gradient -> neutral (mid) illumination;
-    # the cell itself is made transparent below if its elevation is non-finite.
-    intensity = np.where(np.isfinite(intensity), intensity, 0.5)
-
+    intensity = _illumination(
+        elevation, azimuth, altitude, vert_exag, multidirectional, fraction, dx, dy
+    )
     ls = LightSource(azdeg=azimuth, altdeg=altitude)
     shaded_rgb = _blend_fn(ls, blend_mode)(rgb, intensity[..., np.newaxis])
     shaded_rgb = np.clip(shaded_rgb, 0.0, 1.0)
@@ -180,6 +197,57 @@ def shade_grid(
     )
     rgba[~finite] = 0.0
     return rgba
+
+
+def shade_rgb(
+    rgb: np.ndarray,
+    elevation: np.ndarray,
+    *,
+    azimuth: float = 315.0,
+    altitude: float = 45.0,
+    vert_exag: float = 1.0,
+    blend_mode: str = "overlay",
+    multidirectional: Any = False,
+    fraction: float = 1.0,
+    dx: float = 1.0,
+    dy: float = 1.0,
+) -> np.ndarray:
+    """Blend hillshade relief into an already-coloured RGB(A) image (regular grid).
+
+    Unlike `shade_grid` (which colours `elevation` itself with a colormap), this
+    lights colours produced elsewhere -- e.g. a `DATA_STYLES` preset image -- so
+    the source colours and their opacity are preserved and merely illuminated by
+    the terrain. An input alpha channel is carried through unchanged (so the
+    preset's transparent nodata / value-linked opacity survives).
+
+    Args:
+        rgb: `(*, *, 3)` or `(*, *, 4)` image to be lit.
+        elevation: 2D surface whose slopes drive the illumination (same shape as
+            `rgb`'s first two axes).
+        azimuth: Light compass direction in degrees (315 = NW).
+        altitude: Light height above the horizon in degrees.
+        vert_exag: Vertical exaggeration -- raise it for more relief contrast.
+        blend_mode: `"overlay"`, `"soft"`, or `"hsv"`.
+        multidirectional: `False`, an int `N`, or a sequence of azimuths.
+        fraction: Increases the illumination contrast.
+        dx: Grid spacing in x (affects slope).
+        dy: Grid spacing in y (affects slope).
+
+    Returns:
+        np.ndarray: The lit image, same channel count as `rgb`.
+    """
+    rgb = np.asarray(rgb, dtype=float)
+    elevation = np.asarray(elevation, dtype=float)
+    intensity = _illumination(
+        elevation, azimuth, altitude, vert_exag, multidirectional, fraction, dx, dy
+    )
+    ls = LightSource(azdeg=azimuth, altdeg=altitude)
+    shaded = np.clip(
+        _blend_fn(ls, blend_mode)(rgb[..., :3], intensity[..., np.newaxis]), 0.0, 1.0
+    )
+    if rgb.shape[-1] == 4:
+        return np.concatenate([shaded, rgb[..., 3:4]], axis=-1)
+    return shaded
 
 
 def shade_faces(

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -40,6 +40,7 @@ from matplotlib.figure import Figure
 from matplotlib.patches import Patch
 from matplotlib.path import Path as MplPath
 
+from cleopatra.colors import resolve_single_layer_style, resolve_style_norm
 from cleopatra.glyph import Glyph
 from cleopatra.hillshade import resolve_hillshade, shade_grid
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
@@ -62,6 +63,7 @@ KDE_DEFAULT_OPTIONS = {
     "ticks_spacing": None,
     "add_colorbar": True,
     "hillshade": False,
+    "style": None,
 }
 KDE_DEFAULT_OPTIONS = STYLE_DEFAULTS | KDE_DEFAULT_OPTIONS
 
@@ -300,6 +302,7 @@ class KDEGlyph(Glyph):
         title: str | None = None,
         add_colorbar: bool | None = None,
         hillshade: bool | dict | None = None,
+        style: str | None = None,
     ):
         """Render the 2-D density as filled or line contours.
 
@@ -372,6 +375,20 @@ class KDEGlyph(Glyph):
         gx, gy, density = self.evaluate()
         level_edges = self._resolve_levels(density)
         norm, cbar_kw, _ = self._prepare_scalar_mapping(density)
+
+        # Named data-style preset: a continuous preset overrides the density's
+        # cmap + norm (and composes with hillshade below). A categorical preset
+        # has no meaning for a continuous density surface, so reject it.
+        style = style if style is not None else opts.get("style")
+        if style is not None:
+            _, cfg = resolve_single_layer_style(style)
+            if cfg.get("categories") is not None:
+                raise ValueError(
+                    f"data style {style!r} is categorical; KDEGlyph colours a "
+                    "continuous density, so only continuous presets apply"
+                )
+            opts["cmap"] = cfg["cmap"]
+            norm, _, _ = resolve_style_norm(np.asarray(density, dtype=float), cfg)
 
         hillshade = resolve_hillshade(
             hillshade if hillshade is not None else opts.get("hillshade")

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -381,10 +381,13 @@ class KDEGlyph(Glyph):
         gx, gy, density = self.evaluate()
         level_edges = self._resolve_levels(density)
         norm, cbar_kw, _ = self._prepare_scalar_mapping(density)
+        cmap = opts["cmap"]
 
         # Named data-style preset: a continuous preset overrides the density's
         # cmap + norm (and composes with hillshade below). A categorical preset
-        # has no meaning for a continuous density surface, so reject it.
+        # has no meaning for a continuous density surface, so reject it. The
+        # cmap is resolved into a LOCAL (not `opts`), so a per-call `style` does
+        # not leak its colormap into a later `plot()` on the same instance.
         style = style if style is not None else opts.get("style")
         if style is not None:
             _, cfg = resolve_single_layer_style(style)
@@ -393,7 +396,7 @@ class KDEGlyph(Glyph):
                     f"data style {style!r} is categorical; KDEGlyph colours a "
                     "continuous density, so only continuous presets apply"
                 )
-            opts["cmap"] = cfg["cmap"]
+            cmap = cfg["cmap"]
             norm, _, _ = resolve_style_norm(np.asarray(density, dtype=float), cfg)
 
         hillshade = resolve_hillshade(
@@ -407,13 +410,13 @@ class KDEGlyph(Glyph):
             hs_norm = norm if norm is not None else Normalize(
                 vmin=float(density.min()), vmax=float(density.max())
             )
-            rgba = shade_grid(density, opts["cmap"], norm=hs_norm, **hillshade)
+            rgba = shade_grid(density, cmap, norm=hs_norm, **hillshade)
             extent = [float(gx.min()), float(gx.max()), float(gy.min()), float(gy.max())]
             mappable = ax.imshow(rgba, extent=extent, origin="lower", aspect="auto")
             self._apply_clip(mappable)
             self.im = mappable
             if draw_colorbar:
-                proxy = ScalarMappable(norm=hs_norm, cmap=opts["cmap"])
+                proxy = ScalarMappable(norm=hs_norm, cmap=cmap)
                 proxy.set_array(density)
                 self.cbar = self.create_color_bar(ax, proxy, cbar_kw)
             if opts["title"]:
@@ -422,7 +425,7 @@ class KDEGlyph(Glyph):
 
         render = ax.contourf if opts["shade"] else ax.contour
         contour_set = render(
-            gx, gy, density, levels=level_edges, cmap=opts["cmap"], norm=norm
+            gx, gy, density, levels=level_edges, cmap=cmap, norm=norm
         )
         self._apply_clip(contour_set)
         self.im = contour_set

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -398,6 +398,8 @@ class KDEGlyph(Glyph):
                 )
             cmap = cfg["cmap"]
             norm, _, _ = resolve_style_norm(np.asarray(density, dtype=float), cfg)
+            # Drop the linear ticks so the colorbar matches the preset norm.
+            cbar_kw.pop("ticks", None)
 
         hillshade = resolve_hillshade(
             hillshade if hillshade is not None else opts.get("hillshade")

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -324,6 +324,12 @@ class KDEGlyph(Glyph):
                 None, which keeps the value set at construction. Accepting it
                 here mirrors `ArrayGlyph.plot`/`MeshGlyph.plot`, so `hillshade`
                 works the same way across all three glyphs.
+            style: Name of a continuous `cleopatra.colors.DATA_STYLES` preset
+                to colour the density with (its cmap + norm; composes with
+                `hillshade`). Defaults to None, keeping the construction value.
+                A categorical preset has no meaning for a continuous density
+                and raises `ValueError`. Valid names:
+                `sorted(cleopatra.colors.DATA_STYLES)`.
 
         Returns:
             tuple[Figure, Axes, QuadContourSet]: The figure, the axes, and

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -28,6 +28,7 @@ Examples:
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 import matplotlib.collections as mcoll
@@ -953,6 +954,13 @@ class MeshGlyph(GeoMixin, Glyph):
                 colorbar = False
                 self.default_options["hillshade"] = False
                 style_legend = (cat_colors, cat_labels, cfg["label"])
+                if location == "node":
+                    warnings.warn(
+                        "a categorical data-style preset with location='node' "
+                        "interpolates discrete class codes via tricontourf; use "
+                        "location='face' for correct per-cell class colours.",
+                        stacklevel=2,
+                    )
             else:
                 self.default_options["cmap"] = cfg["cmap"]
                 norm, _, _ = resolve_style_norm(data_f, cfg)

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -956,6 +956,11 @@ class MeshGlyph(GeoMixin, Glyph):
             else:
                 self.default_options["cmap"] = cfg["cmap"]
                 norm, _, _ = resolve_style_norm(data_f, cfg)
+                # The preset norm may be nonlinear (log/symlog) or carry its own
+                # vmin/vmax; drop the linear ticks computed above so the colorbar
+                # picks a locator/format matching the norm instead of misplacing
+                # evenly-spaced ticks on a log axis.
+                cbar_kw.pop("ticks", None)
 
         # Reset any inline contour labels from a previous render; the
         # line-tricontour branch below repopulates this when `labels=True`,

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -36,10 +36,18 @@ import matplotlib.tri as mtri
 import numpy as np
 from matplotlib.animation import FuncAnimation
 
+from matplotlib.colors import BoundaryNorm, ListedColormap
+
+from cleopatra.colors import (
+    category_boundaries,
+    resolve_single_layer_style,
+    resolve_style_norm,
+)
 from cleopatra.geo import GeoMixin
 from cleopatra.glyph import Glyph
 from cleopatra.hillshade import resolve_hillshade, shade_faces
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+from cleopatra.styles import disjoint_legend
 
 MESH_DEFAULT_OPTIONS = {
     "vmin": None,
@@ -47,6 +55,7 @@ MESH_DEFAULT_OPTIONS = {
     "labels": False,
     "label_kw": None,
     "hillshade": False,
+    "style": None,
 }
 MESH_DEFAULT_OPTIONS = STYLE_DEFAULTS | MESH_DEFAULT_OPTIONS
 
@@ -910,6 +919,34 @@ class MeshGlyph(GeoMixin, Glyph):
         ticks = self.get_ticks()
         norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
 
+        # Named data-style preset: a continuous preset overrides the cmap/norm
+        # (and composes with hillshade, which reads them); a categorical preset
+        # builds a discrete colormap, masks out-of-range codes to transparent,
+        # swaps the colorbar for a `disjoint_legend`, and disables relief
+        # (undefined for class codes).
+        style = self.default_options.get("style")
+        style_legend = None
+        if style is not None:
+            _, cfg = resolve_single_layer_style(style)
+            data_f = np.asarray(data, dtype=float)
+            categories = cfg.get("categories")
+            if categories is not None:
+                cats = sorted(categories, key=lambda c: c[0])
+                cat_values = np.array([float(c[0]) for c in cats])
+                cat_colors = [c[1] for c in cats]
+                cat_labels = [c[2] for c in cats]
+                self.default_options["cmap"] = ListedColormap(cat_colors)
+                norm = BoundaryNorm(
+                    category_boundaries(list(cat_values)), len(cat_colors)
+                )
+                data = np.where(np.isin(data_f, cat_values), data_f, np.nan)
+                colorbar = False
+                self.default_options["hillshade"] = False
+                style_legend = (cat_colors, cat_labels, cfg["label"])
+            else:
+                self.default_options["cmap"] = cfg["cmap"]
+                norm, _, _ = resolve_style_norm(data_f, cfg)
+
         # Reset any inline contour labels from a previous render; the
         # line-tricontour branch below repopulates this when `labels=True`,
         # every other path leaves it `None`.
@@ -966,6 +1003,13 @@ class MeshGlyph(GeoMixin, Glyph):
 
         if colorbar:
             self._cbar = self.create_color_bar(self.ax, tpc, cbar_kw)
+
+        # A categorical preset presents its classes via a discrete legend.
+        if style_legend is not None:
+            cat_colors, cat_labels, cat_title = style_legend
+            disjoint_legend(
+                self.ax, cat_colors, cat_labels, title=cat_title, loc="upper right"
+            )
 
         if self.default_options["title"]:
             self.ax.set_title(

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -777,6 +777,16 @@ class MeshGlyph(GeoMixin, Glyph):
                   transparent. Passing `hillshade` with `location="face"`
                   raises `ValueError`.
 
+                A data-style preset option:
+
+                - `style` (str, default `None`): name of a
+                  `cleopatra.colors.DATA_STYLES` preset (valid names:
+                  `sorted(cleopatra.colors.DATA_STYLES)`). A continuous preset
+                  overrides the cmap + norm (and composes with `hillshade`); a
+                  categorical preset builds a discrete colormap, masks
+                  out-of-range codes transparent, and draws a legend instead of
+                  the colorbar. Takes precedence over `cmap`/`color_scale`.
+
         Returns:
             tuple[Figure, Axes]: The matplotlib Figure and Axes objects.
                 When no axes exist, a new figure is created. Call

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3960,6 +3960,16 @@ class TestArrayGlyphDataStyle:
             ArrayGlyph(self._accum(), style="flow_accumulation", hillshade=True).plot()
         plt.close("all")
 
+    def test_unknown_style_with_coords_reports_style_error_first(self):
+        """With a bad style name and curvilinear coords, the unknown-style error is reported first."""
+        arr = self._accum()
+        ny, nx = arr.shape
+        x = np.linspace(0.0, 1.0, nx)
+        y = np.linspace(0.0, 1.0, ny)
+        with pytest.raises(ValueError, match="unknown data style"):
+            ArrayGlyph(arr, coords=(x, y), style="not_a_style").plot()
+        plt.close("all")
+
 
 class TestArrayGlyphShadedAnimate:
     """Tests for hillshade + data-style presets in `animate`."""
@@ -4009,7 +4019,37 @@ class TestArrayGlyphShadedAnimate:
         anim._func(2)  # drive a frame; must not raise on the scale-norm colorbar
         assert g.im.cmap.name == "Blues"
         assert type(g.im.norm).__name__ == "SymLogNorm"
-        assert np.asarray(g.im.get_array()).ndim == 2, "hillshade dropped -> scalar frames"
+        frame = np.asarray(g.im.get_array())
+        assert frame.ndim == 3 and frame.shape[-1] == 4, "style renders its own RGBA (hillshade dropped)"
+        plt.close("all")
+
+    def test_continuous_style_animate_reproduces_alpha_glow(self):
+        """A value-linked-opacity preset fades low cells in animate too (plot/animate parity)."""
+        rng = np.random.default_rng(8)
+        accum = np.stack(
+            [np.abs(rng.normal(size=(20, 25))).cumsum(1) * 40 for _ in range(3)]
+        )
+        g = ArrayGlyph(accum, style="flow_accumulation")
+        anim = g.animate(time=list(range(3)))
+        anim._func(1)
+        frame = np.asarray(g.im.get_array())
+        assert frame.shape[-1] == 4, "animate frames are RGBA"
+        alpha = frame[..., 3]
+        assert alpha.min() < 0.2 and alpha.max() > 0.8, "opacity ramps with value like plot()"
+        plt.close("all")
+
+    def test_hillshade_animate_integer_masked_frame_does_not_crash(self):
+        """An integer masked frame (via data_getter) is shaded without a `ma.filled` TypeError."""
+        template = np.zeros((10, 10))
+        base = np.arange(100).reshape(10, 10)
+
+        def getter(i):
+            return np.ma.array((base + i).astype(int), mask=(base % 7 == 0))
+
+        g = ArrayGlyph(template, cmap="terrain", hillshade=True)
+        anim = g.animate(time=list(range(3)), data_getter=getter)
+        anim._func(1)  # integer masked frame through _display_frame's hillshade branch
+        assert np.asarray(g.im.get_array()).shape[-1] == 4
         plt.close("all")
 
     def test_continuous_style_animate_without_colorbar(self):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -4140,6 +4140,35 @@ class TestArrayGlyphShadedAnimate:
         assert g.cbar is None, "categorical presets use a legend, not a colorbar"
         plt.close("all")
 
+    def test_categorical_style_animate_with_hillshade_warns(self):
+        """A categorical preset + hillshade in animate warns and drops the relief."""
+        rng = np.random.default_rng(12)
+        d8 = np.stack(
+            [
+                rng.choice([1, 2, 4, 8, 16, 32, 64, 128], size=(12, 12)).astype(float)
+                for _ in range(3)
+            ]
+        )
+        with pytest.warns(UserWarning, match="categorical data-style preset"):
+            ArrayGlyph(d8, style="flow_direction_d8", hillshade=True).animate(
+                time=list(range(3))
+            )
+        plt.close("all")
+
+    def test_categorical_style_animate_without_colorbar(self):
+        """A categorical preset animates with `add_colorbar=False` (no legend, no colorbar)."""
+        rng = np.random.default_rng(13)
+        d8 = np.stack(
+            [
+                rng.choice([1, 2, 4, 8, 16, 32, 64, 128], size=(12, 12)).astype(float)
+                for _ in range(3)
+            ]
+        )
+        g = ArrayGlyph(d8, style="flow_direction_d8")
+        g.animate(time=list(range(3)), add_colorbar=False)
+        assert g.cbar is None and g.ax.get_legend() is None
+        plt.close("all")
+
     def test_categorical_animate_masks_out_of_range_codes(self):
         """Non-declared codes render transparent in animated categorical frames."""
         rng = np.random.default_rng(9)

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -4108,6 +4108,20 @@ class TestArrayGlyphShadedAnimate:
         assert g.im.cmap.name == "Blues"
         plt.close("all")
 
+    def test_animate_style_warns_and_bypasses_overlays(self):
+        """`animate` warns and drops point/cell-value overlays under a style, like `plot`."""
+        rng = np.random.default_rng(11)
+        accum = np.stack(
+            [np.abs(rng.normal(size=(20, 25))).cumsum(1) * 40 for _ in range(3)]
+        )
+        pts = np.array([[1.0, 2, 3], [2.0, 5, 6]])
+        g = ArrayGlyph(accum, style="flow_accumulation")
+        with pytest.warns(UserWarning, match="bypass point and cell-value overlays"):
+            g.animate(time=list(range(3)), points=pts)
+        # no scatter overlay drawn (the preset image is the only artist family)
+        assert len(g.ax.collections) == 0
+        plt.close("all")
+
     def test_categorical_style_in_animate_renders_with_legend(self):
         """A categorical preset animates: per-frame remap to RGBA + a discrete legend, no colorbar."""
         rng = np.random.default_rng(4)

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3941,6 +3941,13 @@ class TestArrayGlyphDataStyle:
         assert ax.get_legend() is not None
         plt.close("all")
 
+    def test_style_hides_pixel_ticks_without_extent(self):
+        """A style plot with no extent hides pixel-index ticks, like the imshow path."""
+        g = ArrayGlyph(self._accum(), style="flow_accumulation")
+        _, ax = g.plot()
+        assert ax.get_xticks().size == 0 and ax.get_yticks().size == 0
+        plt.close("all")
+
     def test_points_with_style_warns(self):
         """A preset bypasses point/cell-value overlays; the drop is warned, not silent."""
         pts = np.array([[1.0, 2, 3], [2.0, 5, 6]])

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3926,6 +3926,20 @@ class TestArrayGlyphDataStyle:
         assert ax.get_legend() is not None
         plt.close("all")
 
+    def test_points_with_style_warns(self):
+        """A preset bypasses point/cell-value overlays; the drop is warned, not silent."""
+        pts = np.array([[1.0, 2, 3], [2.0, 5, 6]])
+        with pytest.warns(UserWarning, match="bypass point and cell-value overlays"):
+            ArrayGlyph(self._accum()).plot(points=pts, style="flow_accumulation")
+        plt.close("all")
+
+    def test_rgb_with_style_warns(self):
+        """A `style` on an RGB array is ignored with a warning, not silently."""
+        rgb = np.random.default_rng(6).random((3, 8, 8))
+        with pytest.warns(UserWarning, match="do not apply to RGB"):
+            ArrayGlyph(rgb, rgb=[0, 1, 2], style="flow_accumulation").plot()
+        plt.close("all")
+
 
 class TestArrayGlyphShadedAnimate:
     """Tests for hillshade + data-style presets in `animate`."""

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3967,6 +3967,15 @@ class TestArrayGlyphDataStyle:
         assert not np.allclose(shaded[..., :3], base[..., :3]), "hillshade lit the preset colours"
         plt.close("all")
 
+    def test_categorical_style_with_hillshade_warns_not_shaded(self):
+        """A categorical preset + hillshade warns and is NOT relief-shaded (like MeshGlyph)."""
+        with pytest.warns(UserWarning, match="categorical data-style preset"):
+            g = ArrayGlyph(self._d8(), style="flow_direction_d8", hillshade=True)
+            g.plot()
+        # the categorical image keeps its flat class colours (RGBA from the preset)
+        assert np.asarray(g.im.get_array()).shape[-1] == 4
+        plt.close("all")
+
     def test_curvilinear_style_with_hillshade_warns(self):
         """On a curvilinear grid, `style` + `hillshade` warns (no 2D RGBA grid to light)."""
         arr = self._accum()

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3881,6 +3881,20 @@ class TestArrayGlyphDataStyle:
         assert np.asarray(g.im.get_array()).shape[-1] == 4
         plt.close("all")
 
+    def test_continuous_preset_draws_swatch_legend(self):
+        """A continuous preset draws its swatch legend as an inset child axes."""
+        g = ArrayGlyph(self._accum(), style="flow_accumulation")
+        _, ax = g.plot()
+        assert len(ax.child_axes) == 1
+        plt.close("all")
+
+    def test_continuous_add_colorbar_false_suppresses_swatch(self):
+        """`add_colorbar=False` suppresses the continuous swatch legend."""
+        g = ArrayGlyph(self._accum(), style="flow_accumulation")
+        _, ax = g.plot(add_colorbar=False)
+        assert len(ax.child_axes) == 0
+        plt.close("all")
+
     def test_categorical_preset_draws_disjoint_legend(self):
         """A categorical preset renders a discrete legend of its class codes."""
         g = ArrayGlyph(self._d8(), style="flow_direction_d8")

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -4081,8 +4081,8 @@ class TestArrayGlyphShadedAnimate:
         assert g.im.cmap.name == "Blues"
         plt.close("all")
 
-    def test_categorical_style_in_animate_raises(self):
-        """Categorical presets are not animated yet; raise a clear `NotImplementedError`."""
+    def test_categorical_style_in_animate_renders_with_legend(self):
+        """A categorical preset animates: per-frame remap to RGBA + a discrete legend, no colorbar."""
         rng = np.random.default_rng(4)
         d8 = np.stack(
             [
@@ -4090,6 +4090,27 @@ class TestArrayGlyphShadedAnimate:
                 for _ in range(3)
             ]
         )
-        with pytest.raises(NotImplementedError, match="categorical data-style presets"):
-            ArrayGlyph(d8, style="flow_direction_d8").animate(time=list(range(3)))
+        g = ArrayGlyph(d8, style="flow_direction_d8")
+        anim = g.animate(time=list(range(3)))
+        anim._func(1)
+        frame = np.asarray(g.im.get_array())
+        assert frame.ndim == 3 and frame.shape[-1] == 4, "categorical frames are RGBA"
+        assert g.ax.get_legend() is not None, "a discrete legend is drawn"
+        assert g.cbar is None, "categorical presets use a legend, not a colorbar"
+        plt.close("all")
+
+    def test_categorical_animate_masks_out_of_range_codes(self):
+        """Non-declared codes render transparent in animated categorical frames."""
+        rng = np.random.default_rng(9)
+        d8 = np.stack(
+            [
+                rng.choice([1, 2, 4, 8, 16, 32, 64, 128], size=(10, 10)).astype(float)
+                for _ in range(3)
+            ]
+        )
+        d8[:, 0, 0] = 999.0  # nodata / out-of-range
+        g = ArrayGlyph(d8, style="flow_direction_d8")
+        anim = g.animate(time=list(range(3)))
+        anim._func(1)
+        assert np.asarray(g.im.get_array())[0, 0, 3] == 0.0
         plt.close("all")

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3846,3 +3846,113 @@ class TestArrayGlyphHillshade:
         with pytest.warns(UserWarning, match="hillshade is only applied to kind='imshow'"):
             ArrayGlyph(self._dem(), cmap="terrain", hillshade=True).plot(kind="pcolormesh")
         plt.close("all")
+
+
+class TestArrayGlyphDataStyle:
+    """Tests for the `style` data-style preset option on `plot`."""
+
+    @staticmethod
+    def _accum():
+        rng = np.random.default_rng(0)
+        return np.abs(rng.normal(size=(30, 40))).cumsum(axis=1) * 50.0
+
+    @staticmethod
+    def _d8():
+        rng = np.random.default_rng(1)
+        return rng.choice([1, 2, 4, 8, 16, 32, 64, 128], size=(20, 20)).astype(float)
+
+    def test_continuous_preset_renders_image_without_colorbar(self):
+        """A continuous preset draws an image and presents its scale via a legend, not a colorbar."""
+        g = ArrayGlyph(self._accum(), style="flow_accumulation")
+        g.plot()
+        assert type(g.im).__name__ == "AxesImage"
+        assert g.cbar is None
+        plt.close("all")
+
+    def test_continuous_preset_renders_baked_rgba(self):
+        """The preset delegates to `apply_data_style`, baking the norm/alpha into an RGBA image.
+
+        The symlog norm is applied when building the RGBA (verified on the
+        animate path, which keeps the norm on the artist); here the drawn
+        image is the baked RGBA that alpha_scaled_image produces.
+        """
+        g = ArrayGlyph(self._accum(), style="flow_accumulation")
+        g.plot()
+        assert np.asarray(g.im.get_array()).shape[-1] == 4
+        plt.close("all")
+
+    def test_categorical_preset_draws_disjoint_legend(self):
+        """A categorical preset renders a discrete legend of its class codes."""
+        g = ArrayGlyph(self._d8(), style="flow_direction_d8")
+        _, ax = g.plot()
+        assert ax.get_legend() is not None
+        plt.close("all")
+
+    def test_add_colorbar_false_suppresses_preset_legend(self):
+        """`add_colorbar=False` suppresses the preset's legend."""
+        g = ArrayGlyph(self._d8(), style="flow_direction_d8")
+        _, ax = g.plot(add_colorbar=False)
+        assert ax.get_legend() is None
+        plt.close("all")
+
+    def test_unknown_style_raises(self):
+        """An unknown style name raises a clear `ValueError`."""
+        with pytest.raises(ValueError, match="unknown data style"):
+            ArrayGlyph(self._accum(), style="not_a_style").plot()
+        plt.close("all")
+
+    def test_multilayer_style_rejected(self):
+        """A multi-layer preset (`haze`) cannot apply to a single band."""
+        with pytest.raises(ValueError, match="multiple layers"):
+            ArrayGlyph(self._accum(), style="haze").plot()
+        plt.close("all")
+
+
+class TestArrayGlyphShadedAnimate:
+    """Tests for hillshade + data-style presets in `animate`."""
+
+    @staticmethod
+    def _dem_stack(n=5):
+        yy, xx = np.mgrid[0:30, 0:40]
+        return np.stack(
+            [
+                10.0
+                + 0.3 * yy
+                + 200.0 * np.exp(-(((xx - 20 - i) / 6) ** 2 + ((yy - 15) / 8) ** 2))
+                for i in range(n)
+            ]
+        )
+
+    def test_hillshade_shades_every_frame(self):
+        """`animate_a` shades each frame RGBA rather than reverting to the raw scalar frame."""
+        g = ArrayGlyph(self._dem_stack(), cmap="terrain", hillshade={"vert_exag": 5})
+        anim = g.animate(time=list(range(5)))
+        anim._func(2)  # drive a mid-sequence frame through animate_a
+        arr = np.asarray(g.im.get_array())
+        assert arr.ndim == 3 and arr.shape[-1] == 4
+        plt.close("all")
+
+    def test_continuous_style_applies_preset_cmap_and_norm(self):
+        """A continuous preset drives the animation through its cmap + norm."""
+        rng = np.random.default_rng(3)
+        accum = np.stack(
+            [np.abs(rng.normal(size=(20, 25))).cumsum(1) * 40 for _ in range(4)]
+        )
+        g = ArrayGlyph(accum, style="flow_accumulation")
+        g.animate(time=list(range(4)))
+        assert g.im.cmap.name == "Blues"
+        assert type(g.im.norm).__name__ == "SymLogNorm"
+        plt.close("all")
+
+    def test_categorical_style_in_animate_raises(self):
+        """Categorical presets are not animated yet; raise a clear `NotImplementedError`."""
+        rng = np.random.default_rng(4)
+        d8 = np.stack(
+            [
+                rng.choice([1, 2, 4, 8, 16, 32, 64, 128], size=(15, 15)).astype(float)
+                for _ in range(3)
+            ]
+        )
+        with pytest.raises(NotImplementedError, match="categorical data-style presets"):
+            ArrayGlyph(d8, style="flow_direction_d8").animate(time=list(range(3)))
+        plt.close("all")

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -4040,20 +4040,31 @@ class TestArrayGlyphShadedAnimate:
         assert type(g.im.norm).__name__ == "SymLogNorm"
         plt.close("all")
 
-    def test_symlog_style_with_hillshade_and_colorbar_does_not_crash(self):
-        """A symlog preset + hillshade + default colorbar animates: style wins, hillshade warned and dropped."""
+    def test_symlog_style_with_hillshade_composes_without_crash(self):
+        """A symlog preset + hillshade animates: relief composes into the preset RGBA, no scale-norm crash."""
         rng = np.random.default_rng(5)
         accum = np.stack(
             [np.abs(rng.normal(size=(20, 25))).cumsum(1) * 40 for _ in range(4)]
         )
-        g = ArrayGlyph(accum, style="flow_accumulation", hillshade=True)
-        with pytest.warns(UserWarning, match="hillshade is not composed"):
-            anim = g.animate(time=list(range(4)))
-        anim._func(2)  # drive a frame; must not raise on the scale-norm colorbar
+        g = ArrayGlyph(accum, style="flow_accumulation", hillshade={"vert_exag": 5})
+        anim = g.animate(time=list(range(4)))
+        anim._func(2)  # drive a frame; must not raise on the scale-norm path
         assert g.im.cmap.name == "Blues"
         assert type(g.im.norm).__name__ == "SymLogNorm"
         frame = np.asarray(g.im.get_array())
-        assert frame.ndim == 3 and frame.shape[-1] == 4, "style renders its own RGBA (hillshade dropped)"
+        assert frame.ndim == 3 and frame.shape[-1] == 4
+        plt.close("all")
+
+    def test_continuous_style_uses_swatch_legend_like_plot(self):
+        """A continuous preset presents a swatch legend (cbar=None) in animate, matching plot."""
+        rng = np.random.default_rng(6)
+        accum = np.stack(
+            [np.abs(rng.normal(size=(20, 25))).cumsum(1) * 40 for _ in range(3)]
+        )
+        g = ArrayGlyph(accum, style="flow_accumulation")
+        g.animate(time=list(range(3)))
+        assert g.cbar is None
+        assert len(g.ax.child_axes) == 1  # the swatch legend inset
         plt.close("all")
 
     def test_continuous_style_animate_reproduces_alpha_glow(self):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3954,6 +3954,12 @@ class TestArrayGlyphDataStyle:
             ArrayGlyph(rgb, rgb=[0, 1, 2], style="flow_accumulation").plot()
         plt.close("all")
 
+    def test_plot_style_with_hillshade_warns(self):
+        """In `plot`, a `style` takes precedence over `hillshade`, which is warned and dropped."""
+        with pytest.warns(UserWarning, match="hillshade is not composed"):
+            ArrayGlyph(self._accum(), style="flow_accumulation", hillshade=True).plot()
+        plt.close("all")
+
 
 class TestArrayGlyphShadedAnimate:
     """Tests for hillshade + data-style presets in `animate`."""
@@ -4004,6 +4010,18 @@ class TestArrayGlyphShadedAnimate:
         assert g.im.cmap.name == "Blues"
         assert type(g.im.norm).__name__ == "SymLogNorm"
         assert np.asarray(g.im.get_array()).ndim == 2, "hillshade dropped -> scalar frames"
+        plt.close("all")
+
+    def test_continuous_style_animate_without_colorbar(self):
+        """A continuous style animates with `add_colorbar=False` (no colorbar to refresh)."""
+        rng = np.random.default_rng(7)
+        accum = np.stack(
+            [np.abs(rng.normal(size=(20, 25))).cumsum(1) * 40 for _ in range(4)]
+        )
+        g = ArrayGlyph(accum, style="flow_accumulation")
+        g.animate(time=list(range(4)), add_colorbar=False)
+        assert g.cbar is None
+        assert g.im.cmap.name == "Blues"
         plt.close("all")
 
     def test_categorical_style_in_animate_raises(self):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -4065,6 +4065,8 @@ class TestArrayGlyphShadedAnimate:
         g.animate(time=list(range(3)))
         assert g.cbar is None
         assert len(g.ax.child_axes) == 1  # the swatch legend inset
+        g.animate(time=list(range(3)))  # repeat must not stack swatches
+        assert len(g.ax.child_axes) == 1
         plt.close("all")
 
     def test_continuous_style_animate_reproduces_alpha_glow(self):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3907,6 +3907,16 @@ class TestArrayGlyphDataStyle:
             ArrayGlyph(self._accum(), style="haze").plot()
         plt.close("all")
 
+    def test_curvilinear_coords_with_style_raises_clear_error(self):
+        """Curvilinear `coords` + `style` fails with a clear cleopatra message, not a matplotlib TypeError."""
+        arr = self._accum()
+        ny, nx = arr.shape
+        x = np.linspace(-3.0, 3.0, nx)
+        y = np.linspace(-3.0, 3.0, ny)
+        with pytest.raises(ValueError, match="do not support curvilinear 'coords'"):
+            ArrayGlyph(arr, coords=(x, y), style="flow_accumulation").plot()
+        plt.close("all")
+
 
 class TestArrayGlyphShadedAnimate:
     """Tests for hillshade + data-style presets in `animate`."""

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3921,14 +3921,15 @@ class TestArrayGlyphDataStyle:
             ArrayGlyph(self._accum(), style="haze").plot()
         plt.close("all")
 
-    def test_curvilinear_coords_with_style_raises_clear_error(self):
-        """Curvilinear `coords` + `style` fails with a clear cleopatra message, not a matplotlib TypeError."""
+    def test_curvilinear_coords_with_style_renders(self):
+        """Curvilinear `coords` + `style` render via shading='nearest' (a QuadMesh)."""
         arr = self._accum()
         ny, nx = arr.shape
         x = np.linspace(-3.0, 3.0, nx)
         y = np.linspace(-3.0, 3.0, ny)
-        with pytest.raises(ValueError, match="do not support curvilinear 'coords'"):
-            ArrayGlyph(arr, coords=(x, y), style="flow_accumulation").plot()
+        g = ArrayGlyph(arr, coords=(x, y), style="flow_accumulation")
+        g.plot()
+        assert type(g.im).__name__ == "QuadMesh"
         plt.close("all")
 
     def test_integer_masked_categorical_input_does_not_crash(self):
@@ -3954,10 +3955,26 @@ class TestArrayGlyphDataStyle:
             ArrayGlyph(rgb, rgb=[0, 1, 2], style="flow_accumulation").plot()
         plt.close("all")
 
-    def test_plot_style_with_hillshade_warns(self):
-        """In `plot`, a `style` takes precedence over `hillshade`, which is warned and dropped."""
-        with pytest.warns(UserWarning, match="hillshade is not composed"):
-            ArrayGlyph(self._accum(), style="flow_accumulation", hillshade=True).plot()
+    def test_plot_style_with_hillshade_composes(self):
+        """In `plot`, `style` + `hillshade` compose: the preset RGBA is relief-shaded."""
+        g = ArrayGlyph(self._accum(), style="flow_accumulation", hillshade={"vert_exag": 5})
+        g.plot()
+        shaded = np.asarray(g.im.get_array())
+        assert shaded.ndim == 3 and shaded.shape[-1] == 4
+        g2 = ArrayGlyph(self._accum(), style="flow_accumulation")
+        g2.plot()
+        base = np.asarray(g2.im.get_array())
+        assert not np.allclose(shaded[..., :3], base[..., :3]), "hillshade lit the preset colours"
+        plt.close("all")
+
+    def test_curvilinear_style_with_hillshade_warns(self):
+        """On a curvilinear grid, `style` + `hillshade` warns (no 2D RGBA grid to light)."""
+        arr = self._accum()
+        ny, nx = arr.shape
+        x = np.linspace(-3.0, 3.0, nx)
+        y = np.linspace(-3.0, 3.0, ny)
+        with pytest.warns(UserWarning, match="curvilinear grid"):
+            ArrayGlyph(arr, coords=(x, y), style="flow_accumulation", hillshade=True).plot()
         plt.close("all")
 
     def test_unknown_style_with_coords_reports_style_error_first(self):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3963,6 +3963,21 @@ class TestArrayGlyphShadedAnimate:
         assert type(g.im.norm).__name__ == "SymLogNorm"
         plt.close("all")
 
+    def test_symlog_style_with_hillshade_and_colorbar_does_not_crash(self):
+        """A symlog preset + hillshade + default colorbar animates: style wins, hillshade warned and dropped."""
+        rng = np.random.default_rng(5)
+        accum = np.stack(
+            [np.abs(rng.normal(size=(20, 25))).cumsum(1) * 40 for _ in range(4)]
+        )
+        g = ArrayGlyph(accum, style="flow_accumulation", hillshade=True)
+        with pytest.warns(UserWarning, match="hillshade is not composed"):
+            anim = g.animate(time=list(range(4)))
+        anim._func(2)  # drive a frame; must not raise on the scale-norm colorbar
+        assert g.im.cmap.name == "Blues"
+        assert type(g.im.norm).__name__ == "SymLogNorm"
+        assert np.asarray(g.im.get_array()).ndim == 2, "hillshade dropped -> scalar frames"
+        plt.close("all")
+
     def test_categorical_style_in_animate_raises(self):
         """Categorical presets are not animated yet; raise a clear `NotImplementedError`."""
         rng = np.random.default_rng(4)

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3917,6 +3917,15 @@ class TestArrayGlyphDataStyle:
             ArrayGlyph(arr, coords=(x, y), style="flow_accumulation").plot()
         plt.close("all")
 
+    def test_integer_masked_categorical_input_does_not_crash(self):
+        """An integer-coded categorical raster with masked nodata renders (no `ma.filled` TypeError)."""
+        rng = np.random.default_rng(2)
+        d8 = rng.choice([0, 1, 2, 4, 8, 16, 32, 64, 128], size=(20, 20))  # int dtype, 0 = nodata
+        g = ArrayGlyph(d8, style="flow_direction_d8", exclude_value=[0])
+        _, ax = g.plot()
+        assert ax.get_legend() is not None
+        plt.close("all")
+
 
 class TestArrayGlyphShadedAnimate:
     """Tests for hillshade + data-style presets in `animate`."""

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3982,7 +3982,7 @@ class TestArrayGlyphDataStyle:
         ny, nx = arr.shape
         x = np.linspace(-3.0, 3.0, nx)
         y = np.linspace(-3.0, 3.0, ny)
-        with pytest.warns(UserWarning, match="curvilinear grid"):
+        with pytest.warns(UserWarning, match="curvilinear data-style preset"):
             ArrayGlyph(arr, coords=(x, y), style="flow_accumulation", hillshade=True).plot()
         plt.close("all")
 

--- a/tests/test_hillshade.py
+++ b/tests/test_hillshade.py
@@ -17,6 +17,7 @@ from cleopatra.hillshade import (
     resolve_hillshade,
     shade_faces,
     shade_grid,
+    shade_rgb,
 )
 
 
@@ -101,6 +102,31 @@ class TestShadeGrid:
         rgba = shade_grid(dem, "terrain", vert_exag=5, multidirectional=[0.0, 90.0, 180.0])
         assert rgba.shape == dem.shape + (4,)
         assert np.all(np.isfinite(rgba))
+
+
+class TestShadeRgb:
+    """Tests for `shade_rgb` (lighting an already-coloured image)."""
+
+    @pytest.fixture
+    def dem(self):
+        """A small varied synthetic DEM."""
+        yy, xx = np.mgrid[0:20, 0:25]
+        return 10.0 + 0.5 * yy + 8.0 * np.sin(xx / 3.0) * np.cos(yy / 3.0)
+
+    def test_lights_the_input_colours(self, dem):
+        """Relief shading changes the supplied RGB rather than recolouring it."""
+        rgb = mpl.colormaps["viridis"](Normalize()(dem))[..., :3]
+        shaded = shade_rgb(rgb, dem, vert_exag=5)
+        assert shaded.shape == rgb.shape
+        assert not np.allclose(shaded, rgb)
+
+    def test_preserves_the_alpha_channel(self, dem):
+        """An input alpha channel is carried through unchanged."""
+        rgba = mpl.colormaps["viridis"](Normalize()(dem))
+        rgba[..., 3] = np.linspace(0.0, 1.0, rgba[..., 3].size).reshape(rgba.shape[:2])
+        out = shade_rgb(rgba, dem, vert_exag=5)
+        assert out.shape[-1] == 4
+        assert np.allclose(out[..., 3], rgba[..., 3])
 
 
 class TestShadeFaces:

--- a/tests/test_kde_glyph.py
+++ b/tests/test_kde_glyph.py
@@ -601,3 +601,14 @@ class TestKDEGlyphDataStyle:
         with pytest.raises(ValueError, match="unknown data style"):
             KDEGlyph(x, y, gridsize=40).plot(style="not_a_style")
         plt.close("all")
+
+    def test_plot_time_style_does_not_leak_cmap(self):
+        """A per-call `style` does not persist its colormap into a later `plot()`."""
+        x, y = self._cloud()
+        g = KDEGlyph(x, y, gridsize=40)
+        default_cmap = g.default_options["cmap"]
+        g.plot(style="temperature")
+        plt.close("all")
+        _, _, cs = g.plot()  # style=None
+        assert cs.get_cmap().name == default_cmap
+        plt.close("all")

--- a/tests/test_kde_glyph.py
+++ b/tests/test_kde_glyph.py
@@ -555,3 +555,49 @@ class TestKDEGlyphHillshade:
         assert ax.get_title() == "Density terrain"
         assert g.cbar is None
         plt.close("all")
+
+
+class TestKDEGlyphDataStyle:
+    """Tests for the `style` data-style preset option on KDEGlyph."""
+
+    @staticmethod
+    def _cloud():
+        rng = np.random.default_rng(3)
+        x = np.concatenate([rng.normal(-2, 0.7, 200), rng.normal(2, 1.0, 150)])
+        y = np.concatenate([rng.normal(-1, 0.6, 200), rng.normal(2, 1.2, 150)])
+        return x, y
+
+    def test_continuous_preset_sets_cmap_at_construction(self):
+        """A continuous preset set at construction colours the density."""
+        x, y = self._cloud()
+        _, _, cs = KDEGlyph(x, y, gridsize=40, style="temperature").plot()
+        assert cs.get_cmap().name == "RdYlBu_r"
+        plt.close("all")
+
+    def test_continuous_preset_at_plot_time(self):
+        """A continuous preset passed to `plot()` colours the density."""
+        x, y = self._cloud()
+        _, _, cs = KDEGlyph(x, y, gridsize=40).plot(style="elevation")
+        assert cs.get_cmap().name == "terrain"
+        plt.close("all")
+
+    def test_style_composes_with_hillshade(self):
+        """A continuous preset composes with the relief-shaded density image."""
+        x, y = self._cloud()
+        _, _, im = KDEGlyph(x, y, gridsize=40).plot(style="temperature", hillshade=True)
+        assert type(im).__name__ == "AxesImage"
+        plt.close("all")
+
+    def test_categorical_style_raises(self):
+        """A categorical preset is meaningless for a continuous density and raises."""
+        x, y = self._cloud()
+        with pytest.raises(ValueError, match="is categorical"):
+            KDEGlyph(x, y, gridsize=40, style="flow_direction_d8").plot()
+        plt.close("all")
+
+    def test_unknown_style_raises(self):
+        """An unknown style name raises a clear `ValueError`."""
+        x, y = self._cloud()
+        with pytest.raises(ValueError, match="unknown data style"):
+            KDEGlyph(x, y, gridsize=40).plot(style="not_a_style")
+        plt.close("all")

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1558,3 +1558,12 @@ class TestMeshGlyphDataStyle:
         g.plot(z, location="node", style="topography", hillshade=True)
         assert type(g.im).__name__ == "PolyCollection"
         plt.close("all")
+
+    def test_symlog_preset_colorbar_uses_a_log_locator(self):
+        """A symlog preset's colorbar picks a log locator, not the linear ticks."""
+        nx, ny, faces = self._mesh()
+        fvals = np.abs(np.random.default_rng(0).normal(size=len(faces))) * 100
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(fvals, location="face", style="flow_accumulation")
+        assert type(g._cbar.locator).__name__ == "SymmetricalLogLocator"
+        plt.close("all")

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1501,3 +1501,60 @@ class TestMeshGlyphHillshade:
         assert np.allclose(alphas[[0, 1]], 0.0), "nodata-touching faces are transparent"
         assert alphas[2] > 0.0, "the fully-finite face stays opaque"
         plt.close("all")
+
+
+class TestMeshGlyphDataStyle:
+    """Tests for the `style` data-style preset option on MeshGlyph."""
+
+    @staticmethod
+    def _mesh(n=8):
+        gx, gy = np.meshgrid(np.linspace(0, 10, n), np.linspace(0, 10, n))
+        nx, ny = gx.ravel(), gy.ravel()
+        faces = np.array(
+            [
+                [j * n + i, j * n + i + 1, j * n + i + n + 1, j * n + i + n]
+                for j in range(n - 1)
+                for i in range(n - 1)
+            ]
+        )
+        return nx, ny, faces
+
+    def test_continuous_preset_sets_cmap_and_norm(self):
+        """A continuous preset drives the mesh through its cmap + norm."""
+        nx, ny, faces = self._mesh()
+        fvals = np.abs(np.random.default_rng(0).normal(size=len(faces))) * 100
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(fvals, location="face", style="flow_accumulation")
+        assert g.im.cmap.name == "Blues"
+        assert type(g.im.norm).__name__ == "SymLogNorm"
+        plt.close("all")
+
+    def test_categorical_preset_draws_disjoint_legend(self):
+        """A categorical preset renders a discrete legend and no colorbar."""
+        nx, ny, faces = self._mesh()
+        d8 = np.random.default_rng(1).choice(
+            [1, 2, 4, 8, 16, 32, 64, 128], size=len(faces)
+        ).astype(float)
+        g = MeshGlyph(nx, ny, faces)
+        _, ax = g.plot(d8, location="face", style="flow_direction_d8")
+        assert ax.get_legend() is not None
+        assert g._cbar is None
+        plt.close("all")
+
+    def test_unknown_style_raises(self):
+        """An unknown style name raises a clear `ValueError`."""
+        nx, ny, faces = self._mesh()
+        with pytest.raises(ValueError, match="unknown data style"):
+            MeshGlyph(nx, ny, faces).plot(
+                np.ones(len(faces)), location="face", style="not_a_style"
+            )
+        plt.close("all")
+
+    def test_continuous_style_composes_with_hillshade(self):
+        """A continuous preset composes with node-elevation relief shading."""
+        nx, ny, faces = self._mesh()
+        z = 50 + 150 * np.exp(-(((nx - 7) / 2) ** 2 + ((ny - 5) / 3) ** 2))
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(z, location="node", style="topography", hillshade=True)
+        assert type(g.im).__name__ == "PolyCollection"
+        plt.close("all")

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1559,6 +1559,18 @@ class TestMeshGlyphDataStyle:
         assert type(g.im).__name__ == "PolyCollection"
         plt.close("all")
 
+    def test_categorical_preset_with_node_location_warns(self):
+        """A categorical preset on node data warns (tricontourf interpolates class codes)."""
+        nx, ny, faces = self._mesh()
+        codes = np.random.default_rng(2).choice(
+            [1, 2, 4, 8, 16, 32, 64, 128], size=len(nx)
+        ).astype(float)
+        with pytest.warns(UserWarning, match="interpolates discrete class codes"):
+            MeshGlyph(nx, ny, faces).plot(
+                codes, location="node", style="flow_direction_d8"
+            )
+        plt.close("all")
+
     def test_symlog_preset_colorbar_uses_a_log_locator(self):
         """A symlog preset's colorbar picks a log locator, not the linear ticks."""
         nx, ny, faces = self._mesh()


### PR DESCRIPTION
# Description

Closes #199. Adds a `style` data-style-preset option to cleopatra's surface glyphs so a named `DATA_STYLES` preset
(colormap + norm + nodata transparency + value-linked opacity + categorical legend) can be selected on
`plot()`/`animate()` — the mechanism downstream packages like pyramids forward by name.

- **`ArrayGlyph.style`** — `plot()` delegates to `cleopatra.colors.apply_data_style`, reproducing the full preset
  semantics (log/symlog/diverging norms, transparent nodata, alpha glow, categorical `disjoint_legend`). Works with
  curvilinear `coords` (via `shading="nearest"`) and **composes with `hillshade`** (the preset colours are
  relief-lit via the new `hillshade.shade_rgb`).
- **`ArrayGlyph.animate`** — continuous presets reproduce cmap + norm + value-linked opacity per frame;
  **categorical presets animate too** (per-frame remap to a discrete colormap + a legend drawn once). Hillshade is
  also (finally) applied to every animated frame.
- **`MeshGlyph.style`** — continuous presets override the tripcolor/tricontour cmap + norm (composing with
  node-elevation hillshade); categorical presets mask out-of-range codes and draw a discrete legend.
- **`KDEGlyph.style`** — continuous presets colour the density (composing with the shaded density image); a
  categorical preset raises a clear error (meaningless for a continuous density).
- **Public API** promoted for reuse (private aliases kept): `colors.resolve_style_norm`, `colors.alpha_rgba`,
  `colors.category_boundaries`, `colors.resolve_single_layer_style`, and `hillshade.shade_rgb`.
- Unknown / multi-layer style names, RGB arrays, and overlay kwargs are all guarded with clear errors or warnings.

**Dependencies:** none.

# Issues

- Closes #199 — data-style preset option (`style=`) + hillshade-in-animate, across ArrayGlyph, MeshGlyph, KDEGlyph.

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Run against the external uv env (`VIRTUAL_ENV=C:/python-environments/uv/cleopatra`, `MPLBACKEND=Agg`,
`uv run --active`):

- [x] Full non-e2e suite green: `pytest -m "not e2e" -q` -> **1463 passed**.
- [x] **72 style/animate/shade tests** across `test_array_glyph.py`, `test_mesh_glyph.py`, `test_kde_glyph.py`,
      `test_hillshade.py` — continuous + categorical presets on all three glyphs, plot + animate, curvilinear,
      style+hillshade composition, per-frame alpha glow, integer-masked input, and the guard paths.
- [x] The ArrayGlyph example notebook (new `style=` section) executes clean via `jupyter nbconvert --execute`;
      changed-module doctests green.
- [x] Two prior `/review-rounds` passes on the original prototype (14 findings resolved) plus this completion work.

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

> Note: the version bump / release (0.24.0) is handled by the repo's commitizen release PR (`version_provider =
> pep621`), not this feature branch — bumping here would double-bump at `cz bump`.