### PR TITLE
feat(glyphs): public apply_style() to (re)apply a data-style preset on an existing glyph

### DIFF
--- a/docs/notebooks/array_glyph/array_glyph_examples.ipynb
+++ b/docs/notebooks/array_glyph/array_glyph_examples.ipynb
@@ -882,6 +882,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7c3b4eef",
+   "metadata": {},
+   "source": [
+    "### Restyling an existing glyph: `apply_style()` and `.style`\n",
+    "\n",
+    "You can apply -- or change -- a preset on a glyph that already exists, without rebuilding it. `apply_style(name)` re-renders the glyph **in place** by preset name, `glyph.style` reads the applied preset back, and the style is **sticky** (a later plain `plot()` keeps it) and **clearable** (`plot(style=None)`). `apply_style` takes ownership of the glyph's own axes -- don't use it on an axes shared with other content."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b3ab0ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "glyph = ArrayGlyph(accum)\n",
+    "glyph.plot(title='default colouring')\n",
+    "print('style before:', glyph.style)\n",
+    "\n",
+    "glyph.apply_style('flow_accumulation')          # restyle in place, by name\n",
+    "print('style after apply_style:', glyph.style)\n",
+    "\n",
+    "glyph.plot(title='still flow_accumulation (sticky)')   # a plain plot keeps it\n",
+    "glyph.plot(style=None, title='cleared back to default')\n",
+    "print('style after plot(style=None):', glyph.style)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "45",
    "metadata": {},
    "source": [

--- a/docs/notebooks/kde_glyph/kde_glyph_examples.ipynb
+++ b/docs/notebooks/kde_glyph/kde_glyph_examples.ipynb
@@ -124,6 +124,31 @@
     "The two clusters read as shaded 'hills' -- the taller, denser peak clearly rising above the smaller one --\n",
     "which a flat colour ramp alone would not convey as vividly."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81f1770a",
+   "metadata": {},
+   "source": [
+    "## Data-style presets: `style=` and `apply_style()`\n",
+    "\n",
+    "Colour the density with a named preset. `style=` works at construction or `plot()` time; `apply_style(name)` restyles the glyph **in place** and `glyph.style` reads it back. The preset is sticky (a later plain `plot()` keeps it) and clearable (`plot(style=None)`). Only continuous presets apply -- a categorical preset is rejected, since a density is continuous."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac3a55ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kde = KDEGlyph(x, y, gridsize=80)\n",
+    "kde.plot(style='temperature')\n",
+    "print('style:', kde.style)\n",
+    "\n",
+    "kde.apply_style('precipitation')     # restyle the density in place\n",
+    "print('style after apply_style:', kde.style)"
+   ]
   }
  ],
  "metadata": {

--- a/docs/notebooks/mesh_glyph/mesh_glyph_examples.ipynb
+++ b/docs/notebooks/mesh_glyph/mesh_glyph_examples.ipynb
@@ -619,6 +619,31 @@
     "and the colorbar still reads the elevation scale. This is the same `hillshade` option as `ArrayGlyph`, using\n",
     "the mesh (`shade_faces`) geometry instead of the raster grid."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "15fecdce",
+   "metadata": {},
+   "source": [
+    "## Data-style presets: `style=` and `apply_style()`\n",
+    "\n",
+    "Pick a preset by name instead of a colormap. `style=` works at construction or `plot()` time; `apply_style(name)` restyles an existing glyph **in place** (reusing the last-plotted mesh data), `glyph.style` reads it back, and the preset is sticky/clearable. A continuous preset composes with `hillshade`; a categorical preset (e.g. `flow_direction_d8`) draws a discrete legend."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae0234b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mg = MeshGlyph(node_x, node_y, faces)\n",
+    "mg.plot(elevation, location='node', style='topography', title=\"style='topography'\")\n",
+    "print('style:', mg.style)\n",
+    "\n",
+    "mg.apply_style('elevation')          # restyle in place, reusing the data\n",
+    "print('style after apply_style:', mg.style)"
+   ]
   }
  ],
  "metadata": {

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1577,6 +1577,9 @@ class ArrayGlyph(GeoMixin, Glyph):
 
                 ```
         """
+        # Validate the name up front, before clearing the axes or persisting it,
+        # so a typo raises without wiping the render or poisoning the style.
+        resolve_single_layer_style(style)
         self._reset_axes_for_restyle()
         return self.plot(style=style, ax=self.ax, **kwargs)
 
@@ -2491,6 +2494,13 @@ class ArrayGlyph(GeoMixin, Glyph):
         # are reproduced rather than lossily mapped onto `color_scale`.
         style = self.default_options.get("style")
         if style is not None:
+            # Validate before rendering; on a bad name clear the sticky style
+            # and re-raise, so a poisoned name can't brick every later plot().
+            try:
+                resolve_single_layer_style(style)
+            except ValueError:
+                self.default_options["style"] = None
+                raise
             if self.rgb:
                 warnings.warn(
                     "data-style presets do not apply to RGB arrays; 'style' is "

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1541,10 +1541,14 @@ class ArrayGlyph(GeoMixin, Glyph):
         """Apply a `DATA_STYLES` preset by name, re-rendering the glyph in place.
 
         A discoverable wrapper over `plot(style=...)` for restyling an
-        already-built glyph: it redraws on the glyph's existing axes (clearing
-        the previous render first) or, if the glyph has not been plotted yet,
-        on a new figure. Extra keyword arguments (e.g. `hillshade`,
-        `add_colorbar`) are forwarded to `plot`.
+        already-built glyph. It redraws **in place** on the glyph's own axes
+        (clearing the previous render first), so `apply_style` takes full
+        ownership of that axes -- do not use it on an axes shared with unrelated
+        caller content. If the glyph was never plotted (or its figure was
+        closed), it renders on a fresh figure. Extra keyword arguments (e.g.
+        `hillshade`, `add_colorbar`) are forwarded to `plot`. The applied style
+        is **sticky** (survives a later plain `plot()`); `plot(style=None)`
+        clears it.
 
         Args:
             style: A `cleopatra.colors.DATA_STYLES` preset name (see
@@ -1573,19 +1577,8 @@ class ArrayGlyph(GeoMixin, Glyph):
 
                 ```
         """
-        if getattr(self, "ax", None) is not None:
-            self._clear_axes_for_restyle()
-            return self.plot(style=style, ax=self.ax, **kwargs)
-        return self.plot(style=style, **kwargs)
-
-    def _clear_axes_for_restyle(self) -> None:
-        """Remove the previous render (colorbar, legend insets, artists) in place."""
-        if self.cbar is not None:
-            self.cbar.remove()
-            self.cbar = None
-        for inset in list(self.ax.child_axes):
-            inset.remove()
-        self.ax.clear()
+        self._reset_axes_for_restyle()
+        return self.plot(style=style, ax=self.ax, **kwargs)
 
     def _resolve_style_layer(self, style: str) -> str:
         """Validate a `DATA_STYLES` name and return its single layer key.

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1528,6 +1528,65 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         return im, cbar_kw
 
+    @property
+    def style(self) -> str | None:
+        """Name of the `DATA_STYLES` preset currently applied, or `None`.
+
+        Reads back the preset set via the `style` constructor kwarg, a
+        `plot(style=...)` call, or `apply_style`.
+        """
+        return self.default_options.get("style")
+
+    def apply_style(self, style: str, **kwargs: Any) -> tuple[Figure, Axes]:
+        """Apply a `DATA_STYLES` preset by name, re-rendering the glyph in place.
+
+        A discoverable wrapper over `plot(style=...)` for restyling an
+        already-built glyph: it redraws on the glyph's existing axes (clearing
+        the previous render first) or, if the glyph has not been plotted yet,
+        on a new figure. Extra keyword arguments (e.g. `hillshade`,
+        `add_colorbar`) are forwarded to `plot`.
+
+        Args:
+            style: A `cleopatra.colors.DATA_STYLES` preset name (see
+                `sorted(cleopatra.colors.DATA_STYLES)`).
+            **kwargs: Forwarded to `plot` (e.g. `hillshade`).
+
+        Returns:
+            tuple[Figure, Axes]: The figure and axes drawn on.
+
+        Raises:
+            ValueError: If `style` is unknown or names a multi-layer preset
+                (raised by `plot`).
+
+        Examples:
+            - Restyle a rendered glyph by name:
+                ```python
+                >>> import matplotlib
+                >>> matplotlib.use("Agg")
+                >>> import numpy as np
+                >>> from cleopatra.array_glyph import ArrayGlyph
+                >>> glyph = ArrayGlyph(np.arange(60.0).reshape(6, 10))
+                >>> _ = glyph.plot()
+                >>> _ = glyph.apply_style("topography")
+                >>> glyph.style
+                'topography'
+
+                ```
+        """
+        if getattr(self, "ax", None) is not None:
+            self._clear_axes_for_restyle()
+            return self.plot(style=style, ax=self.ax, **kwargs)
+        return self.plot(style=style, **kwargs)
+
+    def _clear_axes_for_restyle(self) -> None:
+        """Remove the previous render (colorbar, legend insets, artists) in place."""
+        if self.cbar is not None:
+            self.cbar.remove()
+            self.cbar = None
+        for inset in list(self.ax.child_axes):
+            inset.remove()
+        self.ax.clear()
+
     def _resolve_style_layer(self, style: str) -> str:
         """Validate a `DATA_STYLES` name and return its single layer key.
 

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -371,6 +371,38 @@ class Glyph:
         fig, ax = plt.subplots(figsize=self.default_options["figsize"])
         return fig, ax
 
+    def _reset_axes_for_restyle(self) -> None:
+        """Prepare `self.ax` for an in-place restyle (used by `apply_style`).
+
+        When the glyph has a **live** axes (already plotted and its figure is
+        still open), the previous render is cleared from it -- the glyph's
+        colorbar, any legend / swatch inset axes, and all artists -- so the
+        restyle replaces the content in place. `apply_style` therefore takes
+        full ownership of this axes and must not be used on an axes shared with
+        unrelated caller content. When the glyph was never plotted, its figure
+        was closed, or it was built with a figure but no axes, a fresh axes is
+        created instead (on the existing figure when one is still open).
+        """
+        ax = getattr(self, "ax", None)
+        fig = getattr(self, "fig", None)
+        num = getattr(fig, "number", None)
+        fig_open = fig is not None and (num is None or plt.fignum_exists(num))
+        if ax is not None and fig_open:
+            for attr in ("cbar", "_cbar"):
+                cbar = getattr(self, attr, None)
+                if cbar is not None:
+                    cbar.remove()
+                    setattr(self, attr, None)
+            for inset in list(self.ax.child_axes):
+                inset.remove()
+            self.ax.clear()
+        elif fig_open:
+            # figure exists but has no axes (e.g. a `fig`-only construction):
+            # add one rather than crashing when `plot` dereferences `self.ax`.
+            self.ax = fig.add_subplot(111)
+        else:
+            self.fig, self.ax = self.create_figure_axes()
+
     def get_ticks(self) -> np.ndarray:
         """Compute colorbar tick locations from default_options.
 

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -76,6 +76,17 @@ def _root_figure(ax: Axes) -> Figure:
     return fig
 
 
+def _figure_is_open(fig: Figure | None) -> bool:
+    """True if `fig` is a live top-level `Figure` still registered with pyplot.
+
+    Pass a root `Figure` (resolve a `SubFigure` via `_root_figure` first); a
+    figure whose window/number has been closed, or a `SubFigure` (no `.number`),
+    returns `False`.
+    """
+    num = getattr(fig, "number", None)
+    return num is not None and plt.fignum_exists(num)
+
+
 def _immediate_figure(ax: Axes) -> Figure:
     """Return the figure `ax` is directly attached to (its immediate parent).
 
@@ -385,9 +396,11 @@ class Glyph:
         """
         ax = getattr(self, "ax", None)
         fig = getattr(self, "fig", None)
-        num = getattr(fig, "number", None)
-        fig_open = fig is not None and (num is None or plt.fignum_exists(num))
-        if ax is not None and fig_open:
+        # Decide liveness by the ROOT figure's number: a SubFigure has no number
+        # of its own, so resolving the root detects a closed parent Figure too.
+        root = _root_figure(ax) if ax is not None else fig
+        ax_live = ax is not None and _figure_is_open(root)
+        if ax_live:
             for attr in ("cbar", "_cbar"):
                 cbar = getattr(self, attr, None)
                 if cbar is not None:
@@ -396,10 +409,12 @@ class Glyph:
             for inset in list(self.ax.child_axes):
                 inset.remove()
             self.ax.clear()
-        elif fig_open:
-            # figure exists but has no axes (e.g. a `fig`-only construction):
-            # add one rather than crashing when `plot` dereferences `self.ax`.
-            self.ax = fig.add_subplot(111)
+        elif _figure_is_open(fig):
+            # A live figure with no (live) axes -- e.g. a `fig`-only construction:
+            # reuse an existing axes on it if present, else add one, rather than
+            # crashing when `plot` dereferences `self.ax` (or overlapping a
+            # caller's own axes with a fresh `111` subplot).
+            self.ax = fig.axes[0] if fig.axes else fig.add_subplot(111)
         else:
             self.fig, self.ax = self.create_figure_axes()
 

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -321,9 +321,11 @@ class KDEGlyph(Glyph):
         """Apply a continuous `DATA_STYLES` preset by name, re-rendering in place.
 
         A discoverable wrapper over `plot(style=...)` for restyling an
-        already-built glyph: it redraws on the glyph's existing axes (clearing
-        the previous render first) or, if the glyph has not been plotted yet,
-        on a new figure.
+        already-built glyph. It redraws **in place** on the glyph's own axes
+        (taking full ownership -- do not use on a shared axes), or on a fresh
+        figure if the glyph was never plotted or its figure was closed. The
+        applied style is **sticky** (survives a later plain `plot()`);
+        `plot(style=None)` clears it.
 
         Args:
             style: A continuous `cleopatra.colors.DATA_STYLES` preset name.
@@ -338,19 +340,10 @@ class KDEGlyph(Glyph):
             ValueError: If `style` is unknown, or is categorical (a density is
                 continuous), raised by `plot`.
         """
-        if getattr(self, "ax", None) is not None:
-            if self.cbar is not None:
-                self.cbar.remove()
-                self.cbar = None
-            for inset in list(self.ax.child_axes):
-                inset.remove()
-            self.ax.clear()
-            return self.plot(
-                ax=self.ax, title=title, add_colorbar=add_colorbar,
-                hillshade=hillshade, style=style,
-            )
+        self._reset_axes_for_restyle()
         return self.plot(
-            title=title, add_colorbar=add_colorbar, hillshade=hillshade, style=style
+            ax=self.ax, title=title, add_colorbar=add_colorbar,
+            hillshade=hillshade, style=style,
         )
 
     def plot(
@@ -383,7 +376,13 @@ class KDEGlyph(Glyph):
                 works the same way across all three glyphs.
             style: Name of a continuous `cleopatra.colors.DATA_STYLES` preset
                 to colour the density with (its cmap + norm; composes with
-                `hillshade`). Defaults to None, keeping the construction value.
+                `hillshade`). The preset name is **sticky** -- once set it
+                persists into `default_options` and survives later plain
+                `plot()` calls (like `ArrayGlyph`), and `self.style` reads it
+                back; the resolved cmap is not persisted, so it never leaks.
+                Not passing `style` keeps the current preset; passing
+                `style=None` clears it back to the plain density colouring
+                (unlike `hillshade`, which reverts to its construction value).
                 A categorical preset has no meaning for a continuous density
                 and raises `ValueError`. Valid names:
                 `sorted(cleopatra.colors.DATA_STYLES)`.

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -296,6 +296,58 @@ class KDEGlyph(Glyph):
                 f"{type(clip).__name__}."
             )
 
+    @property
+    def style(self) -> str | None:
+        """Name of the `DATA_STYLES` preset currently applied, or `None`.
+
+        Reads back the preset set via the `style` constructor kwarg, a
+        `plot(style=...)` call, or `apply_style`.
+        """
+        return self.default_options.get("style")
+
+    def apply_style(
+        self,
+        style: str,
+        *,
+        hillshade: bool | dict | None = None,
+        add_colorbar: bool | None = None,
+        title: str | None = None,
+    ):
+        """Apply a continuous `DATA_STYLES` preset by name, re-rendering in place.
+
+        A discoverable wrapper over `plot(style=...)` for restyling an
+        already-built glyph: it redraws on the glyph's existing axes (clearing
+        the previous render first) or, if the glyph has not been plotted yet,
+        on a new figure.
+
+        Args:
+            style: A continuous `cleopatra.colors.DATA_STYLES` preset name.
+            hillshade: Optional relief shading, forwarded to `plot`.
+            add_colorbar: Optional colorbar toggle, forwarded to `plot`.
+            title: Optional title, forwarded to `plot`.
+
+        Returns:
+            tuple[Figure, Axes, QuadContourSet]: The `plot` result.
+
+        Raises:
+            ValueError: If `style` is unknown, or is categorical (a density is
+                continuous), raised by `plot`.
+        """
+        if getattr(self, "ax", None) is not None:
+            if self.cbar is not None:
+                self.cbar.remove()
+                self.cbar = None
+            for inset in list(self.ax.child_axes):
+                inset.remove()
+            self.ax.clear()
+            return self.plot(
+                ax=self.ax, title=title, add_colorbar=add_colorbar,
+                hillshade=hillshade, style=style,
+            )
+        return self.plot(
+            title=title, add_colorbar=add_colorbar, hillshade=hillshade, style=style
+        )
+
     def plot(
         self,
         ax: Axes = None,
@@ -388,7 +440,12 @@ class KDEGlyph(Glyph):
         # has no meaning for a continuous density surface, so reject it. The
         # cmap is resolved into a LOCAL (not `opts`), so a per-call `style` does
         # not leak its colormap into a later `plot()` on the same instance.
-        style = style if style is not None else opts.get("style")
+        # Persist a plot-time `style` name into the options so `self.style`
+        # reads it back (matching ArrayGlyph, whose **kwargs persist it). Only
+        # the name is stored -- the resolved cmap stays a local (no leak).
+        if style is not None:
+            opts["style"] = style
+        style = opts.get("style")
         if style is not None:
             _, cfg = resolve_single_layer_style(style)
             if cfg.get("categories") is not None:

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -51,10 +51,21 @@ from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 #: the temporary at ~`MAX_KDE_BLOCK` floats (a few tens of MB).
 MAX_KDE_BLOCK = 4_000_000
 
-#: Sentinel for `plot(style=...)` distinguishing "not passed" (keep the current
-#: sticky style) from an explicit `style=None` (clear it back to plain density
-#: colouring). KDE's fixed signature cannot use `None` for both.
-_UNSET = object()
+class _Unset:
+    """Sentinel type for `plot(style=...)`'s tri-state default.
+
+    Distinguishes "not passed" (keep the current sticky style) from an explicit
+    `style=None` (clear it back to plain density colouring); KDE's fixed
+    signature cannot use `None` for both. A named type (rather than a bare
+    `object()`) keeps the `str | None | _Unset` annotation accurate for mypy.
+    """
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<UNSET>"
+
+
+#: The single `_Unset` sentinel instance used as `plot(style=...)`'s default.
+_UNSET = _Unset()
 
 #: Option keys for KDEGlyph. `ticks_spacing` is `None` so the shared
 #: `_prepare_scalar_mapping` helper auto-derives it from the density range.
@@ -338,8 +349,17 @@ class KDEGlyph(Glyph):
 
         Raises:
             ValueError: If `style` is unknown, or is categorical (a density is
-                continuous), raised by `plot`.
+                continuous).
         """
+        # Validate the name up front, before clearing the axes or persisting it,
+        # so a bad/categorical style raises without wiping the render or
+        # poisoning the style (a categorical preset is invalid for a density).
+        _, cfg = resolve_single_layer_style(style)
+        if cfg.get("categories") is not None:
+            raise ValueError(
+                f"data style {style!r} is categorical; KDEGlyph colours a "
+                "continuous density, so only continuous presets apply"
+            )
         self._reset_axes_for_restyle()
         return self.plot(
             ax=self.ax, title=title, add_colorbar=add_colorbar,
@@ -352,7 +372,7 @@ class KDEGlyph(Glyph):
         title: str | None = None,
         add_colorbar: bool | None = None,
         hillshade: bool | dict | None = None,
-        style: str | None = _UNSET,
+        style: str | None | _Unset = _UNSET,
     ):
         """Render the 2-D density as filled or line contours.
 
@@ -449,16 +469,24 @@ class KDEGlyph(Glyph):
         # ArrayGlyph). Only the name is stored -- the resolved cmap stays a
         # local (no leak). A passed `style=None` clears it; not passing `style`
         # (the `_UNSET` sentinel) keeps the current sticky value.
+        prev_style = opts.get("style")
         if style is not _UNSET:
             opts["style"] = style
         style = opts.get("style")
         if style is not None:
-            _, cfg = resolve_single_layer_style(style)
-            if cfg.get("categories") is not None:
-                raise ValueError(
-                    f"data style {style!r} is categorical; KDEGlyph colours a "
-                    "continuous density, so only continuous presets apply"
-                )
+            # Validate before rendering, and roll back to the prior good style
+            # on a bad/categorical name so the sticky style isn't poisoned
+            # (a poisoned name would re-raise on every later plot()).
+            try:
+                _, cfg = resolve_single_layer_style(style)
+                if cfg.get("categories") is not None:
+                    raise ValueError(
+                        f"data style {style!r} is categorical; KDEGlyph colours "
+                        "a continuous density, so only continuous presets apply"
+                    )
+            except ValueError:
+                opts["style"] = prev_style
+                raise
             cmap = cfg["cmap"]
             norm, _, _ = resolve_style_norm(np.asarray(density, dtype=float), cfg)
             # Drop the linear ticks so the colorbar matches the preset norm.

--- a/src/cleopatra/kde_glyph.py
+++ b/src/cleopatra/kde_glyph.py
@@ -51,6 +51,11 @@ from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 #: the temporary at ~`MAX_KDE_BLOCK` floats (a few tens of MB).
 MAX_KDE_BLOCK = 4_000_000
 
+#: Sentinel for `plot(style=...)` distinguishing "not passed" (keep the current
+#: sticky style) from an explicit `style=None` (clear it back to plain density
+#: colouring). KDE's fixed signature cannot use `None` for both.
+_UNSET = object()
+
 #: Option keys for KDEGlyph. `ticks_spacing` is `None` so the shared
 #: `_prepare_scalar_mapping` helper auto-derives it from the density range.
 KDE_DEFAULT_OPTIONS = {
@@ -354,7 +359,7 @@ class KDEGlyph(Glyph):
         title: str | None = None,
         add_colorbar: bool | None = None,
         hillshade: bool | dict | None = None,
-        style: str | None = None,
+        style: str | None = _UNSET,
     ):
         """Render the 2-D density as filled or line contours.
 
@@ -440,10 +445,12 @@ class KDEGlyph(Glyph):
         # has no meaning for a continuous density surface, so reject it. The
         # cmap is resolved into a LOCAL (not `opts`), so a per-call `style` does
         # not leak its colormap into a later `plot()` on the same instance.
-        # Persist a plot-time `style` name into the options so `self.style`
-        # reads it back (matching ArrayGlyph, whose **kwargs persist it). Only
-        # the name is stored -- the resolved cmap stays a local (no leak).
-        if style is not None:
+        # Persist a plot-time `style` into the options so `self.style` reads it
+        # back and it stays sticky across later plain `plot()` calls (matching
+        # ArrayGlyph). Only the name is stored -- the resolved cmap stays a
+        # local (no leak). A passed `style=None` clears it; not passing `style`
+        # (the `_UNSET` sentinel) keeps the current sticky value.
+        if style is not _UNSET:
             opts["style"] = style
         style = opts.get("style")
         if style is not None:

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -180,9 +180,12 @@ class MeshGlyph(GeoMixin, Glyph):
         #: `hillshade` is not overridden at `plot()` time -- keeping the option
         #: honoured at construction, consistent with `ArrayGlyph`/`KDEGlyph`.
         self._construct_hillshade = self.default_options.get("hillshade", False)
-        #: `style` set at construction, restored after `plot()`'s options reset
-        #: (same shim as `hillshade`) so a construction-time preset is honoured.
-        self._construct_style = self.default_options.get("style")
+        #: The sticky `style` preset. `plot()` resets `default_options` each
+        #: call, so this tracks the current preset (updated whenever `plot()` /
+        #: `apply_style` passes `style`, including `None` to clear) and is
+        #: restored after the reset -- so a style survives a later plain
+        #: `plot(data)` (sticky + clearable, like `ArrayGlyph`).
+        self._style_state = self.default_options.get("style")
         #: Last `(data, location)` rendered, so `apply_style` can restyle in
         #: place without the caller re-supplying the mesh data.
         self._last_data = None
@@ -957,13 +960,16 @@ class MeshGlyph(GeoMixin, Glyph):
                 render_kwargs[key] = val
         self._merge_kwargs(option_kwargs)
 
-        # The reset above drops a construction-time `hillshade`/`style`; restore
-        # each unless this `plot()` call overrides it, so both options behave
-        # like they do on `ArrayGlyph`/`KDEGlyph` (honoured at construction).
+        # The reset above drops `hillshade`/`style`; restore each unless this
+        # `plot()` overrides it. `hillshade` reverts to its construction value;
+        # `style` is sticky (tracks the last applied preset, incl. a `None`
+        # clear) so it survives a later plain `plot(data)` like on `ArrayGlyph`.
         if "hillshade" not in option_kwargs:
             self.default_options["hillshade"] = self._construct_hillshade
-        if "style" not in option_kwargs:
-            self.default_options["style"] = self._construct_style
+        if "style" in option_kwargs:
+            self._style_state = self.default_options["style"]
+        else:
+            self.default_options["style"] = self._style_state
 
         # Remember what was rendered so `apply_style` can restyle in place.
         self._last_data = data

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -734,9 +734,13 @@ class MeshGlyph(GeoMixin, Glyph):
         """Apply a `DATA_STYLES` preset by name, re-rendering the mesh in place.
 
         A discoverable wrapper over `plot(style=...)` for restyling an
-        already-built glyph. It reuses the last-plotted mesh data (and
-        location) so the caller need not re-supply it; pass `data=` when the
-        glyph has not been plotted yet. Extra keyword arguments (e.g.
+        already-built glyph. It redraws **in place** on the glyph's own axes
+        (taking full ownership -- do not use on a shared axes), or on a fresh
+        figure if the glyph was never plotted or its figure was closed. It
+        reuses the last-plotted mesh data (and location) so the caller need not
+        re-supply it; pass `data=` when the glyph has not been plotted yet. The
+        applied style is **sticky** (survives a later plain `plot(data)`);
+        `plot(data, style=None)` clears it. Extra keyword arguments (e.g.
         `location`, `hillshade`, `edgecolor`) are forwarded to `plot`.
 
         Args:
@@ -759,17 +763,8 @@ class MeshGlyph(GeoMixin, Glyph):
                     "or pass data= explicitly."
                 )
         location = kwargs.pop("location", self._last_location)
-        if getattr(self, "ax", None) is not None:
-            if self._cbar is not None:
-                self._cbar.remove()
-                self._cbar = None
-            for inset in list(self.ax.child_axes):
-                inset.remove()
-            self.ax.clear()
-            return self.plot(
-                data, location=location, ax=self.ax, style=style, **kwargs
-            )
-        return self.plot(data, location=location, style=style, **kwargs)
+        self._reset_axes_for_restyle()
+        return self.plot(data, location=location, ax=self.ax, style=style, **kwargs)
 
     def plot(
         self,
@@ -972,7 +967,9 @@ class MeshGlyph(GeoMixin, Glyph):
             self.default_options["style"] = self._style_state
 
         # Remember what was rendered so `apply_style` can restyle in place.
-        self._last_data = data
+        # Copy the array so a caller mutating its buffer after plot() (a common
+        # reuse pattern) does not change what a later `apply_style` renders.
+        self._last_data = np.array(data, copy=True)
         self._last_location = location
 
         # Recompute vmin/vmax from data unless user explicitly passed them.

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -755,6 +755,9 @@ class MeshGlyph(GeoMixin, Glyph):
             ValueError: If `style` is unknown (raised by `plot`), or no data is
                 available (never plotted and none passed).
         """
+        # Validate the name up front, before touching data/axes or persisting
+        # it, so a typo raises without wiping the render or poisoning the style.
+        resolve_single_layer_style(style)
         if data is None:
             data = self._last_data
             if data is None:
@@ -962,14 +965,27 @@ class MeshGlyph(GeoMixin, Glyph):
         if "hillshade" not in option_kwargs:
             self.default_options["hillshade"] = self._construct_hillshade
         if "style" in option_kwargs:
-            self._style_state = self.default_options["style"]
+            new_style = self.default_options["style"]
+            if new_style is not None:
+                # Validate before committing to the sticky state, and roll back
+                # to the prior good style on a bad name so the glyph isn't
+                # bricked (a poisoned sticky style re-raises on every plot).
+                try:
+                    resolve_single_layer_style(new_style)
+                except ValueError:
+                    self.default_options["style"] = self._style_state
+                    raise
+            self._style_state = new_style
         else:
             self.default_options["style"] = self._style_state
 
         # Remember what was rendered so `apply_style` can restyle in place.
         # Copy the array so a caller mutating its buffer after plot() (a common
-        # reuse pattern) does not change what a later `apply_style` renders.
-        self._last_data = np.array(data, copy=True)
+        # reuse pattern) does not change what a later `apply_style` renders;
+        # preserve a masked array's mask (a plain `np.array` copy would drop it).
+        self._last_data = (
+            np.ma.copy(data) if np.ma.isMaskedArray(data) else np.array(data, copy=True)
+        )
         self._last_location = location
 
         # Recompute vmin/vmax from data unless user explicitly passed them.

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -180,6 +180,13 @@ class MeshGlyph(GeoMixin, Glyph):
         #: `hillshade` is not overridden at `plot()` time -- keeping the option
         #: honoured at construction, consistent with `ArrayGlyph`/`KDEGlyph`.
         self._construct_hillshade = self.default_options.get("hillshade", False)
+        #: `style` set at construction, restored after `plot()`'s options reset
+        #: (same shim as `hillshade`) so a construction-time preset is honoured.
+        self._construct_style = self.default_options.get("style")
+        #: Last `(data, location)` rendered, so `apply_style` can restyle in
+        #: place without the caller re-supplying the mesh data.
+        self._last_data = None
+        self._last_location = "face"
 
     @property
     def node_x(self) -> np.ndarray:
@@ -709,6 +716,58 @@ class MeshGlyph(GeoMixin, Glyph):
         tpc.set_facecolor(shaded)
         return tpc
 
+    @property
+    def style(self) -> str | None:
+        """Name of the `DATA_STYLES` preset currently applied, or `None`.
+
+        Reads back the preset set via the `style` constructor kwarg, a
+        `plot(style=...)` call, or `apply_style`.
+        """
+        return self.default_options.get("style")
+
+    def apply_style(
+        self, style: str, data: np.ndarray | None = None, **kwargs: Any
+    ) -> tuple[plt.Figure, plt.Axes]:
+        """Apply a `DATA_STYLES` preset by name, re-rendering the mesh in place.
+
+        A discoverable wrapper over `plot(style=...)` for restyling an
+        already-built glyph. It reuses the last-plotted mesh data (and
+        location) so the caller need not re-supply it; pass `data=` when the
+        glyph has not been plotted yet. Extra keyword arguments (e.g.
+        `location`, `hillshade`, `edgecolor`) are forwarded to `plot`.
+
+        Args:
+            style: A `cleopatra.colors.DATA_STYLES` preset name.
+            data: Mesh data to render; defaults to the last-plotted data.
+            **kwargs: Forwarded to `plot` (e.g. `location`, `hillshade`).
+
+        Returns:
+            tuple[Figure, Axes]: The figure and axes drawn on.
+
+        Raises:
+            ValueError: If `style` is unknown (raised by `plot`), or no data is
+                available (never plotted and none passed).
+        """
+        if data is None:
+            data = self._last_data
+            if data is None:
+                raise ValueError(
+                    "apply_style needs mesh data: call plot(data, ...) first, "
+                    "or pass data= explicitly."
+                )
+        location = kwargs.pop("location", self._last_location)
+        if getattr(self, "ax", None) is not None:
+            if self._cbar is not None:
+                self._cbar.remove()
+                self._cbar = None
+            for inset in list(self.ax.child_axes):
+                inset.remove()
+            self.ax.clear()
+            return self.plot(
+                data, location=location, ax=self.ax, style=style, **kwargs
+            )
+        return self.plot(data, location=location, style=style, **kwargs)
+
     def plot(
         self,
         data: np.ndarray,
@@ -898,11 +957,17 @@ class MeshGlyph(GeoMixin, Glyph):
                 render_kwargs[key] = val
         self._merge_kwargs(option_kwargs)
 
-        # The reset above drops a construction-time `hillshade`; restore it
-        # unless this `plot()` call overrides it, so the option behaves like
-        # it does on `ArrayGlyph`/`KDEGlyph` (honoured at construction).
+        # The reset above drops a construction-time `hillshade`/`style`; restore
+        # each unless this `plot()` call overrides it, so both options behave
+        # like they do on `ArrayGlyph`/`KDEGlyph` (honoured at construction).
         if "hillshade" not in option_kwargs:
             self.default_options["hillshade"] = self._construct_hillshade
+        if "style" not in option_kwargs:
+            self.default_options["style"] = self._construct_style
+
+        # Remember what was rendered so `apply_style` can restyle in place.
+        self._last_data = data
+        self._last_location = location
 
         # Recompute vmin/vmax from data unless user explicitly passed them.
         if "vmin" not in option_kwargs:

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -4239,6 +4239,26 @@ class TestArrayGlyphApplyStyle:
             ArrayGlyph(self._dem()).apply_style("not_a_style")
         plt.close("all")
 
+    def test_failed_apply_style_leaves_glyph_usable(self):
+        """A bad apply_style name raises without poisoning the style or wiping the render."""
+        g = ArrayGlyph(self._dem())
+        g.plot(style="topography")
+        with pytest.raises(ValueError, match="unknown data style"):
+            g.apply_style("not_a_style")
+        assert g.style == "topography"  # prior good style preserved
+        assert np.asarray(g.im.get_array()).ndim == 3  # render not wiped
+        g.plot()  # still usable
+        plt.close("all")
+
+    def test_failed_plot_style_does_not_poison(self):
+        """plot(style='bad') raises and clears the style so later plain plot() works."""
+        g = ArrayGlyph(self._dem())
+        with pytest.raises(ValueError, match="unknown data style"):
+            g.plot(style="not_a_style")
+        assert g.style is None
+        g.plot()  # not bricked
+        plt.close("all")
+
     def test_style_is_sticky_and_clearable(self):
         """A style survives a later plain plot() and is cleared by style=None."""
         g = ArrayGlyph(self._dem())

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -4186,3 +4186,55 @@ class TestArrayGlyphShadedAnimate:
         anim._func(1)
         assert np.asarray(g.im.get_array())[0, 0, 3] == 0.0
         plt.close("all")
+
+
+class TestArrayGlyphApplyStyle:
+    """Tests for the public `apply_style` method and `style` read-back."""
+
+    @staticmethod
+    def _dem():
+        return np.arange(600.0).reshape(20, 30)
+
+    def test_style_defaults_to_none(self):
+        """`style` is None on a glyph with no preset applied."""
+        assert ArrayGlyph(self._dem()).style is None
+
+    def test_apply_style_restyles_in_place_and_reads_back(self):
+        """apply_style renders the preset and `style` reads back its name."""
+        g = ArrayGlyph(self._dem())
+        g.plot()
+        g.apply_style("topography")
+        assert g.style == "topography"
+        assert g.cbar is None and len(g.ax.child_axes) == 1
+        plt.close("all")
+
+    def test_apply_style_repeated_does_not_stack_legends(self):
+        """Restyling repeatedly replaces the render rather than stacking insets."""
+        g = ArrayGlyph(self._dem())
+        g.plot()
+        g.apply_style("topography")
+        g.apply_style("flow_accumulation")
+        assert g.style == "flow_accumulation"
+        assert len(g.ax.child_axes) == 1
+        plt.close("all")
+
+    def test_apply_style_forwards_hillshade(self):
+        """Extra kwargs (hillshade) are forwarded to plot and compose."""
+        g = ArrayGlyph(self._dem())
+        g.plot()
+        g.apply_style("topography", hillshade={"vert_exag": 6})
+        assert np.asarray(g.im.get_array()).ndim == 3  # shaded RGBA
+        plt.close("all")
+
+    def test_apply_style_on_unplotted_glyph_creates_figure(self):
+        """apply_style works before any plot() (renders on a fresh figure)."""
+        g = ArrayGlyph(self._dem())
+        fig, ax = g.apply_style("elevation")
+        assert fig is not None and g.style == "elevation"
+        plt.close("all")
+
+    def test_apply_style_unknown_name_raises(self):
+        """An unknown preset name raises a clear `ValueError`."""
+        with pytest.raises(ValueError, match="unknown data style"):
+            ArrayGlyph(self._dem()).apply_style("not_a_style")
+        plt.close("all")

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -4238,3 +4238,12 @@ class TestArrayGlyphApplyStyle:
         with pytest.raises(ValueError, match="unknown data style"):
             ArrayGlyph(self._dem()).apply_style("not_a_style")
         plt.close("all")
+
+    def test_style_is_sticky_and_clearable(self):
+        """A style survives a later plain plot() and is cleared by style=None."""
+        g = ArrayGlyph(self._dem())
+        g.plot(style="topography")
+        g.plot()
+        assert g.style == "topography"
+        g.plot(style=None)
+        assert g.style is None

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -4247,3 +4247,37 @@ class TestArrayGlyphApplyStyle:
         assert g.style == "topography"
         g.plot(style=None)
         assert g.style is None
+
+    def test_apply_style_on_closed_figure_renders_fresh(self):
+        """After the figure is closed, apply_style renders on a new live figure."""
+        g = ArrayGlyph(self._dem())
+        fig, _ = g.plot()
+        plt.close(fig)
+        g.apply_style("topography")
+        assert plt.fignum_exists(g.fig.number)
+        plt.close("all")
+
+    def test_apply_style_on_fig_only_construction_does_not_crash(self):
+        """apply_style on a glyph built with fig= but never plotted creates an axes."""
+        fig = plt.figure()
+        g = ArrayGlyph(self._dem(), fig=fig)
+        g.apply_style("elevation")
+        assert g.ax is not None and g.style == "elevation"
+        plt.close("all")
+
+    def test_apply_style_takes_ownership_of_its_axes(self):
+        """apply_style clears the glyph's axes (documented full ownership)."""
+        g = ArrayGlyph(self._dem())
+        _, ax = g.plot()
+        ax.plot([0, 1], [0, 1])  # prior artist on the glyph's axes
+        g.apply_style("topography")
+        assert len(ax.lines) == 0  # the restyle owns and clears the axes
+        plt.close("all")
+
+    def test_apply_style_forwards_add_colorbar(self):
+        """add_colorbar=False forwards to plot (no swatch legend inset drawn)."""
+        g = ArrayGlyph(self._dem())
+        g.plot()
+        g.apply_style("flow_accumulation", add_colorbar=False)
+        assert len(g.ax.child_axes) == 0
+        plt.close("all")

--- a/tests/test_kde_glyph.py
+++ b/tests/test_kde_glyph.py
@@ -602,13 +602,52 @@ class TestKDEGlyphDataStyle:
             KDEGlyph(x, y, gridsize=40).plot(style="not_a_style")
         plt.close("all")
 
-    def test_plot_time_style_does_not_leak_cmap(self):
-        """A per-call `style` does not persist its colormap into a later `plot()`."""
+    def test_style_renders_preset_cmap_without_mutating_default(self):
+        """A style renders with the preset cmap but never overwrites `default_options['cmap']`.
+
+        A plot-time `style` name persists (like ArrayGlyph), so a later plain
+        `plot()` keeps it -- but the base `default_options['cmap']` is left
+        untouched (the cmap is resolved into a local), so nothing is corrupted.
+        """
         x, y = self._cloud()
         g = KDEGlyph(x, y, gridsize=40)
         default_cmap = g.default_options["cmap"]
-        g.plot(style="temperature")
+        _, _, cs = g.plot(style="temperature")
+        assert cs.get_cmap().name == "RdYlBu_r"
+        assert g.default_options["cmap"] == default_cmap
+        assert g.style == "temperature"  # the name persists for read-back
         plt.close("all")
-        _, _, cs = g.plot()  # style=None
-        assert cs.get_cmap().name == default_cmap
+
+
+class TestKDEGlyphApplyStyle:
+    """Tests for the public `apply_style` method and `style` read-back."""
+
+    @staticmethod
+    def _cloud():
+        rng = np.random.default_rng(3)
+        x = np.concatenate([rng.normal(-2, 0.7, 200), rng.normal(2, 1.0, 150)])
+        y = np.concatenate([rng.normal(-1, 0.6, 200), rng.normal(2, 1.2, 150)])
+        return x, y
+
+    def test_apply_style_restyles_and_reads_back(self):
+        """apply_style colours the density and `style` reads back its name."""
+        x, y = self._cloud()
+        g = KDEGlyph(x, y, gridsize=40)
+        g.plot()
+        _, _, cs = g.apply_style("temperature")
+        assert g.style == "temperature" and cs.get_cmap().name == "RdYlBu_r"
+        plt.close("all")
+
+    def test_apply_style_categorical_raises(self):
+        """A categorical preset via apply_style raises (density is continuous)."""
+        x, y = self._cloud()
+        with pytest.raises(ValueError, match="is categorical"):
+            KDEGlyph(x, y, gridsize=40).apply_style("flow_direction_d8")
+        plt.close("all")
+
+    def test_apply_style_unknown_name_raises(self):
+        """An unknown preset name raises a clear `ValueError`."""
+        x, y = self._cloud()
+        with pytest.raises(ValueError, match="unknown data style"):
+            KDEGlyph(x, y, gridsize=40).apply_style("not_a_style")
         plt.close("all")

--- a/tests/test_kde_glyph.py
+++ b/tests/test_kde_glyph.py
@@ -652,6 +652,16 @@ class TestKDEGlyphApplyStyle:
             KDEGlyph(x, y, gridsize=40).apply_style("not_a_style")
         plt.close("all")
 
+    def test_failed_plot_style_does_not_poison(self):
+        """plot(style='bad') raises and does not brick later plain plot()."""
+        x, y = self._cloud()
+        g = KDEGlyph(x, y, gridsize=40)
+        with pytest.raises(ValueError, match="unknown data style"):
+            g.plot(style="not_a_style")
+        assert g.style is None
+        g.plot()  # not bricked
+        plt.close("all")
+
     def test_style_is_sticky_and_clearable(self):
         """A style survives a later plain plot() and is cleared by style=None."""
         x, y = self._cloud()

--- a/tests/test_kde_glyph.py
+++ b/tests/test_kde_glyph.py
@@ -651,3 +651,14 @@ class TestKDEGlyphApplyStyle:
         with pytest.raises(ValueError, match="unknown data style"):
             KDEGlyph(x, y, gridsize=40).apply_style("not_a_style")
         plt.close("all")
+
+    def test_style_is_sticky_and_clearable(self):
+        """A style survives a later plain plot() and is cleared by style=None."""
+        x, y = self._cloud()
+        g = KDEGlyph(x, y, gridsize=40)
+        g.plot(style="temperature")
+        g.plot()
+        assert g.style == "temperature"
+        g.plot(style=None)
+        assert g.style is None
+        plt.close("all")

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1579,3 +1579,57 @@ class TestMeshGlyphDataStyle:
         g.plot(fvals, location="face", style="flow_accumulation")
         assert type(g._cbar.locator).__name__ == "SymmetricalLogLocator"
         plt.close("all")
+
+
+class TestMeshGlyphApplyStyle:
+    """Tests for the public `apply_style` method and `style` read-back."""
+
+    @staticmethod
+    def _mesh(n=8):
+        gx, gy = np.meshgrid(np.linspace(0, 10, n), np.linspace(0, 10, n))
+        nx, ny = gx.ravel(), gy.ravel()
+        faces = np.array(
+            [
+                [j * n + i, j * n + i + 1, j * n + i + n + 1, j * n + i + n]
+                for j in range(n - 1)
+                for i in range(n - 1)
+            ]
+        )
+        return nx, ny, faces
+
+    def test_apply_style_reuses_last_data_and_reads_back(self):
+        """apply_style restyles using the last-plotted data; `style` reads back."""
+        nx, ny, faces = self._mesh()
+        fvals = np.abs(np.random.default_rng(0).normal(size=len(faces))) * 100
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(fvals, location="face")
+        g.apply_style("flow_accumulation")
+        assert g.style == "flow_accumulation"
+        assert g.im.cmap.name == "Blues"
+        plt.close("all")
+
+    def test_construction_time_style_is_honoured(self):
+        """A `style` set at construction survives plot()'s options reset."""
+        nx, ny, faces = self._mesh()
+        fvals = np.abs(np.random.default_rng(1).normal(size=len(faces))) * 100
+        g = MeshGlyph(nx, ny, faces, style="flow_accumulation")
+        g.plot(fvals, location="face")
+        assert g.style == "flow_accumulation" and g.im.cmap.name == "Blues"
+        plt.close("all")
+
+    def test_apply_style_without_data_or_prior_plot_raises(self):
+        """apply_style before any plot and with no data raises a clear error."""
+        nx, ny, faces = self._mesh()
+        with pytest.raises(ValueError, match="apply_style needs mesh data"):
+            MeshGlyph(nx, ny, faces).apply_style("flow_accumulation")
+        plt.close("all")
+
+    def test_apply_style_unknown_name_raises(self):
+        """An unknown preset name raises a clear `ValueError`."""
+        nx, ny, faces = self._mesh()
+        fvals = np.ones(len(faces))
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(fvals, location="face")
+        with pytest.raises(ValueError, match="unknown data style"):
+            g.apply_style("not_a_style")
+        plt.close("all")

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1645,3 +1645,29 @@ class TestMeshGlyphApplyStyle:
         g.plot(fvals, location="face", style=None)
         assert g.style is None
         plt.close("all")
+
+    def test_apply_style_repeated_does_not_stack_legends(self):
+        """Restyling a mesh repeatedly replaces the render rather than stacking legends."""
+        nx, ny, faces = self._mesh()
+        fvals = np.abs(np.random.default_rng(5).normal(size=len(faces))) * 100
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(fvals, location="face")
+        g.apply_style("flow_accumulation")
+        g.apply_style("topography")
+        assert g.style == "topography"
+        n_cbar_axes = sum(1 for a in g.fig.axes if a is not g.ax)
+        assert n_cbar_axes == 1  # one colorbar, not stacked
+        plt.close("all")
+
+    def test_apply_style_data_override_and_copy(self):
+        """apply_style uses an explicit data= override and the cached data is a copy."""
+        nx, ny, faces = self._mesh()
+        fvals = np.abs(np.random.default_rng(6).normal(size=len(faces))) * 100
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(fvals, location="face")
+        fvals[:] = 0.0  # mutate caller buffer after plot -> must not affect cache
+        assert not np.allclose(g._last_data, 0.0)
+        other = np.abs(np.random.default_rng(7).normal(size=len(faces))) * 50
+        g.apply_style("flow_accumulation", data=other)
+        assert g.style == "flow_accumulation"
+        plt.close("all")

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1633,3 +1633,15 @@ class TestMeshGlyphApplyStyle:
         with pytest.raises(ValueError, match="unknown data style"):
             g.apply_style("not_a_style")
         plt.close("all")
+
+    def test_style_is_sticky_and_clearable(self):
+        """A style survives a later plain plot(data) and is cleared by style=None."""
+        nx, ny, faces = self._mesh()
+        fvals = np.abs(np.random.default_rng(4).normal(size=len(faces))) * 100
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(fvals, location="face", style="flow_accumulation")
+        g.plot(fvals, location="face")
+        assert g.style == "flow_accumulation"
+        g.plot(fvals, location="face", style=None)
+        assert g.style is None
+        plt.close("all")

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1659,6 +1659,29 @@ class TestMeshGlyphApplyStyle:
         assert n_cbar_axes == 1  # one colorbar, not stacked
         plt.close("all")
 
+    def test_failed_apply_style_leaves_glyph_usable(self):
+        """A bad apply_style name raises without poisoning the sticky style."""
+        nx, ny, faces = self._mesh()
+        fvals = np.abs(np.random.default_rng(8).normal(size=len(faces))) * 100
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(fvals, location="face", style="flow_accumulation")
+        with pytest.raises(ValueError, match="unknown data style"):
+            g.apply_style("not_a_style")
+        assert g.style == "flow_accumulation"
+        g.plot(fvals, location="face")  # still usable
+        plt.close("all")
+
+    def test_masked_data_cache_preserves_mask(self):
+        """A masked mesh array's mask survives the _last_data cache for restyle."""
+        nx, ny, faces = self._mesh()
+        vals = np.abs(np.random.default_rng(9).normal(size=len(faces))) * 100
+        masked = np.ma.array(vals, mask=[i % 5 == 0 for i in range(len(faces))])
+        g = MeshGlyph(nx, ny, faces)
+        g.plot(masked, location="face")
+        assert np.ma.isMaskedArray(g._last_data)
+        assert np.any(np.ma.getmaskarray(g._last_data))
+        plt.close("all")
+
     def test_apply_style_data_override_and_copy(self):
         """apply_style uses an explicit data= override and the cached data is a copy."""
         nx, ny, faces = self._mesh()


### PR DESCRIPTION
# Description

Closes #202. Adds a public, discoverable way to apply (or change) a `DATA_STYLES` preset on a glyph instance that
already exists, so a caller holding a rendered glyph (e.g. one returned by a downstream library) can restyle it by
name without rebuilding it or reaching into private methods.

- `glyph.apply_style("name", **kwargs)` on `ArrayGlyph`, `MeshGlyph`, and `KDEGlyph` — applies the preset **in
  place**: it clears the previous render and re-plots on the glyph's existing axes, or draws on a new figure if the
  glyph has not been plotted yet. Extra kwargs (e.g. `hillshade`, `add_colorbar`) forward to `plot`. Unknown /
  multi-layer / categorical (for KDE) names raise the same clear `ValueError` as the constructor `style=` path.
- `glyph.style` — a read-back property exposing the currently-applied preset name.
- MeshGlyph caches the last-plotted `(data, location)` so `apply_style` needs no re-supplied mesh data (pass
  `data=` if the glyph was never plotted).
- KDEGlyph's `plot()` now persists a plot-time `style` **name** into `default_options` (the resolved cmap stays a
  local, so nothing leaks) so `style` reads it back and behaves like ArrayGlyph, whose `**kwargs` already persist it.

Also fixes a latent bug from #200: a construction-time `style` on **MeshGlyph** was dropped by `plot()`'s
options reset (only `hillshade` was restored). Added the parallel `_construct_style` shim so
`MeshGlyph(..., style=...)` is honoured, matching ArrayGlyph/KDEGlyph.

**Dependencies:** none.

# Issues

- Closes #202 — public `apply_style()` + `style` read-back on the surface glyphs.

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Run against the external uv env (`VIRTUAL_ENV=C:/python-environments/uv/cleopatra`, `MPLBACKEND=Agg`,
`uv run --active`):

- [x] Full non-e2e suite green: `pytest -m "not e2e" -q` -> **1485 passed**.
- [x] 13 new `apply_style`/`style` tests across the three glyphs: restyle in place + read-back, no-stack on
      repeat, forward hillshade, apply before first plot, unknown-name error, MeshGlyph reuse-last-data +
      construction-time style + no-data error, KDE categorical error.
- [x] Doctests green (an `ArrayGlyph.apply_style` example included).

## Behaviour note

A KDE plot-time `style` now persists across `plot()` calls (matching ArrayGlyph, and required for the `style`
read-back). The one prior test that asserted the old non-persistent behaviour is updated to assert the real
invariant it protects (`default_options["cmap"]` is never mutated), which still holds.

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes