### PR TITLE
feat(styles,glyphs): distinct-value categorical colouring for PolygonGlyph/ScatterGlyph

### DIFF
--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1095,7 +1095,12 @@ class Glyph:
         `cleopatra.styles.disjoint_legend` — the discrete counterpart to
         `create_color_bar`, used instead of it whenever `scheme` is
         `"categorical"` (a colorbar would imply a false ordering over
-        nominal classes).
+        nominal classes). The legend's title defaults to the `cbar_label`
+        option (the same label a continuous plot would put on its
+        colorbar); the `category_legend_kwargs` option is merged over that
+        default and forwarded to `disjoint_legend` (e.g. `loc`, `ncol`,
+        `bbox_to_anchor`, or an explicit `title` override) — the categorical
+        counterpart to `size_legend_kwargs`.
 
         Args:
             ax: The axes to attach the legend to.
@@ -1138,6 +1143,25 @@ class Glyph:
                 >>> plt.close(fig)
 
                 ```
+            - `category_legend_kwargs` overrides the default title and adds
+                a `loc`:
+                ```python
+                >>> import numpy as np
+                >>> import matplotlib.pyplot as plt
+                >>> from cleopatra.polygon_glyph import PolygonGlyph
+                >>> polys = [np.zeros((3, 2))] * 2
+                >>> g = PolygonGlyph(
+                ...     polys, values=np.array(["a", "b"]),
+                ...     category_legend_kwargs={"title": "Class", "loc": "upper left"},
+                ... )
+                >>> _ = g._prepare_categorical_mapping(np.array(["a", "b"]))
+                >>> fig, ax = plt.subplots()
+                >>> legend = g.create_categorical_legend(ax)
+                >>> legend.get_title().get_text()
+                'Class'
+                >>> plt.close(fig)
+
+                ```
         """
         categorical = self._categorical
         if categorical is None:
@@ -1146,11 +1170,15 @@ class Glyph:
                 "scheme='categorical' mapping was prepared -- call "
                 "_prepare_scalar_mapping (or plot()) first."
             )
+        legend_kwargs = {
+            "title": self.default_options.get("cbar_label"),
+            **(self.default_options.get("category_legend_kwargs") or {}),
+        }
         return disjoint_legend(
             ax,
             categorical["colors"],
             categorical["labels"],
-            title=self.default_options.get("cbar_label"),
+            **legend_kwargs,
         )
 
     def create_color_bar(self, ax: Axes, im: Any, cbar_kw: dict) -> Colorbar:

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1089,8 +1089,19 @@ class Glyph:
 
         Returns:
             Legend: The created legend artist, already added to `ax`.
+
+        Raises:
+            ValueError: If `self._categorical` has not been populated yet
+                (i.e. `_prepare_categorical_mapping` has not run for this
+                glyph instance).
         """
         categorical = self._categorical
+        if categorical is None:
+            raise ValueError(
+                "create_categorical_legend() called before a "
+                "scheme='categorical' mapping was prepared -- call "
+                "_prepare_scalar_mapping (or plot()) first."
+            )
         return disjoint_legend(
             ax,
             categorical["colors"],

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1067,9 +1067,14 @@ class Glyph:
             # An explicit non-default `cmap` (qualitative or not) is always
             # honoured as given.
             cmap = CATEGORICAL_DEFAULT_CMAP
-        categories, palette = categorize(values, cmap=cmap)
-        lookup = {category: i for i, category in enumerate(categories.tolist())}
+        # Flatten `values` once and reuse it for both `categorize` (which
+        # would otherwise redo the identical `np.asarray(...).ravel()` on
+        # the original, possibly nested/2-D `values`) and the codes lookup
+        # below -- passing an already-flat list back through `categorize`
+        # is a cheap no-op re-wrap, not a second real flattening pass.
         raw = np.asarray(values, dtype=object).ravel().tolist()
+        categories, palette = categorize(raw, cmap=cmap)
+        lookup = {category: i for i, category in enumerate(categories.tolist())}
         codes = np.array([lookup.get(v, np.nan) for v in raw], dtype=float)
         listed_cmap = colors.ListedColormap(palette)
         edges = np.arange(len(categories) + 1) - 0.5

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1094,6 +1094,37 @@ class Glyph:
             ValueError: If `self._categorical` has not been populated yet
                 (i.e. `_prepare_categorical_mapping` has not run for this
                 glyph instance).
+
+        Examples:
+            - Prepare a categorical mapping, then draw and inspect the legend:
+                ```python
+                >>> import numpy as np
+                >>> import matplotlib.pyplot as plt
+                >>> from cleopatra.polygon_glyph import PolygonGlyph
+                >>> polys = [np.zeros((3, 2))] * 3
+                >>> g = PolygonGlyph(polys, values=np.array(["a", "b", "a"]))
+                >>> _ = g._prepare_categorical_mapping(np.array(["a", "b", "a"]))
+                >>> fig, ax = plt.subplots()
+                >>> legend = g.create_categorical_legend(ax)
+                >>> [t.get_text() for t in legend.get_texts()]
+                ['a', 'b']
+                >>> plt.close(fig)
+
+                ```
+            - Calling it before a categorical mapping exists raises `ValueError`:
+                ```python
+                >>> import numpy as np
+                >>> import matplotlib.pyplot as plt
+                >>> from cleopatra.polygon_glyph import PolygonGlyph
+                >>> g = PolygonGlyph([np.zeros((3, 2))] * 2, values=np.array(["a", "b"]))
+                >>> fig, ax = plt.subplots()
+                >>> g.create_categorical_legend(ax)
+                Traceback (most recent call last):
+                    ...
+                ValueError: create_categorical_legend() called before a scheme='categorical' mapping was prepared -- call _prepare_scalar_mapping (or plot()) first.
+                >>> plt.close(fig)
+
+                ```
         """
         categorical = self._categorical
         if categorical is None:

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -885,6 +885,30 @@ class Glyph:
         norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
         return norm, cbar_kw, ticks
 
+    def _warn_scheme_overrides_continuous_options(self) -> None:
+        """Warn when a `scheme` is set alongside continuous-only options.
+
+        Shared by `_prepare_classified_mapping` and
+        `_prepare_categorical_mapping`: either scheme owns the norm
+        entirely, so a `color_scale` other than `"linear"` or an explicit
+        `levels` the caller also set is silently ignored rather than
+        applied -- this warns so that conflicting configuration is visible
+        instead of quietly doing nothing.
+        """
+        if self.default_options.get("color_scale", "linear") != "linear":
+            warnings.warn(
+                "`scheme` is set, so `color_scale="
+                f"{self.default_options['color_scale']!r}` is ignored "
+                "(classification builds its own discrete norm).",
+                stacklevel=5,
+            )
+        if self.default_options.get("levels") is not None:
+            warnings.warn(
+                "`scheme` is set, so `levels` is ignored (the classification "
+                "scheme determines the bins).",
+                stacklevel=5,
+            )
+
     def _prepare_classified_mapping(
         self, values: np.ndarray, scheme: str | list | np.ndarray
     ) -> tuple[colors.BoundaryNorm, dict, np.ndarray]:
@@ -938,22 +962,7 @@ class Glyph:
 
                 ```
         """
-        # `scheme` owns the norm, so any continuous `color_scale` / `levels`
-        # the caller also set is ignored here. Warn rather than silently drop
-        # it, so a conflicting configuration is visible.
-        if self.default_options.get("color_scale", "linear") != "linear":
-            warnings.warn(
-                "`scheme` is set, so `color_scale="
-                f"{self.default_options['color_scale']!r}` is ignored "
-                "(classification builds its own discrete norm).",
-                stacklevel=4,
-            )
-        if self.default_options.get("levels") is not None:
-            warnings.warn(
-                "`scheme` is set, so `levels` is ignored (the classification "
-                "scheme determines the bins).",
-                stacklevel=4,
-            )
+        self._warn_scheme_overrides_continuous_options()
         k = self.default_options.get("k", 5)
         bin_edges, norm = classify(values, scheme, k)
         extend = self.default_options.get("extend")
@@ -1036,21 +1045,7 @@ class Glyph:
                 "(its values are a continuous magnitude, not nominal class "
                 "labels)."
             )
-        # `scheme` owns the norm, so any continuous `color_scale` / `levels`
-        # the caller also set is ignored here, same as the classified path.
-        if self.default_options.get("color_scale", "linear") != "linear":
-            warnings.warn(
-                "`scheme` is set, so `color_scale="
-                f"{self.default_options['color_scale']!r}` is ignored "
-                "(classification builds its own discrete norm).",
-                stacklevel=4,
-            )
-        if self.default_options.get("levels") is not None:
-            warnings.warn(
-                "`scheme` is set, so `levels` is ignored (the classification "
-                "scheme determines the bins).",
-                stacklevel=4,
-            )
+        self._warn_scheme_overrides_continuous_options()
         cmap = self.default_options["cmap"]
         # Compare by resolved name, not raw `==`: `Colormap` does not
         # implement equality, so a `Colormap` *instance* equivalent to the

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -990,11 +990,13 @@ class Glyph:
 
         The glyph's `cmap` option drives `categorize`'s palette, with one
         override: if `cmap` is still at the shared continuous/diverging
-        default (`"coolwarm_r"`) — i.e. the caller never overrode it — it is
-        substituted with `CATEGORICAL_DEFAULT_CMAP` (`"tab10"`) instead,
-        since sampling a diverging gradient at N points would defeat the
-        point of "one distinct colour per class". Any other `cmap`,
-        qualitative or not, is always honoured as given.
+        default (`"coolwarm_r"`, matched by resolved name so a `Colormap`
+        instance equivalent to the default is caught too, not just the bare
+        string) — i.e. the caller never overrode it — it is substituted with
+        `CATEGORICAL_DEFAULT_CMAP` (`"tab10"`) instead, since sampling a
+        diverging gradient at N points would defeat the point of "one
+        distinct colour per class". Any other `cmap`, qualitative or not,
+        is always honoured as given.
 
         Args:
             values: The per-element nominal values to categorize.
@@ -1050,7 +1052,13 @@ class Glyph:
                 stacklevel=4,
             )
         cmap = self.default_options["cmap"]
-        if cmap == STYLE_DEFAULTS["cmap"]:
+        # Compare by resolved name, not raw `==`: `Colormap` does not
+        # implement equality, so a `Colormap` *instance* equivalent to the
+        # default (e.g. `mpl.colormaps["coolwarm_r"]`, a legitimate way to
+        # pass a colormap) would otherwise never match the string default
+        # and silently bypass the fallback below.
+        cmap_name = cmap if isinstance(cmap, str) else getattr(cmap, "name", None)
+        if cmap_name == STYLE_DEFAULTS["cmap"]:
             # `cmap` is still at the shared continuous/diverging default
             # ("coolwarm_r") -- nobody chose it *for* a categorical mapping,
             # they just never overrode it. Sampling a diverging gradient at

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -43,6 +43,11 @@ from cleopatra.styles import (
 #: and `np.linspace` with a huge count would exhaust memory.
 MAX_DISCRETE_LEVELS = 1000
 
+#: Qualitative colormap `_prepare_categorical_mapping` falls back to when the
+#: caller left `cmap` at the shared continuous/diverging default -- see the
+#: fallback logic there.
+CATEGORICAL_DEFAULT_CMAP = "tab10"
+
 
 def _get_figure_supports_root(get_figure) -> bool:
     """Return True if `get_figure` accepts a `root` keyword argument.
@@ -983,6 +988,14 @@ class Glyph:
         not know to read `self._categorical` back in the first place — it
         would keep feeding the raw (mismatched) values to the mappable.
 
+        The glyph's `cmap` option drives `categorize`'s palette, with one
+        override: if `cmap` is still at the shared continuous/diverging
+        default (`"coolwarm_r"`) — i.e. the caller never overrode it — it is
+        substituted with `CATEGORICAL_DEFAULT_CMAP` (`"tab10"`) instead,
+        since sampling a diverging gradient at N points would defeat the
+        point of "one distinct colour per class". Any other `cmap`,
+        qualitative or not, is always honoured as given.
+
         Args:
             values: The per-element nominal values to categorize.
 
@@ -1036,7 +1049,17 @@ class Glyph:
                 "scheme determines the bins).",
                 stacklevel=4,
             )
-        categories, palette = categorize(values, cmap=self.default_options["cmap"])
+        cmap = self.default_options["cmap"]
+        if cmap == STYLE_DEFAULTS["cmap"]:
+            # `cmap` is still at the shared continuous/diverging default
+            # ("coolwarm_r") -- nobody chose it *for* a categorical mapping,
+            # they just never overrode it. Sampling a diverging gradient at
+            # N points defeats the point of "one distinct colour per class",
+            # so fall back to `categorize`'s own qualitative default instead.
+            # An explicit non-default `cmap` (qualitative or not) is always
+            # honoured as given.
+            cmap = CATEGORICAL_DEFAULT_CMAP
+        categories, palette = categorize(values, cmap=cmap)
         lookup = {category: i for i, category in enumerate(categories.tolist())}
         raw = np.asarray(values, dtype=object).ravel().tolist()
         codes = np.array([lookup.get(v, np.nan) for v in raw], dtype=float)

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -21,6 +21,7 @@ from matplotlib.animation import FuncAnimation
 from matplotlib.axes import Axes
 from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure, SubFigure
+from matplotlib.legend import Legend
 from matplotlib.ticker import LogFormatter
 
 # `SUPPORTED_VIDEO_FORMAT` is re-imported (not redefined) so the constant has
@@ -29,7 +30,13 @@ from matplotlib.ticker import LogFormatter
 from cleopatra.animation import SUPPORTED_VIDEO_FORMAT  # noqa: F401  (re-export)
 from cleopatra.animation import save_animation as _save_animation
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
-from cleopatra.styles import ColorScale, MidpointNormalize, classify
+from cleopatra.styles import (
+    ColorScale,
+    MidpointNormalize,
+    categorize,
+    classify,
+    disjoint_legend,
+)
 
 #: Upper bound for an integer `levels` value (number of discrete colour
 #: levels / contour lines). A larger request is almost certainly a mistake
@@ -195,6 +202,14 @@ class Glyph:
     #: base value is the shared style defaults.
     DEFAULT_OPTIONS: dict = STYLE_DEFAULTS
 
+    #: Whether this glyph's `plot()` reads back the categorical side-channel
+    #: (`self._categorical`) instead of feeding raw `values` straight into
+    #: the mappable. Only true for glyphs whose per-element value is a
+    #: nominal class label rather than a continuous magnitude (e.g.
+    #: `PolygonGlyph`, `ScatterGlyph`) — `scheme="categorical"` is rejected
+    #: for any other glyph rather than silently mis-colouring it.
+    _SUPPORTS_CATEGORICAL_SCHEME = False
+
     def __init__(
         self,
         default_options: dict,
@@ -207,6 +222,9 @@ class Glyph:
         self._vmin: float | None = None
         self._vmax: float | None = None
         self.ticks_spacing: float | None = None
+        #: Set by `_prepare_categorical_mapping` when `scheme="categorical"`
+        #: — `{"codes", "cmap", "colors", "labels"}` — else `None`.
+        self._categorical: dict | None = None
         # Resolve the (fig, ax) binding. An `ax` fully determines its
         # figure, so accept `ax` on its own and derive the figure from it
         # rather than dropping the axes when `fig` is omitted. An explicit
@@ -786,7 +804,11 @@ class Glyph:
         When the `scheme` option is set, the continuous steps above are
         bypassed: control is handed to `_prepare_classified_mapping`, which
         bins the data into discrete colour classes (a `BoundaryNorm`).
-        With `scheme` unset (the default) the behaviour is unchanged.
+        `scheme="categorical"` bypasses them even earlier — before
+        `_resolve_limits`, since a `vmin`/`vmax` range is meaningless for
+        nominal values (and would raise for non-numeric ones) — and hands
+        off to `_prepare_categorical_mapping` instead. With `scheme` unset
+        (the default) the behaviour is unchanged.
 
         Args:
             values: The scalar array to be colour-mapped (e.g. point
@@ -837,6 +859,9 @@ class Glyph:
 
                 ```
         """
+        self._categorical = None
+        if self.default_options.get("scheme") == "categorical":
+            return self._prepare_categorical_mapping(values)
         self._vmin, self._vmax = self._resolve_limits(np.asarray(values))
         if self.default_options.get("ticks_spacing") is None:
             # `or 1.0` guards flat data (vmax == vmin -> spacing 0), which
@@ -932,6 +957,123 @@ class Glyph:
             "extend": "neither" if extend is None else extend,
         }
         return norm, cbar_kw, bin_edges
+
+    def _prepare_categorical_mapping(
+        self, values: np.ndarray
+    ) -> tuple[colors.BoundaryNorm, dict, np.ndarray]:
+        """Build the `(norm, cbar_kw, edges)` triple for `scheme="categorical"`.
+
+        The nominal sibling of `_prepare_classified_mapping`: instead of
+        binning a continuous range, `cleopatra.styles.categorize` assigns
+        one colour per distinct value in `values` (sorted when sortable),
+        and this builds a `ListedColormap` + `BoundaryNorm` over the
+        resulting integer class codes — the same construction
+        `colors.apply_data_style` uses for a preset's `categories`, but with
+        the category table auto-derived from the data instead of
+        hand-authored. The mapping (per-element codes, the `ListedColormap`,
+        and the colour/label pairs) is stashed on `self._categorical` for
+        the calling glyph to read back, since — unlike the continuous and
+        classified paths — the array fed to the mappable is these integer
+        codes, not `values` itself (which may not even be numeric).
+
+        Only glyphs with `_SUPPORTS_CATEGORICAL_SCHEME = True` may use this
+        scheme: for any other glyph, `values` are a continuous magnitude
+        (e.g. vector length), where "one colour per distinct float" is
+        almost never what the caller wants, and the glyph's `plot()` does
+        not know to read `self._categorical` back in the first place — it
+        would keep feeding the raw (mismatched) values to the mappable.
+
+        Args:
+            values: The per-element nominal values to categorize.
+
+        Returns:
+            tuple[BoundaryNorm, dict, np.ndarray]: the discrete norm over
+                the integer class codes, an empty colorbar-kwargs dict (a
+                categorical scheme draws a `disjoint_legend`, never a
+                colorbar — see `create_categorical_legend`), and the code
+                boundary edges (`-0.5 .. n_categories - 0.5`).
+
+        Raises:
+            ValueError: If this glyph does not support `scheme="categorical"`,
+                or (propagated from `categorize`) if `values` has no
+                non-null entries.
+
+        Examples:
+            - Three distinct values map to three integer codes and colours:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.polygon_glyph import PolygonGlyph
+                >>> polys = [np.zeros((3, 2))] * 3
+                >>> g = PolygonGlyph(polys, values=np.array(["a", "b", "a"]))
+                >>> norm, cbar_kw, edges = g._prepare_categorical_mapping(
+                ...     np.array(["a", "b", "a"])
+                ... )
+                >>> [float(b) for b in edges]
+                [-0.5, 0.5, 1.5]
+                >>> [float(c) for c in g._categorical["codes"]]
+                [0.0, 1.0, 0.0]
+
+                ```
+        """
+        if not self._SUPPORTS_CATEGORICAL_SCHEME:
+            raise ValueError(
+                f"{type(self).__name__} does not support scheme='categorical' "
+                "(its values are a continuous magnitude, not nominal class "
+                "labels)."
+            )
+        # `scheme` owns the norm, so any continuous `color_scale` / `levels`
+        # the caller also set is ignored here, same as the classified path.
+        if self.default_options.get("color_scale", "linear") != "linear":
+            warnings.warn(
+                "`scheme` is set, so `color_scale="
+                f"{self.default_options['color_scale']!r}` is ignored "
+                "(classification builds its own discrete norm).",
+                stacklevel=4,
+            )
+        if self.default_options.get("levels") is not None:
+            warnings.warn(
+                "`scheme` is set, so `levels` is ignored (the classification "
+                "scheme determines the bins).",
+                stacklevel=4,
+            )
+        categories, palette = categorize(values, cmap=self.default_options["cmap"])
+        lookup = {category: i for i, category in enumerate(categories.tolist())}
+        raw = np.asarray(values, dtype=object).ravel().tolist()
+        codes = np.array([lookup.get(v, np.nan) for v in raw], dtype=float)
+        listed_cmap = colors.ListedColormap(palette)
+        edges = np.arange(len(categories) + 1) - 0.5
+        norm = colors.BoundaryNorm(edges, len(palette))
+        self._categorical = {
+            "codes": codes,
+            "cmap": listed_cmap,
+            "colors": palette,
+            "labels": [str(c) for c in categories.tolist()],
+        }
+        return norm, {}, edges
+
+    def create_categorical_legend(self, ax: Axes) -> Legend:
+        """Attach the disjoint legend for a `scheme="categorical"` mapping.
+
+        Reads the category colours/labels `_prepare_categorical_mapping`
+        stashed on `self._categorical` and draws them via
+        `cleopatra.styles.disjoint_legend` — the discrete counterpart to
+        `create_color_bar`, used instead of it whenever `scheme` is
+        `"categorical"` (a colorbar would imply a false ordering over
+        nominal classes).
+
+        Args:
+            ax: The axes to attach the legend to.
+
+        Returns:
+            Legend: The created legend artist, already added to `ax`.
+        """
+        categorical = self._categorical
+        return disjoint_legend(
+            ax,
+            categorical["colors"],
+            categorical["labels"],
+            title=self.default_options.get("cbar_label"),
+        )
 
     def create_color_bar(self, ax: Axes, im: Any, cbar_kw: dict) -> Colorbar:
         """Create a colorbar with full customization from default_options.

--- a/src/cleopatra/polygon_glyph.py
+++ b/src/cleopatra/polygon_glyph.py
@@ -169,6 +169,12 @@ class PolygonGlyph(GeoMixin, Glyph):
         use `OUTLINE_EDGECOLOR` when `edgecolor` is left at its
         borderless-fill default of `"none"`.
 
+        The one exception is `scheme="categorical"`: `vmin` / `vmax` /
+        `levels` / `color_scale` are ignored (with a warning if set), and
+        instead of a colorbar a `disjoint_legend` is drawn and stored on
+        `self.category_legend` (`self.cbar` stays `None`). See
+        `Glyph._prepare_categorical_mapping`.
+
         Args:
             outline_only: Draw unfilled outlines even when `values` is
                 present (the `shapes` use case). Default is False.
@@ -224,6 +230,11 @@ class PolygonGlyph(GeoMixin, Glyph):
         # Resolve the colorbar choice for this call only (a plot-time
         # override does not persist into the glyph's options).
         draw_colorbar = opts["add_colorbar"] if add_colorbar is None else add_colorbar
+        # Reset both artifacts unconditionally so a re-plot (e.g. switching
+        # `scheme` between calls) never leaves a stale reference from the
+        # previous call -- only one of the two is (re)created below.
+        self.cbar = None
+        self.category_legend = None
 
         if outline_only or self.values is None:
             edgecolor = opts["edgecolor"]

--- a/src/cleopatra/polygon_glyph.py
+++ b/src/cleopatra/polygon_glyph.py
@@ -118,6 +118,9 @@ class PolygonGlyph(GeoMixin, Glyph):
 
     #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
     DEFAULT_OPTIONS = POLYGON_DEFAULT_OPTIONS
+    #: Per-polygon `values` are a nominal class label just as often as a
+    #: continuous magnitude, so `scheme="categorical"` is supported.
+    _SUPPORTS_CATEGORICAL_SCHEME = True
 
     def __init__(
         self,
@@ -141,6 +144,9 @@ class PolygonGlyph(GeoMixin, Glyph):
                 )
         self.values = values
         self.cbar = None
+        #: The disjoint legend created by `plot` when `scheme="categorical"`
+        #: (`None` otherwise); built via `Glyph.create_categorical_legend`.
+        self.category_legend = None
 
     def plot(
         self,
@@ -231,10 +237,15 @@ class PolygonGlyph(GeoMixin, Glyph):
             ax.autoscale_view()
         else:
             norm, cbar_kw, ticks = self._prepare_scalar_mapping(self.values)
+            categorical = self._categorical
+            if categorical is not None:
+                color_array, cmap = categorical["codes"], categorical["cmap"]
+            else:
+                color_array, cmap = np.asarray(self.values), opts["cmap"]
             pc = PolyCollection(
                 self.polygons,
-                array=np.asarray(self.values),
-                cmap=opts["cmap"],
+                array=color_array,
+                cmap=cmap,
                 norm=norm,
                 edgecolors=opts["edgecolor"],
                 linewidths=opts["linewidth"],
@@ -244,7 +255,10 @@ class PolygonGlyph(GeoMixin, Glyph):
             ax.add_collection(pc)
             ax.autoscale_view()
             if draw_colorbar:
-                self.cbar = self.create_color_bar(ax, pc, cbar_kw)
+                if categorical is not None:
+                    self.category_legend = self.create_categorical_legend(ax)
+                else:
+                    self.cbar = self.create_color_bar(ax, pc, cbar_kw)
 
         if opts["title"]:
             ax.set_title(opts["title"], fontsize=opts["title_size"])

--- a/src/cleopatra/polygon_glyph.py
+++ b/src/cleopatra/polygon_glyph.py
@@ -137,10 +137,14 @@ class PolygonGlyph(GeoMixin, Glyph):
         self.polygons = [np.asarray(p, dtype=float) for p in polygons]
         if values is not None:
             values = np.asarray(values)
-            if values.shape[0] != len(self.polygons):
+            # A full-shape check (not just `shape[0]`) rejects an accidentally
+            # un-flattened 2-D `values` array with a matching row count -- it
+            # would otherwise slip through here and only surface as a
+            # silently mis-sized colour array once `plot()` flattens it.
+            if values.shape != (len(self.polygons),):
                 raise ValueError(
-                    f"values length ({values.shape[0]}) must match the number "
-                    f"of polygons ({len(self.polygons)})."
+                    f"values shape {values.shape} must match the number of "
+                    f"polygons ({len(self.polygons)},)."
                 )
         self.values = values
         self.cbar = None

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -336,6 +336,15 @@ class ScatterGlyph(GeoMixin, Glyph):
                     self.cbar = self.create_color_bar(ax, paths, cbar_kw)
 
         if self.sizes is not None and opts["size_legend"]:
+            # `Axes.legend()` is single-slot per axes: `size_legend` calls it
+            # internally, which would otherwise silently evict the
+            # categorical legend just drawn above (matplotlib replaces
+            # `ax.legend_`, so the earlier Legend stops being part of
+            # `ax.get_children()` even though `self.category_legend` still
+            # references it). Re-attach it as a plain artist first, mirroring
+            # the multi-legend pattern in `colors.apply_data_style`.
+            if self.category_legend is not None:
+                ax.add_artist(self.category_legend)
             self.size_legend_artist = self._draw_size_legend(ax, marker_area)
 
         if opts["title"]:

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -210,6 +210,12 @@ class ScatterGlyph(GeoMixin, Glyph):
         `color_scale` behave as for the other glyphs. With no values,
         a single-colour scatter is drawn and no colorbar is added.
 
+        The one exception is `scheme="categorical"`: `vmin` / `vmax` /
+        `levels` / `color_scale` are ignored (with a warning if set), and
+        instead of a colorbar a `disjoint_legend` is drawn and stored on
+        `self.category_legend` (`self.cbar` stays `None`). See
+        `Glyph._prepare_categorical_mapping`.
+
         When `sizes` was supplied, each marker's area is resolved from
         that magnitude via `cleopatra.styles.resolve_sizes` (honouring
         `size_limits` / `size_scale`); otherwise the scalar `point_size`
@@ -290,6 +296,11 @@ class ScatterGlyph(GeoMixin, Glyph):
         # Resolve the colorbar choice for this call only (a plot-time
         # override does not persist into the glyph's options).
         draw_colorbar = opts["add_colorbar"] if add_colorbar is None else add_colorbar
+        # Reset both artifacts unconditionally so a re-plot (e.g. switching
+        # `scheme` between calls) never leaves a stale reference from the
+        # previous call -- only one of the two is (re)created below.
+        self.cbar = None
+        self.category_legend = None
 
         marker_area = self._resolve_marker_area()
 

--- a/src/cleopatra/scatter_glyph.py
+++ b/src/cleopatra/scatter_glyph.py
@@ -148,6 +148,9 @@ class ScatterGlyph(GeoMixin, Glyph):
 
     #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
     DEFAULT_OPTIONS = SCATTER_DEFAULT_OPTIONS
+    #: Per-point `values` are a nominal class label just as often as a
+    #: continuous magnitude, so `scheme="categorical"` is supported.
+    _SUPPORTS_CATEGORICAL_SCHEME = True
 
     def __init__(
         self,
@@ -189,6 +192,9 @@ class ScatterGlyph(GeoMixin, Glyph):
         #: The size legend created by `plot` when `size_legend` is truthy
         #: (None otherwise); built via `cleopatra.styles.size_legend`.
         self.size_legend_artist = None
+        #: The disjoint legend created by `plot` when `scheme="categorical"`
+        #: (`None` otherwise); built via `Glyph.create_categorical_legend`.
+        self.category_legend = None
 
     def plot(
         self,
@@ -296,19 +302,27 @@ class ScatterGlyph(GeoMixin, Glyph):
             )
         else:
             norm, cbar_kw, ticks = self._prepare_scalar_mapping(self.values)
+            categorical = self._categorical
+            if categorical is not None:
+                color_array, cmap = categorical["codes"], categorical["cmap"]
+            else:
+                color_array, cmap = np.asarray(self.values), opts["cmap"]
             paths = ax.scatter(
                 self.x,
                 self.y,
-                c=np.asarray(self.values),
+                c=color_array,
                 s=marker_area,
                 marker=opts["marker"],
-                cmap=opts["cmap"],
+                cmap=cmap,
                 norm=norm,
                 vmin=None if norm else ticks[0],
                 vmax=None if norm else ticks[-1],
             )
             if draw_colorbar:
-                self.cbar = self.create_color_bar(ax, paths, cbar_kw)
+                if categorical is not None:
+                    self.category_legend = self.create_categorical_legend(ax)
+                else:
+                    self.cbar = self.create_color_bar(ax, paths, cbar_kw)
 
         if self.sizes is not None and opts["size_legend"]:
             self.size_legend_artist = self._draw_size_legend(ax, marker_area)

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -6,7 +6,7 @@ import copy
 import warnings
 from collections import OrderedDict
 from enum import StrEnum
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 import matplotlib as mpl
 import matplotlib.colors as colors
@@ -114,10 +114,13 @@ DEFAULT_OPTIONS = {
     "grid_alpha": 0.75,
 }
 
-#: Classification options (`scheme` selects a `classify` scheme or explicit
-#: bin edges; `k` is the class count). Mixed into the option dicts of glyphs
-#: whose colour mapping routes through `Glyph._prepare_scalar_mapping` — kept
-#: out of the shared `DEFAULT_OPTIONS` so glyphs that bypass that pipeline
+#: Classification options (`scheme` selects a `classify` scheme, explicit
+#: bin edges, or the literal `"categorical"` for a `styles.categorize`
+#: distinct-value mapping — supported only by glyphs whose values are
+#: nominal, see `Glyph._SUPPORTS_CATEGORICAL_SCHEME`; `k` is the class count,
+#: ignored by `"categorical"`). Mixed into the option dicts of glyphs whose
+#: colour mapping routes through `Glyph._prepare_scalar_mapping` — kept out
+#: of the shared `DEFAULT_OPTIONS` so glyphs that bypass that pipeline
 #: (e.g. `ArrayGlyph` / `MeshGlyph`) reject `scheme` instead of silently
 #: ignoring it.
 CLASSIFY_OPTIONS = {
@@ -1662,6 +1665,119 @@ def classify(
         )
     norm = colors.BoundaryNorm(boundaries=edges, ncolors=256)
     return edges, norm
+
+
+def categorize(
+    values: np.ndarray | Sequence,
+    cmap: str | colors.Colormap = "tab10",
+) -> tuple[np.ndarray, list[str]]:
+    """Map each distinct value in `values` to its own colour.
+
+    The distinct-value (nominal) counterpart to `classify`: instead of
+    binning a continuous range, it assigns one colour per unique value —
+    the auto-derived equivalent of a hand-authored `colors.DATA_STYLES`
+    categorical preset. Values are sorted when they support `<` (numbers,
+    strings); otherwise first-encounter order is kept. Null entries
+    (`None` / `NaN`) never become a category.
+
+    Args:
+        values: The data to categorize. Any array-like of hashable values
+            (numeric or string class codes). Non-hashable entries (e.g.
+            nested lists) raise `TypeError`.
+        cmap: A qualitative colormap name (or `Colormap` instance) to draw
+            category colours from. A `ListedColormap` (e.g. the default
+            `"tab10"`, or `"tab20"`/`"Set1"`/...) contributes its colours
+            in order, cycling once there are more categories than colours.
+            Any other colormap is sampled at `len(categories)` evenly
+            spaced points instead (no cycling).
+
+    Returns:
+        tuple[np.ndarray, list[str]]: The distinct categories (an object
+            array, so mixed numeric/string codes round-trip) and one hex
+            colour string per category, aligned by position.
+
+    Raises:
+        ValueError: If `values` has no non-null entries.
+
+    Examples:
+        - Distinct integer codes get one colour each, sorted ascending:
+            ```python
+            >>> from cleopatra.styles import categorize
+            >>> categories, palette = categorize([3, 1, 2, 1])
+            >>> list(categories)
+            [1, 2, 3]
+            >>> len(palette)
+            3
+
+            ```
+        - String labels are sorted alphabetically; `None`/`NaN` are dropped:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.styles import categorize
+            >>> categories, palette = categorize(
+            ...     ["urban", "water", None, "forest", np.nan]
+            ... )
+            >>> list(categories)
+            ['forest', 'urban', 'water']
+
+            ```
+        - More categories than the cmap's colours cycles back to the start:
+            ```python
+            >>> from cleopatra.styles import categorize
+            >>> categories, palette = categorize(range(12), cmap="tab10")
+            >>> palette[0] == palette[10]
+            True
+
+            ```
+        - An all-null input has no category to assign, so it is rejected:
+            ```python
+            >>> from cleopatra.styles import categorize
+            >>> categorize([None, None])
+            Traceback (most recent call last):
+                ...
+            ValueError: Cannot categorize: `values` has no non-null entries.
+
+            ```
+
+    See Also:
+        classify: The continuous-range counterpart (bins a numeric range
+            instead of mapping distinct values).
+        cleopatra.glyph.Glyph._prepare_categorical_mapping: Turns this
+            function's categories/palette into per-element integer codes
+            plus a matching `ListedColormap` + `BoundaryNorm`.
+        disjoint_legend: The legend primitive that pairs with a categorical
+            colouring (one swatch per category).
+    """
+    raw = np.asarray(values, dtype=object).ravel().tolist()
+
+    def _is_null(value: Any) -> bool:
+        if value is None:
+            return True
+        try:
+            return bool(np.isnan(value))
+        except TypeError:
+            return False
+
+    seen = list(dict.fromkeys(v for v in raw if not _is_null(v)))
+    if not seen:
+        raise ValueError("Cannot categorize: `values` has no non-null entries.")
+    try:
+        categories = sorted(seen)
+    except TypeError:
+        # Mixed / unorderable types (e.g. int and str together): keep the
+        # order values were first encountered rather than raising.
+        categories = seen
+
+    mpl_cmap = mpl.colormaps[cmap] if isinstance(cmap, str) else cmap
+    base_colors = getattr(mpl_cmap, "colors", None)
+    n = len(categories)
+    if base_colors is None:
+        # A continuous colormap has no discrete swatches to cycle through;
+        # sample it at n evenly spaced points instead.
+        base_colors = [mpl_cmap(i) for i in np.linspace(0.0, 1.0, n)]
+    palette = [colors.to_hex(base_colors[i % len(base_colors)]) for i in range(n)]
+
+    return np.array(categories, dtype=object), palette
 
 
 def _scheme_edges(finite: np.ndarray, scheme: str, k: int) -> np.ndarray:

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -1678,7 +1678,13 @@ def categorize(
     the auto-derived equivalent of a hand-authored `colors.DATA_STYLES`
     categorical preset. Values are sorted when they support `<` (numbers,
     strings); otherwise first-encounter order is kept. Null entries
-    (`None` / `NaN`) never become a category.
+    (`None` / `NaN`) never become a category. Deduplication is by Python
+    `hash`/`==`, so values that are *equal but differently typed* collapse
+    into one category, same as any other Python `dict`/`set`: `1`, `1.0`,
+    and `True` are indistinguishable class codes here (`1 == True` and
+    `hash(1) == hash(True)`). This rarely matters for genuinely nominal
+    attributes, but a caller mixing integer class codes with a boolean
+    mask on the same field should not expect them to stay separate.
 
     Args:
         values: The data to categorize. Any array-like of hashable scalar

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -118,14 +118,17 @@ DEFAULT_OPTIONS = {
 #: bin edges, or the literal `"categorical"` for a `styles.categorize`
 #: distinct-value mapping — supported only by glyphs whose values are
 #: nominal, see `Glyph._SUPPORTS_CATEGORICAL_SCHEME`; `k` is the class count,
-#: ignored by `"categorical"`). Mixed into the option dicts of glyphs whose
-#: colour mapping routes through `Glyph._prepare_scalar_mapping` — kept out
-#: of the shared `DEFAULT_OPTIONS` so glyphs that bypass that pipeline
-#: (e.g. `ArrayGlyph` / `MeshGlyph`) reject `scheme` instead of silently
-#: ignoring it.
+#: ignored by `"categorical"`; `category_legend_kwargs` is forwarded to the
+#: `disjoint_legend` a `"categorical"` scheme draws, e.g. `loc`/`ncol`/
+#: `bbox_to_anchor`/`title` — see `Glyph.create_categorical_legend`).
+#: Mixed into the option dicts of glyphs whose colour mapping routes
+#: through `Glyph._prepare_scalar_mapping` — kept out of the shared
+#: `DEFAULT_OPTIONS` so glyphs that bypass that pipeline (e.g. `ArrayGlyph`
+#: / `MeshGlyph`) reject `scheme` instead of silently ignoring it.
 CLASSIFY_OPTIONS = {
     "scheme": None,
     "k": 5,
+    "category_legend_kwargs": None,
 }
 
 

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -1681,9 +1681,16 @@ def categorize(
     (`None` / `NaN`) never become a category.
 
     Args:
-        values: The data to categorize. Any array-like of hashable values
-            (numeric or string class codes). Non-hashable entries (e.g.
-            nested lists) raise `TypeError`.
+        values: The data to categorize. Any array-like of hashable scalar
+            values (numeric or string class codes), flattened first — so,
+            like `classify`, a 2-D grid of scalar categories (e.g. a
+            categorical raster) is accepted directly. Because flattening
+            happens before the null/hashability checks, a *ragged* sequence
+            of non-hashable entries (e.g. differently-sized nested lists,
+            which numpy cannot coerce into a rectangular array) raises
+            `TypeError`; a rectangular (equal-length) sequence of sequences
+            is instead coerced to a 2-D array and flattened into its scalar
+            elements, the same as any other 2-D input.
         cmap: A qualitative colormap name (or `Colormap` instance) to draw
             category colours from. A `ListedColormap` (e.g. the default
             `"tab10"`, or `"tab20"`/`"Set1"`/...) contributes its colours
@@ -1738,6 +1745,16 @@ def categorize(
             ValueError: Cannot categorize: `values` has no non-null entries.
 
             ```
+        - A ragged (non-rectangular) sequence of non-hashable entries raises
+            `TypeError`, since numpy cannot flatten it into scalar elements:
+            ```python
+            >>> from cleopatra.styles import categorize
+            >>> categorize([[1, 2], [3, 4, 5], [1, 2]])
+            Traceback (most recent call last):
+                ...
+            TypeError: unhashable type: 'list'
+
+            ```
 
     See Also:
         classify: The continuous-range counterpart (bins a numeric range
@@ -1753,6 +1770,13 @@ def categorize(
     def _is_null(value: Any) -> bool:
         if value is None:
             return True
+        if isinstance(value, (list, tuple, dict, set, np.ndarray)):
+            # A non-hashable, non-scalar entry is never a "null" -- and
+            # `np.isnan` on a multi-element one raises `ValueError` (ambiguous
+            # truth value) rather than answering the null check. Treat it as
+            # not-null here so it reaches `dict.fromkeys` below, which raises
+            # the documented `TypeError` for the genuinely unhashable value.
+            return False
         try:
             return bool(np.isnan(value))
         except TypeError:

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -602,6 +602,29 @@ class TestScatterGlyphCategorical:
         assert glyph.category_legend is None, "Stale legend must be cleared"
         assert glyph.cbar is not None, "The new continuous plot should draw a colorbar"
 
+    def test_size_legend_does_not_evict_category_legend(self, xy_species):
+        """Combining `scheme="categorical"` with `size_legend` keeps both legends.
+
+        Test scenario:
+            `Axes.legend()` is single-slot per axes; `size_legend`'s internal
+            call to it would otherwise silently replace the categorical
+            legend drawn just before it. Both legends must remain actual
+            children of the axes (not just non-`None` attributes) after
+            `plot()`.
+        """
+        x, y, species = xy_species
+        sizes = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        glyph = ScatterGlyph(
+            x, y, values=species, sizes=sizes, scheme="categorical", size_legend=True
+        )
+        _, ax, _ = glyph.plot()
+        assert glyph.category_legend in ax.get_children(), (
+            "The categorical legend must still be rendered, not silently evicted"
+        )
+        assert glyph.size_legend_artist in ax.get_children(), (
+            "The size legend must also be rendered"
+        )
+
 
 class TestCategoricalSchemeGlyphScope:
     """Tests for which glyphs accept `scheme="categorical"`.

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -188,6 +188,18 @@ class TestCategorize:
         categories, _ = categorize(grid)
         assert list(categories) == ["a", "b"], f"Unexpected categories: {categories}"
 
+    def test_equal_but_differently_typed_values_collapse_to_one_category(self):
+        """`1`, `1.0`, and `True` dedupe into a single category, as documented.
+
+        Test scenario:
+            Deduplication is by Python `hash`/`==` (the same rule any
+            `dict`/`set` uses), so an integer code, its float equivalent, and
+            the boolean `True` -- all equal to each other -- collapse into
+            one category rather than three, matching the documented caveat.
+        """
+        categories, _ = categorize(np.array([1, True, 0, False, 1.0], dtype=object))
+        assert list(categories) == [0, 1], f"Expected 2 categories, got {categories}"
+
     def test_ragged_non_hashable_entries_raise_type_error(self):
         """A ragged sequence of non-hashable entries raises `TypeError`.
 

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -27,7 +27,7 @@ import numpy as np
 import pytest
 
 from cleopatra.flow_glyph import FlowGlyph
-from cleopatra.glyph import Glyph
+from cleopatra.glyph import CATEGORICAL_DEFAULT_CMAP, Glyph
 from cleopatra.polygon_glyph import PolygonGlyph
 from cleopatra.scatter_glyph import ScatterGlyph
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
@@ -216,6 +216,40 @@ class TestGlyphPrepareCategoricalMapping:
         ), f"Unexpected codes: {categorical['codes']}"
         assert categorical["labels"] == ["a", "b"]
         assert isinstance(categorical["cmap"], mcolors.ListedColormap)
+
+    def test_default_cmap_falls_back_to_qualitative_palette(self):
+        """Leaving `cmap` unset resolves to a qualitative default, not `coolwarm_r`.
+
+        Test scenario:
+            With no explicit `cmap`, categories get `CATEGORICAL_DEFAULT_CMAP`
+            (`"tab10"`) colours instead of samples from the glyph's continuous
+            diverging default -- otherwise "distinct colours" would silently
+            come from a red-white-blue gradient.
+        """
+        g = PolygonGlyph([np.zeros((3, 2))] * 3, values=np.array(["a", "b", "c"]))
+        g._prepare_categorical_mapping(np.array(["a", "b", "c"]))
+        expected = [
+            mcolors.to_hex(c)
+            for c in matplotlib.colormaps[CATEGORICAL_DEFAULT_CMAP].colors[:3]
+        ]
+        assert g._categorical["colors"] == expected, (
+            f"Expected the {CATEGORICAL_DEFAULT_CMAP} palette, got "
+            f"{g._categorical['colors']}"
+        )
+
+    def test_explicit_cmap_is_honoured_even_if_continuous(self):
+        """An explicitly chosen `cmap` is never overridden by the fallback.
+
+        Test scenario:
+            Passing `cmap="viridis"` (continuous, not qualitative) is still
+            respected -- the fallback only triggers when `cmap` was left at
+            the glyph's own unmodified default.
+        """
+        g = PolygonGlyph(
+            [np.zeros((3, 2))] * 3, values=np.array(["a", "b", "c"]), cmap="viridis"
+        )
+        g._prepare_categorical_mapping(np.array(["a", "b", "c"]))
+        assert len(set(g._categorical["colors"])) == 3, "Should still get 3 colours"
 
     def test_prepare_scalar_mapping_routes_to_categorical(self):
         """`_prepare_scalar_mapping` short-circuits for `scheme="categorical"`.

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -387,6 +387,43 @@ class TestPolygonGlyphCategorical:
         assert not isinstance(pc.norm, mcolors.BoundaryNorm)
         assert glyph.category_legend is None
 
+    def test_replot_from_categorical_to_continuous_clears_legend(self, polys_land_use):
+        """Switching `scheme` off on a re-plot drops the stale legend.
+
+        Test scenario:
+            A glyph first plotted with `scheme="categorical"` (legend, no
+            colorbar) is re-plotted with `scheme=None` and numeric values;
+            the stale `category_legend` reference must not survive.
+        """
+        polys, labels = polys_land_use
+        glyph = PolygonGlyph(polys, values=labels, scheme="categorical")
+        glyph.plot()
+        assert glyph.category_legend is not None and glyph.cbar is None
+
+        glyph.default_options["scheme"] = None
+        glyph.values = np.arange(6.0)
+        glyph.plot()
+        assert glyph.category_legend is None, "Stale legend must be cleared"
+        assert glyph.cbar is not None, "The new continuous plot should draw a colorbar"
+
+    def test_replot_from_continuous_to_categorical_clears_colorbar(self, polys_land_use):
+        """Switching `scheme` on for a re-plot drops the stale colorbar.
+
+        Test scenario:
+            The reverse direction of the previous test: continuous first,
+            categorical second.
+        """
+        polys, labels = polys_land_use
+        glyph = PolygonGlyph(polys, values=np.arange(6.0))
+        glyph.plot()
+        assert glyph.cbar is not None and glyph.category_legend is None
+
+        glyph.default_options["scheme"] = "categorical"
+        glyph.values = labels
+        glyph.plot()
+        assert glyph.cbar is None, "Stale colorbar must be cleared"
+        assert glyph.category_legend is not None, "The new categorical plot draws a legend"
+
 
 class TestScatterGlyphCategorical:
     """Integration tests for `scheme="categorical"` through ScatterGlyph."""
@@ -467,6 +504,25 @@ class TestScatterGlyphCategorical:
         _, _, paths = glyph.plot()
         assert not isinstance(paths.norm, mcolors.BoundaryNorm)
         assert glyph.category_legend is None
+
+    def test_replot_from_categorical_to_continuous_clears_legend(self, xy_species):
+        """Switching `scheme` off on a re-plot drops the stale legend.
+
+        Test scenario:
+            A glyph first plotted with `scheme="categorical"` (legend, no
+            colorbar) is re-plotted with `scheme=None` and numeric values;
+            the stale `category_legend` reference must not survive.
+        """
+        x, y, species = xy_species
+        glyph = ScatterGlyph(x, y, values=species, scheme="categorical")
+        glyph.plot()
+        assert glyph.category_legend is not None and glyph.cbar is None
+
+        glyph.default_options["scheme"] = None
+        glyph.values = np.arange(6.0)
+        glyph.plot()
+        assert glyph.category_legend is None, "Stale legend must be cleared"
+        assert glyph.cbar is not None, "The new continuous plot should draw a colorbar"
 
 
 class TestCategoricalSchemeGlyphScope:

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -441,6 +441,23 @@ class TestPolygonGlyphCategorical:
             "water",
         }, f"Unexpected legend labels: {legend_labels}"
 
+    def test_category_legend_kwargs_overrides_title_and_placement(self, polys_land_use):
+        """`category_legend_kwargs` is forwarded to the disjoint legend.
+
+        Test scenario:
+            An explicit `title` in `category_legend_kwargs` overrides the
+            `cbar_label`-derived default, mirroring `size_legend_kwargs`.
+        """
+        polys, labels = polys_land_use
+        glyph = PolygonGlyph(
+            polys,
+            values=labels,
+            scheme="categorical",
+            category_legend_kwargs={"title": "Land use", "loc": "lower left"},
+        )
+        glyph.plot()
+        assert glyph.category_legend.get_title().get_text() == "Land use"
+
     def test_add_colorbar_false_suppresses_legend(self, polys_land_use):
         """`add_colorbar=False` also suppresses the categorical legend.
 

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -302,6 +302,19 @@ class TestGlyphPrepareCategoricalMapping:
         with pytest.raises(ValueError, match="does not support scheme='categorical'"):
             g._prepare_categorical_mapping(np.array(["a", "b"]))
 
+    def test_create_categorical_legend_before_prepare_raises(self):
+        """Calling the legend builder before the mapping is prepared errors clearly.
+
+        Test scenario:
+            A freshly constructed glyph has `self._categorical is None`;
+            `create_categorical_legend` must raise a clear `ValueError`
+            rather than a raw `TypeError` from indexing `None`.
+        """
+        g = PolygonGlyph([np.zeros((3, 2))] * 2, values=np.array(["a", "b"]))
+        _, ax = plt.subplots()
+        with pytest.raises(ValueError, match="before a scheme='categorical' mapping"):
+            g.create_categorical_legend(ax)
+
     def test_warns_on_conflicting_color_scale(self):
         """`scheme="categorical"` with a non-linear `color_scale` warns.
 

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -183,6 +183,30 @@ class TestCategorize:
         categories, _ = categorize(grid)
         assert list(categories) == ["a", "b"], f"Unexpected categories: {categories}"
 
+    def test_ragged_non_hashable_entries_raise_type_error(self):
+        """A ragged sequence of non-hashable entries raises `TypeError`.
+
+        Test scenario:
+            Differently-sized nested lists cannot be coerced into a
+            rectangular array, so each list survives as its own (unhashable)
+            element and `dict.fromkeys` raises `TypeError` -- matching the
+            documented contract.
+        """
+        with pytest.raises(TypeError, match="unhashable"):
+            categorize([[1, 2], [3, 4, 5], [1, 2]])
+
+    def test_rectangular_nested_sequences_are_flattened_not_rejected(self):
+        """Equal-length nested sequences are treated as a 2-D scalar grid.
+
+        Test scenario:
+            A rectangular list-of-lists is coerced to a 2-D array (like
+            `test_2d_input_is_flattened`) and its scalar elements become the
+            categories -- it does not raise, and the "list" values never
+            become categories themselves.
+        """
+        categories, _ = categorize([[1, 2], [3, 4], [1, 2]])
+        assert list(categories) == [1, 2, 3, 4], f"Unexpected categories: {categories}"
+
 
 class TestGlyphPrepareCategoricalMapping:
     """Tests for ``Glyph._prepare_categorical_mapping`` and the routing."""

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -132,12 +132,17 @@ class TestCategorize:
         """A continuous (non-`ListedColormap`) cmap is sampled, not cycled.
 
         Test scenario:
-            `"viridis"` has no discrete `.colors` list; categorize samples
-            it at N evenly spaced points, so distinct categories still get
-            distinct colours even past what a 10-swatch qualitative map
-            would offer.
+            `"coolwarm"` has no discrete `.colors` list (it is a
+            `LinearSegmentedColormap`, unlike the perceptually-uniform maps
+            such as `"viridis"`, which modern matplotlib implements as a
+            256-entry `ListedColormap`); categorize samples it at N evenly
+            spaced points, so distinct categories still get distinct colours
+            even past what a 10-swatch qualitative map would offer.
         """
-        categories, palette = categorize(list(range(15)), cmap="viridis")
+        assert getattr(matplotlib.colormaps["coolwarm"], "colors", None) is None, (
+            "Test assumption: 'coolwarm' must have no discrete .colors list"
+        )
+        categories, palette = categorize(list(range(15)), cmap="coolwarm")
         assert len(categories) == 15
         assert len(set(palette)) == 15, "Sampled continuous cmap should not repeat"
 
@@ -265,12 +270,14 @@ class TestGlyphPrepareCategoricalMapping:
         """An explicitly chosen `cmap` is never overridden by the fallback.
 
         Test scenario:
-            Passing `cmap="viridis"` (continuous, not qualitative) is still
-            respected -- the fallback only triggers when `cmap` was left at
-            the glyph's own unmodified default.
+            Passing `cmap="coolwarm"` explicitly is still respected even
+            though it is the same continuous colormap the glyph's own
+            default resolves to (just spelled out instead of left implicit)
+            -- the fallback only triggers when `cmap` was left at the
+            glyph's own unmodified default value.
         """
         g = PolygonGlyph(
-            [np.zeros((3, 2))] * 3, values=np.array(["a", "b", "c"]), cmap="viridis"
+            [np.zeros((3, 2))] * 3, values=np.array(["a", "b", "c"]), cmap="coolwarm"
         )
         g._prepare_categorical_mapping(np.array(["a", "b", "c"]))
         assert len(set(g._categorical["colors"])) == 3, "Should still get 3 colours"

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -282,6 +282,32 @@ class TestGlyphPrepareCategoricalMapping:
         g._prepare_categorical_mapping(np.array(["a", "b", "c"]))
         assert len(set(g._categorical["colors"])) == 3, "Should still get 3 colours"
 
+    def test_default_cmap_fallback_matches_a_colormap_object_too(self):
+        """A `Colormap` instance equivalent to the default also falls back.
+
+        Test scenario:
+            Passing `cmap=matplotlib.colormaps["coolwarm_r"]` (an object,
+            not the bare string) must be recognised as "still at the
+            glyph's own default" and fall back to the qualitative palette,
+            the same as leaving `cmap` unset entirely -- `Colormap` has no
+            `__eq__`, so a naive `==` comparison would miss this and leave
+            the diverging gradient sampled instead.
+        """
+        g = PolygonGlyph(
+            [np.zeros((3, 2))] * 3,
+            values=np.array(["a", "b", "c"]),
+            cmap=matplotlib.colormaps["coolwarm_r"],
+        )
+        g._prepare_categorical_mapping(np.array(["a", "b", "c"]))
+        expected = [
+            mcolors.to_hex(c)
+            for c in matplotlib.colormaps[CATEGORICAL_DEFAULT_CMAP].colors[:3]
+        ]
+        assert g._categorical["colors"] == expected, (
+            f"Expected the {CATEGORICAL_DEFAULT_CMAP} fallback palette, got "
+            f"{g._categorical['colors']}"
+        )
+
     def test_prepare_scalar_mapping_routes_to_categorical(self):
         """`_prepare_scalar_mapping` short-circuits for `scheme="categorical"`.
 

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -1,0 +1,518 @@
+"""Tests for distinct-value categorical colouring -- issue #204.
+
+Covers:
+
+* `cleopatra.styles.categorize` (distinct-value -> colour mapping: sorted
+  numeric/string categories, mixed-type fallback, null dropping, cmap
+  cycling vs. continuous-cmap sampling, the all-null error path).
+* `Glyph._prepare_categorical_mapping` / `Glyph.create_categorical_legend`
+  and the `scheme="categorical"` short-circuit added to
+  `Glyph._prepare_scalar_mapping`.
+* Integration through `PolygonGlyph` and `ScatterGlyph` (distinct colours,
+  a `disjoint_legend` instead of a colorbar, string- and integer-coded
+  attributes, missing-value handling).
+* The glyph-scope guard: only glyphs with `_SUPPORTS_CATEGORICAL_SCHEME`
+  accept `scheme="categorical"`; the others (whose values are a continuous
+  magnitude) raise a clear `ValueError` instead of mis-colouring.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+from cleopatra.flow_glyph import FlowGlyph
+from cleopatra.glyph import Glyph
+from cleopatra.polygon_glyph import PolygonGlyph
+from cleopatra.scatter_glyph import ScatterGlyph
+from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
+from cleopatra.styles import categorize
+from cleopatra.vector_glyph import VectorGlyph
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+def _make_options(**overrides) -> dict:
+    """Build a Glyph ``default_options`` dict with auto colour limits.
+
+    Args:
+        **overrides: Option keys to override on top of the shared defaults.
+
+    Returns:
+        dict: A copy of ``STYLE_DEFAULTS`` with ``vmin``/``vmax`` unset plus
+            any overrides applied.
+    """
+    opts = STYLE_DEFAULTS.copy()
+    opts["vmin"] = None
+    opts["vmax"] = None
+    opts.update(overrides)
+    return opts
+
+
+class TestCategorize:
+    """Tests for the public ``cleopatra.styles.categorize`` function."""
+
+    def test_distinct_integer_codes_sorted(self):
+        """Integer class codes become sorted, deduplicated categories.
+
+        Test scenario:
+            Repeated/unsorted integers collapse to their sorted unique set.
+        """
+        categories, palette = categorize([3, 1, 2, 1])
+        assert list(categories) == [1, 2, 3], f"Unexpected categories: {categories}"
+        assert len(palette) == 3, f"Expected 3 colours, got {len(palette)}"
+
+    def test_string_categories_sorted_alphabetically(self):
+        """String labels are sorted alphabetically.
+
+        Test scenario:
+            Land-cover-style string labels come back in alpha order.
+        """
+        categories, _ = categorize(["urban", "water", "forest"])
+        assert list(categories) == [
+            "forest",
+            "urban",
+            "water",
+        ], f"Unexpected order: {categories}"
+
+    def test_none_and_nan_dropped(self):
+        """`None` and `NaN` entries never become their own category.
+
+        Test scenario:
+            A mix of valid labels, `None`, and `NaN` yields only the three
+            valid, deduplicated categories.
+        """
+        categories, _ = categorize(["urban", "water", None, "forest", np.nan])
+        assert list(categories) == [
+            "forest",
+            "urban",
+            "water",
+        ], f"Null entries leaked into categories: {categories}"
+
+    def test_colors_aligned_with_categories(self):
+        """Colours and categories have the same length, one-to-one.
+
+        Test scenario:
+            Five distinct values produce five colours.
+        """
+        categories, palette = categorize(list("abcde"))
+        assert len(palette) == len(categories) == 5
+
+    def test_cycles_past_cmap_size(self):
+        """More categories than the cmap's colours cycles back to the start.
+
+        Test scenario:
+            `tab10` has 10 colours; 12 categories repeats colours 0 and 1.
+        """
+        categories, palette = categorize(list(range(12)), cmap="tab10")
+        assert len(categories) == 12, f"Expected 12 categories, got {len(categories)}"
+        assert palette[10] == palette[0], "Colour 10 should cycle back to colour 0"
+        assert palette[11] == palette[1], "Colour 11 should cycle back to colour 1"
+
+    def test_within_cmap_size_no_repeats(self):
+        """Categories within the cmap's size get distinct colours.
+
+        Test scenario:
+            3 categories against `tab10` (10 colours) never repeat.
+        """
+        _, palette = categorize(["a", "b", "c"], cmap="tab10")
+        assert len(set(palette)) == 3, f"Expected 3 distinct colours: {palette}"
+
+    def test_continuous_cmap_is_sampled_not_cycled(self):
+        """A continuous (non-`ListedColormap`) cmap is sampled, not cycled.
+
+        Test scenario:
+            `"viridis"` has no discrete `.colors` list; categorize samples
+            it at N evenly spaced points, so distinct categories still get
+            distinct colours even past what a 10-swatch qualitative map
+            would offer.
+        """
+        categories, palette = categorize(list(range(15)), cmap="viridis")
+        assert len(categories) == 15
+        assert len(set(palette)) == 15, "Sampled continuous cmap should not repeat"
+
+    def test_mixed_unorderable_types_fall_back_to_first_seen_order(self):
+        """Unorderable mixed types keep first-encounter order instead of raising.
+
+        Test scenario:
+            Mixing `int` and `str` values cannot be sorted in Python 3; the
+            categories come back in the order first encountered rather than
+            raising `TypeError`.
+        """
+        categories, _ = categorize([1, "a", 1, "b"])
+        assert list(categories) == [1, "a", "b"], f"Unexpected order: {categories}"
+
+    def test_returned_categories_hex_colors(self):
+        """Colours are returned as hex strings.
+
+        Test scenario:
+            Every palette entry parses as a matplotlib colour and round-trips
+            through `to_hex`.
+        """
+        _, palette = categorize(["x", "y"])
+        for color in palette:
+            assert color == mcolors.to_hex(color), f"Not a hex string: {color}"
+
+    def test_all_null_raises(self):
+        """An all-null input has no category to assign.
+
+        Test scenario:
+            Every entry is `None`/`NaN`; there is nothing to categorize.
+        """
+        with pytest.raises(ValueError, match="no non-null entries"):
+            categorize([None, np.nan])
+
+    def test_2d_input_is_flattened(self):
+        """A 2-D values array is categorized on its flattened entries.
+
+        Test scenario:
+            A grid of two repeating labels yields the same two categories
+            as the flat equivalent.
+        """
+        grid = np.array([["a", "b"], ["b", "a"]], dtype=object)
+        categories, _ = categorize(grid)
+        assert list(categories) == ["a", "b"], f"Unexpected categories: {categories}"
+
+
+class TestGlyphPrepareCategoricalMapping:
+    """Tests for ``Glyph._prepare_categorical_mapping`` and the routing."""
+
+    def test_returns_norm_cbar_edges_triple(self):
+        """The helper returns a BoundaryNorm, empty cbar_kw, and code edges.
+
+        Test scenario:
+            Three distinct values give a 3-colour BoundaryNorm with edges
+            `[-0.5, 0.5, 1.5, 2.5]`.
+        """
+        g = PolygonGlyph([np.zeros((3, 2))] * 3, values=np.array(["a", "b", "c"]))
+        norm, cbar_kw, edges = g._prepare_categorical_mapping(np.array(["a", "b", "c"]))
+        assert isinstance(norm, mcolors.BoundaryNorm), f"Expected BoundaryNorm: {norm}"
+        assert cbar_kw == {}, f"cbar_kw should be empty for categorical: {cbar_kw}"
+        assert np.allclose(edges, [-0.5, 0.5, 1.5, 2.5]), f"Unexpected edges: {edges}"
+
+    def test_populates_categorical_side_channel(self):
+        """`self._categorical` carries codes/cmap/colors/labels.
+
+        Test scenario:
+            After the call, `self._categorical` has the four expected keys
+            with per-element codes aligned to the input order.
+        """
+        g = PolygonGlyph([np.zeros((3, 2))] * 3, values=np.array(["b", "a", "b"]))
+        g._prepare_categorical_mapping(np.array(["b", "a", "b"]))
+        categorical = g._categorical
+        assert set(categorical) == {"codes", "cmap", "colors", "labels"}
+        assert np.allclose(
+            categorical["codes"], [1.0, 0.0, 1.0]
+        ), f"Unexpected codes: {categorical['codes']}"
+        assert categorical["labels"] == ["a", "b"]
+        assert isinstance(categorical["cmap"], mcolors.ListedColormap)
+
+    def test_prepare_scalar_mapping_routes_to_categorical(self):
+        """`_prepare_scalar_mapping` short-circuits for `scheme="categorical"`.
+
+        Test scenario:
+            The shared entry point returns a BoundaryNorm and populates
+            `self._categorical` when the scheme is `"categorical"`.
+        """
+        g = PolygonGlyph(
+            [np.zeros((3, 2))] * 2,
+            values=np.array(["x", "y"]),
+            scheme="categorical",
+        )
+        norm, cbar_kw, _ = g._prepare_scalar_mapping(np.array(["x", "y"]))
+        assert isinstance(norm, mcolors.BoundaryNorm)
+        assert g._categorical is not None, "Categorical side-channel not populated"
+
+    def test_unsupported_glyph_raises(self):
+        """A base `Glyph` (no categorical support) raises a clear error.
+
+        Test scenario:
+            `_SUPPORTS_CATEGORICAL_SCHEME` is `False` on the base class, so
+            calling the helper directly raises `ValueError`.
+        """
+        g = Glyph(default_options=_make_options(scheme="categorical"))
+        with pytest.raises(ValueError, match="does not support scheme='categorical'"):
+            g._prepare_categorical_mapping(np.array(["a", "b"]))
+
+    def test_warns_on_conflicting_color_scale(self):
+        """`scheme="categorical"` with a non-linear `color_scale` warns.
+
+        Test scenario:
+            Categorical colouring owns the norm, so a conflicting
+            `color_scale` is ignored -- and a warning says so.
+        """
+        glyph = ScatterGlyph(
+            np.arange(4.0),
+            np.zeros(4),
+            values=np.array(["a", "b", "a", "b"]),
+            scheme="categorical",
+            color_scale="midpoint",
+        )
+        with pytest.warns(UserWarning, match="color_scale"):
+            glyph.plot()
+
+    def test_warns_on_conflicting_levels(self):
+        """`scheme="categorical"` together with `levels` warns.
+
+        Test scenario:
+            The categorical mapping determines the classes, so `levels` is
+            ignored -- and a warning says so.
+        """
+        glyph = ScatterGlyph(
+            np.arange(4.0),
+            np.zeros(4),
+            values=np.array(["a", "b", "a", "b"]),
+            scheme="categorical",
+            levels=3,
+        )
+        with pytest.warns(UserWarning, match="levels"):
+            glyph.plot()
+
+
+class TestPolygonGlyphCategorical:
+    """Integration tests for `scheme="categorical"` through PolygonGlyph."""
+
+    @pytest.fixture()
+    def polys_land_use(self):
+        """Six triangles labelled with a repeating 3-class land-use attribute.
+
+        Returns:
+            tuple[list[np.ndarray], np.ndarray]: polygon vertices and string
+                land-use labels.
+        """
+        polys = [np.array([[i, 0.0], [i + 1, 0.0], [i + 0.5, 1.0]]) for i in range(6)]
+        labels = np.array(["forest", "water", "urban", "forest", "water", "forest"])
+        return polys, labels
+
+    def test_distinct_values_get_distinct_colors(self, polys_land_use):
+        """Each unique value maps to its own fill colour.
+
+        Test scenario:
+            Three unique labels produce a 3-colour `ListedColormap`.
+        """
+        polys, labels = polys_land_use
+        glyph = PolygonGlyph(polys, values=labels, scheme="categorical", cmap="tab10")
+        _, _, pc = glyph.plot()
+        assert isinstance(pc.cmap, mcolors.ListedColormap)
+        assert len(pc.cmap.colors) == 3, f"Expected 3 colours: {pc.cmap.colors}"
+
+    def test_disjoint_legend_not_colorbar(self, polys_land_use):
+        """A categorical choropleth draws a legend, never a colorbar.
+
+        Test scenario:
+            `glyph.cbar` stays `None`; `glyph.category_legend` is created
+            with one label per distinct value.
+        """
+        polys, labels = polys_land_use
+        glyph = PolygonGlyph(polys, values=labels, scheme="categorical")
+        glyph.plot()
+        assert glyph.cbar is None, "A categorical choropleth must not draw a colorbar"
+        assert glyph.category_legend is not None, "A disjoint legend should be drawn"
+        legend_labels = {t.get_text() for t in glyph.category_legend.get_texts()}
+        assert legend_labels == {
+            "forest",
+            "urban",
+            "water",
+        }, f"Unexpected legend labels: {legend_labels}"
+
+    def test_add_colorbar_false_suppresses_legend(self, polys_land_use):
+        """`add_colorbar=False` also suppresses the categorical legend.
+
+        Test scenario:
+            The same toggle that suppresses a colorbar suppresses the
+            disjoint legend for shared-axes composition.
+        """
+        polys, labels = polys_land_use
+        glyph = PolygonGlyph(polys, values=labels, scheme="categorical")
+        glyph.plot(add_colorbar=False)
+        assert glyph.category_legend is None
+        assert glyph.cbar is None
+
+    def test_integer_coded_attribute(self, polys_land_use):
+        """Integer class codes (e.g. D8 flow directions) work the same way.
+
+        Test scenario:
+            Small integer codes map to as many distinct colours as codes.
+        """
+        polys, _ = polys_land_use
+        codes = np.array([1, 2, 4, 8, 1, 2])
+        glyph = PolygonGlyph(polys, values=codes, scheme="categorical")
+        _, _, pc = glyph.plot()
+        assert len(pc.cmap.colors) == 4, f"Expected 4 colours: {pc.cmap.colors}"
+        assert set(
+            glyph.category_legend.get_texts()[i].get_text() for i in range(4)
+        ) == {
+            "1",
+            "2",
+            "4",
+            "8",
+        }
+
+    def test_missing_value_renders_transparent(self, polys_land_use):
+        """A polygon whose value is `None` gets a masked (transparent) code.
+
+        Test scenario:
+            One `None` entry among valid labels does not become its own
+            category, and its per-polygon code is masked/NaN.
+        """
+        polys, _ = polys_land_use
+        labels = np.array(
+            ["forest", "water", None, "forest", "water", "forest"], dtype=object
+        )
+        glyph = PolygonGlyph(polys, values=labels, scheme="categorical")
+        _, _, pc = glyph.plot()
+        codes = np.ma.asarray(pc.get_array())
+        assert codes.mask[2], "The None-valued polygon's code should be masked"
+        assert len(pc.cmap.colors) == 2, "Only the 2 real labels become categories"
+
+    def test_scheme_none_regression(self, polys_land_use):
+        """Without `scheme`, numeric values still use the continuous path.
+
+        Test scenario:
+            Plain numeric values are unaffected by the categorical addition.
+        """
+        polys, _ = polys_land_use
+        glyph = PolygonGlyph(polys, values=np.arange(6.0))
+        _, _, pc = glyph.plot()
+        assert not isinstance(pc.norm, mcolors.BoundaryNorm)
+        assert glyph.category_legend is None
+
+
+class TestScatterGlyphCategorical:
+    """Integration tests for `scheme="categorical"` through ScatterGlyph."""
+
+    @pytest.fixture()
+    def xy_species(self):
+        """Six points labelled with a repeating 3-class species attribute.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray, np.ndarray]: x, y, and species
+                string labels.
+        """
+        x = np.arange(6.0)
+        y = np.zeros_like(x)
+        species = np.array(["oak", "pine", "oak", "birch", "pine", "oak"])
+        return x, y, species
+
+    def test_distinct_values_get_distinct_colors(self, xy_species):
+        """Each unique species maps to its own point colour.
+
+        Test scenario:
+            Three unique labels produce a 3-colour `ListedColormap`.
+        """
+        x, y, species = xy_species
+        glyph = ScatterGlyph(x, y, values=species, scheme="categorical")
+        _, _, paths = glyph.plot()
+        assert isinstance(paths.cmap, mcolors.ListedColormap)
+        assert len(paths.cmap.colors) == 3
+
+    def test_disjoint_legend_not_colorbar(self, xy_species):
+        """A categorical scatter draws a legend, never a colorbar.
+
+        Test scenario:
+            `glyph.cbar` stays `None`; `glyph.category_legend` carries one
+            label per distinct species.
+        """
+        x, y, species = xy_species
+        glyph = ScatterGlyph(x, y, values=species, scheme="categorical")
+        glyph.plot()
+        assert glyph.cbar is None
+        legend_labels = {t.get_text() for t in glyph.category_legend.get_texts()}
+        assert legend_labels == {"oak", "pine", "birch"}
+
+    def test_integer_coded_attribute(self, xy_species):
+        """Integer class codes work the same way as string labels.
+
+        Test scenario:
+            Station-class integer codes map to distinct colours.
+        """
+        x, y, _ = xy_species
+        codes = np.array([10, 20, 10, 30, 20, 10])
+        glyph = ScatterGlyph(x, y, values=codes, scheme="categorical")
+        _, _, paths = glyph.plot()
+        assert len(paths.cmap.colors) == 3
+
+    def test_missing_value_renders_transparent(self, xy_species):
+        """A point whose value is `NaN` gets a masked (transparent) code.
+
+        Test scenario:
+            One `NaN` entry among valid labels does not become its own
+            category.
+        """
+        x, y, _ = xy_species
+        values = np.array(["oak", "pine", np.nan, "birch", "pine", "oak"], dtype=object)
+        glyph = ScatterGlyph(x, y, values=values, scheme="categorical")
+        _, _, paths = glyph.plot()
+        codes = np.ma.asarray(paths.get_array())
+        assert codes.mask[2], "The NaN-valued point's code should be masked"
+
+    def test_scheme_none_regression(self, xy_species):
+        """Without `scheme`, numeric values still use the continuous path.
+
+        Test scenario:
+            Plain numeric values are unaffected by the categorical addition.
+        """
+        x, y, _ = xy_species
+        glyph = ScatterGlyph(x, y, values=np.arange(6.0))
+        _, _, paths = glyph.plot()
+        assert not isinstance(paths.norm, mcolors.BoundaryNorm)
+        assert glyph.category_legend is None
+
+
+class TestCategoricalSchemeGlyphScope:
+    """Tests for which glyphs accept `scheme="categorical"`.
+
+    `PolygonGlyph`/`ScatterGlyph` colour per-element nominal labels, so they
+    support it. `VectorGlyph`/`FlowGlyph` colour a continuous magnitude
+    (vector length / flow accumulation): they still accept the generic
+    `scheme` option (for continuous classification), but must reject the
+    `"categorical"` value specifically rather than silently mis-colouring.
+    """
+
+    @pytest.mark.parametrize("glyph_cls", [PolygonGlyph, ScatterGlyph])
+    def test_supported_glyphs_flag_true(self, glyph_cls):
+        """The supported glyphs declare `_SUPPORTS_CATEGORICAL_SCHEME`.
+
+        Args:
+            glyph_cls: A glyph class expected to support categorical values.
+
+        Test scenario:
+            The class attribute is `True`.
+        """
+        assert glyph_cls._SUPPORTS_CATEGORICAL_SCHEME is True
+
+    def test_flow_glyph_rejects_categorical(self):
+        """`FlowGlyph` rejects `scheme="categorical"` with a clear error.
+
+        Test scenario:
+            Magnitude-coloured flow lines cannot use nominal categories;
+            plotting raises `ValueError` rather than mis-colouring silently.
+        """
+        paths = [np.array([[0.0, 0.0], [1.0, 1.0]]), np.array([[1.0, 0.0], [2.0, 1.0]])]
+        glyph = FlowGlyph(paths, values=np.array([1.0, 5.0]), scheme="categorical")
+        with pytest.raises(ValueError, match="does not support scheme='categorical'"):
+            glyph.plot()
+
+    def test_vector_glyph_rejects_categorical(self):
+        """`VectorGlyph` rejects `scheme="categorical"` with a clear error.
+
+        Test scenario:
+            Same guard as `FlowGlyph`, exercised through `VectorGlyph`.
+        """
+        x, y = np.meshgrid(np.arange(4.0), np.arange(4.0))
+        rng = np.random.default_rng(2)
+        u = rng.uniform(0.1, 5.0, size=x.shape)
+        v = rng.uniform(0.1, 5.0, size=x.shape)
+        glyph = VectorGlyph(x, y, u, v, scheme="categorical")
+        with pytest.raises(ValueError, match="does not support scheme='categorical'"):
+            glyph.plot(kind="quiver")

--- a/tests/test_polygon_glyph.py
+++ b/tests/test_polygon_glyph.py
@@ -73,6 +73,20 @@ class TestPolygonGlyphInit:
         with pytest.raises(ValueError, match="must match the number"):
             PolygonGlyph(polygons, values=np.array([1.0, 2.0, 3.0]))
 
+    def test_2d_values_with_matching_row_count_raises(self, polygons):
+        """A 2-D values array is rejected even when its row count matches.
+
+        Test scenario:
+            An accidentally un-flattened `(N, 2)` values array has the right
+            `shape[0]` but the wrong `ndim`; the full-shape check must still
+            reject it rather than silently mis-sizing the colour array once
+            it is later flattened.
+        """
+        values = np.array([[1.0, 2.0], [3.0, 4.0]])
+        assert values.shape[0] == len(polygons), "Fixture assumption: row count matches"
+        with pytest.raises(ValueError, match="must match the number"):
+            PolygonGlyph(polygons, values=values)
+
     def test_invalid_kwarg_raises(self, polygons):
         """An unknown kwarg is rejected by the strict merge.
 


### PR DESCRIPTION
# Description

Closes #204. Adds the auto distinct-value (nominal) categorical colouring that 0.24.0 (#198, #199) provided only
as a preset-driven path for `ArrayGlyph`/`MeshGlyph` — and extends it to the value-coloured vector glyphs,
`PolygonGlyph`/`ScatterGlyph`, which previously had no categorical path at all.

- `styles.categorize(values, cmap="tab10") -> (categories, colors)` — the distinct-value counterpart to
  `classify`: unique values (sorted when sortable, first-encounter order otherwise), one colour per category
  cycled from a qualitative cmap (sampled instead of cycled for a continuous cmap), null/NaN entries dropped.
- A `"categorical"` scheme on the shared `Glyph` scalar-mapping pipeline: `_prepare_categorical_mapping` builds a
  `ListedColormap` + `BoundaryNorm` over the per-element integer class codes (reusing the same construction
  `colors.apply_data_style` uses for a preset's `categories`, but auto-derived from the data), and
  `create_categorical_legend` draws a `disjoint_legend` in place of a colorbar.
- `PolygonGlyph` and `ScatterGlyph` opt in via a new `Glyph._SUPPORTS_CATEGORICAL_SCHEME` flag and expose the
  drawn legend as `glyph.category_legend`. `VectorGlyph`/`FlowGlyph` still accept the generic `scheme` option (for
  continuous classification) but raise a clear `ValueError` for `scheme="categorical"` instead of silently
  mis-colouring — their values are a continuous magnitude, not nominal labels.

**Dependencies:** none.

# Issues

- Closes #204 — distinct-value categorical colouring for `PolygonGlyph`/`ScatterGlyph`.

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Run against the external uv env (`VIRTUAL_ENV=C:/python-environments/uv/cleopatra`, `MPLBACKEND=Agg`,
`uv run --active`):

- [x] Full suite green: `pytest tests/` -> **1696 passed, 1 skipped**.
- [x] 32 new tests in `tests/test_categorize.py`: `categorize()` unit tests (sorted numeric/string categories,
      null dropping, cmap cycling vs. continuous-cmap sampling, mixed-type fallback, all-null error), the
      `Glyph._prepare_categorical_mapping` plumbing (side-channel population, conflict warnings, scope guard), and
      integration through `PolygonGlyph`/`ScatterGlyph` (distinct colours, legend-not-colorbar, string- and
      integer-coded attributes, missing-value -> transparent) plus the `VectorGlyph`/`FlowGlyph` rejection path.
- [x] Doctests green (`pytest --doctest-modules src/cleopatra/`).
- [x] black / isort / flake8 clean on every touched file.

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
