### PR TITLE
refactor(array_glyph)!: clean up plot()/animate()'s kwarg API

### DIFF
--- a/docs/notebooks/array_glyph/array_glyph_examples.ipynb
+++ b/docs/notebooks/array_glyph/array_glyph_examples.ipynb
@@ -24,17 +24,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import os\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "from cleopatra.config import Config\n",
-    "Config.set_matplotlib_backend()\n",
-    "from cleopatra.array_glyph import ArrayGlyph\n",
-    "from cleopatra.animation import embed_gif\n",
-    "# Set the random seed for reproducibility\n",
-    "np.random.seed(42)"
-   ]
+   "source": "import os\nimport numpy as np\nimport matplotlib.pyplot as plt\nfrom cleopatra.config import Config\nConfig.set_matplotlib_backend()\nfrom cleopatra.array_glyph import ArrayGlyph, PointOverlay\nfrom cleopatra.animation import embed_gif\n# Set the random seed for reproducibility\nnp.random.seed(42)"
   },
   {
    "cell_type": "markdown",
@@ -441,34 +431,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# Create an array\n",
-    "point_array = np.random.rand(15, 15)\n",
-    "\n",
-    "# Create some points to display on the array\n",
-    "# Points are specified as [value, row, column] coordinates\n",
-    "points = np.array([\n",
-    "    [1, 3, 3],    # Top-left region\n",
-    "    [2, 3, 11],   # Top-right region\n",
-    "    [3, 11, 3],   # Bottom-left region\n",
-    "    [4, 11, 11]   # Bottom-right region\n",
-    "])\n",
-    "\n",
-    "# Initialize the ArrayGlyph with the array\n",
-    "array_glyph_points = ArrayGlyph(point_array)\n",
-    "\n",
-    "# Plot with points\n",
-    "fig, ax = array_glyph_points.plot(\n",
-    "    points=points,            # Points to display\n",
-    "    point_color=\"red\",        # Set point color\n",
-    "    point_size=100,           # Set point size\n",
-    "    pid_color=\"blue\",         # Set point ID color\n",
-    "    pid_size=16,              # Set point ID size\n",
-    "    cmap=\"viridis\",           # Use the viridis colormap\n",
-    "    title=\"Array with Points\",\n",
-    "    figsize=(10, 8)\n",
-    ")"
-   ]
+   "source": "# Create an array\npoint_array = np.random.rand(15, 15)\n\n# Create some points to display on the array\n# Points are specified as [value, row, column] coordinates\npoints = np.array([\n    [1, 3, 3],    # Top-left region\n    [2, 3, 11],   # Top-right region\n    [3, 11, 3],   # Bottom-left region\n    [4, 11, 11]   # Bottom-right region\n])\n\n# Style the points via a PointOverlay: locations plus marker/label styling\npoint_overlay = PointOverlay(\n    points,\n    color=\"red\",         # Set point color\n    size=100,             # Set point size\n    label_color=\"blue\",  # Set point-value label color\n    label_size=16,        # Set point-value label size\n)\n\n# Initialize the ArrayGlyph with the array\narray_glyph_points = ArrayGlyph(point_array)\n\n# Plot with points\nfig, ax = array_glyph_points.plot(\n    points=point_overlay,     # Points to display\n    cmap=\"viridis\",           # Use the viridis colormap\n    title=\"Array with Points\",\n    figsize=(10, 8)\n)"
   },
   {
    "cell_type": "markdown",

--- a/docs/notebooks/array_glyph/rgb_animation.ipynb
+++ b/docs/notebooks/array_glyph/rgb_animation.ipynb
@@ -28,12 +28,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "from IPython.display import HTML\n",
-    "\n",
-    "from cleopatra.array_glyph import ArrayGlyph"
-   ]
+   "source": "import numpy as np\nfrom IPython.display import HTML\n\nfrom cleopatra.array_glyph import ArrayGlyph, FrameLabel"
   },
   {
    "cell_type": "markdown",
@@ -100,15 +95,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "labels = [f\"t{t}\" for t in range(n_frames)]\n",
-    "\n",
-    "glyph = ArrayGlyph(rgb_stack, figsize=(4, 4), title=\"RGB time-lapse\")\n",
-    "anim = glyph.animate(labels, interval=150, label_color=\"white\")\n",
-    "\n",
-    "print(\"colorbar drawn?\", glyph.cbar)  # None for true colour\n",
-    "HTML(anim.to_jshtml())"
-   ]
+   "source": "labels = [f\"t{t}\" for t in range(n_frames)]\n\nglyph = ArrayGlyph(rgb_stack, figsize=(4, 4), title=\"RGB time-lapse\")\nanim = glyph.animate(labels, interval=150, frame_label=FrameLabel(color=\"white\"))\n\nprint(\"colorbar drawn?\", glyph.cbar)  # None for true colour\nHTML(anim.to_jshtml())"
   },
   {
    "cell_type": "markdown",
@@ -133,21 +120,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "import tempfile\n",
-    "from pathlib import Path\n",
-    "\n",
-    "# add a fully-opaque alpha channel -> (time, rows, cols, 4)\n",
-    "alpha = np.ones((n_frames, h, w, 1))\n",
-    "rgba_stack = np.concatenate([rgb_stack, alpha], axis=-1)\n",
-    "\n",
-    "glyph_rgba = ArrayGlyph(rgba_stack, figsize=(4, 4), title=\"RGBA time-lapse\")\n",
-    "glyph_rgba.animate(labels, interval=150, label_color=\"white\")\n",
-    "\n",
-    "out = Path(tempfile.gettempdir()) / \"cleopatra_rgba.gif\"\n",
-    "glyph_rgba.save_animation(str(out), fps=6)\n",
-    "print(\"saved:\", out.exists(), \"| bytes:\", out.stat().st_size)"
-   ]
+   "source": "import tempfile\nfrom pathlib import Path\n\n# add a fully-opaque alpha channel -> (time, rows, cols, 4)\nalpha = np.ones((n_frames, h, w, 1))\nrgba_stack = np.concatenate([rgb_stack, alpha], axis=-1)\n\nglyph_rgba = ArrayGlyph(rgba_stack, figsize=(4, 4), title=\"RGBA time-lapse\")\nglyph_rgba.animate(labels, interval=150, frame_label=FrameLabel(color=\"white\"))\n\nout = Path(tempfile.gettempdir()) / \"cleopatra_rgba.gif\"\nglyph_rgba.save_animation(str(out), fps=6)\nprint(\"saved:\", out.exists(), \"| bytes:\", out.stat().st_size)"
   },
   {
    "cell_type": "markdown",
@@ -172,18 +145,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "template = np.zeros((h, w))  # 2-D shape template only\n",
-    "lazy_glyph = ArrayGlyph(template, figsize=(4, 4), title=\"Lazy RGB\")\n",
-    "\n",
-    "def get_frame(i):\n",
-    "    \"\"\"Return RGB frame i on demand (here, straight from rgb_stack).\"\"\"\n",
-    "    return rgb_stack[i]\n",
-    "\n",
-    "lazy_anim = lazy_glyph.animate(labels, data_getter=get_frame, interval=150, label_color=\"white\")\n",
-    "print(\"colorbar drawn?\", lazy_glyph.cbar)\n",
-    "HTML(lazy_anim.to_jshtml())"
-   ]
+   "source": "template = np.zeros((h, w))  # 2-D shape template only\nlazy_glyph = ArrayGlyph(template, figsize=(4, 4), title=\"Lazy RGB\")\n\ndef get_frame(i):\n    \"\"\"Return RGB frame i on demand (here, straight from rgb_stack).\"\"\"\n    return rgb_stack[i]\n\nlazy_anim = lazy_glyph.animate(\n    labels, data_getter=get_frame, interval=150, frame_label=FrameLabel(color=\"white\")\n)\nprint(\"colorbar drawn?\", lazy_glyph.cbar)\nHTML(lazy_anim.to_jshtml())"
   },
   {
    "cell_type": "markdown",
@@ -208,13 +170,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "single_band = np.linalg.norm(rgb_stack, axis=-1)  # (time, rows, cols)\n",
-    "sb_glyph = ArrayGlyph(single_band, figsize=(4, 4), title=\"Single band\")\n",
-    "sb_anim = sb_glyph.animate(labels, interval=150, label_color=\"white\")\n",
-    "print(\"colorbar drawn?\", sb_glyph.cbar is not None)\n",
-    "HTML(sb_anim.to_jshtml())"
-   ]
+   "source": "single_band = np.linalg.norm(rgb_stack, axis=-1)  # (time, rows, cols)\nsb_glyph = ArrayGlyph(single_band, figsize=(4, 4), title=\"Single band\")\nsb_anim = sb_glyph.animate(labels, interval=150, frame_label=FrameLabel(color=\"white\"))\nprint(\"colorbar drawn?\", sb_glyph.cbar is not None)\nHTML(sb_anim.to_jshtml())"
   }
  ],
  "metadata": {

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -104,14 +104,14 @@ def _resolve_renamed_kwarg(
 ) -> Any:
     """Resolve a renamed keyword argument, honouring its deprecated alias.
 
-    Several `ArrayGlyph.plot`/`animate` parameters were renamed for
-    clarity (e.g. `pid_color` -> `point_label_color`). Since the old name
-    is no longer an explicit parameter, a caller still using it arrives
-    here through `**kwargs` instead -- this pops it out, emits a
-    `DeprecationWarning`, and returns its value. Must be called *before*
-    `plot`/`animate` validate `kwargs` against `self.default_options`
-    (the old name is never a valid option key, so it would otherwise raise
-    there instead of being resolved).
+    Several `ArrayGlyph.animate` parameters were renamed for clarity
+    (e.g. `text_loc` -> `label_location`). Since the old name is no longer
+    an explicit parameter, a caller still using it arrives here through
+    `**kwargs` instead -- this pops it out, emits a `DeprecationWarning`,
+    and returns its value. Must be called *before* `plot`/`animate`
+    validate `kwargs` against `self.default_options` (the old name is
+    never a valid option key, so it would otherwise raise there instead of
+    being resolved).
 
     Args:
         kwargs: The method's `**kwargs` dict; mutated in place (the old
@@ -136,15 +136,15 @@ def _resolve_renamed_kwarg(
         - The old name is used and a `DeprecationWarning` is raised:
             ```python
             >>> import warnings
-            >>> kwargs = {"pid_color": "orange"}
+            >>> kwargs = {"text_loc": [0.1, 0.1]}
             >>> with warnings.catch_warnings(record=True) as caught:
             ...     warnings.simplefilter("always")
             ...     resolved = _resolve_renamed_kwarg(
-            ...         kwargs, "pid_color", "point_label_color", "blue", "blue"
+            ...         kwargs, "text_loc", "label_location", None, None
             ...     )
             >>> resolved
-            'orange'
-            >>> "pid_color" in kwargs
+            [0.1, 0.1]
+            >>> "text_loc" in kwargs
             False
             >>> issubclass(caught[0].category, DeprecationWarning)
             True
@@ -155,9 +155,9 @@ def _resolve_renamed_kwarg(
             ```python
             >>> kwargs = {"cmap": "viridis"}
             >>> _resolve_renamed_kwarg(
-            ...     kwargs, "pid_color", "point_label_color", "green", "blue"
+            ...     kwargs, "text_loc", "label_location", [0.2, 0.2], None
             ... )
-            'green'
+            [0.2, 0.2]
             >>> kwargs
             {'cmap': 'viridis'}
 
@@ -179,6 +179,173 @@ def _resolve_renamed_kwarg(
         )
         return new_value
     return old_value
+
+
+class PointOverlay:
+    """A point overlay for `ArrayGlyph.plot`/`animate`: locations plus styling.
+
+    Bundles the five point-overlay parameters (`points`, and the marker /
+    value-label colour and size) that `plot`/`animate` previously accepted
+    as five separate, identically-named arguments duplicated across both
+    signatures. Pass an instance as `plot(points=...)` /
+    `animate(points=...)` instead of the individual `point_color` /
+    `point_size` / `point_label_color` / `point_label_size` keywords.
+
+    Attributes:
+        points: `(N, 3)` array: first column the value to display at each
+            point, second/third columns the point's row/column index in
+            the underlying array.
+        color: Marker colour, by default `"red"`. Any valid matplotlib
+            colour string.
+        size: Marker size, by default `100`.
+        label_color: Colour of the point-value text label drawn at each
+            point, by default `"blue"`.
+        label_size: Font size of the point-value text label, by default
+            `10`.
+
+    Examples:
+        - Build an overlay and pass it to `plot`:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.array_glyph import ArrayGlyph, PointOverlay
+            >>> arr = np.arange(9, dtype=float).reshape(3, 3)
+            >>> overlay = PointOverlay(np.array([[5.0, 1, 1]]), color="black")
+            >>> fig, ax = ArrayGlyph(arr).plot(points=overlay)
+            >>> overlay.color
+            'black'
+            >>> overlay.size
+            100
+
+            ```
+    """
+
+    def __init__(
+        self,
+        points: np.ndarray,
+        *,
+        color: str = "red",
+        size: int | float = 100,
+        label_color: str = "blue",
+        label_size: int | float = 10,
+    ) -> None:
+        """Initialise a `PointOverlay`.
+
+        Args:
+            points: `(N, 3)` array: value, row index, column index per point.
+            color: Marker colour, by default `"red"`.
+            size: Marker size, by default `100`.
+            label_color: Point-value label colour, by default `"blue"`.
+            label_size: Point-value label font size, by default `10`.
+        """
+        self.points = points
+        self.color = color
+        self.size = size
+        self.label_color = label_color
+        self.label_size = label_size
+
+
+#: Deprecated `plot`/`animate` kwargs that `_resolve_point_overlay` folds
+#: into a `PointOverlay` instead of the (now-removed) individual keywords.
+#: `pid_color`/`pid_size` are the oldest generation (pre-dating even
+#: `point_label_color`/`point_label_size`) and are honoured too, so the
+#: deprecation chain from either generation still lands on `PointOverlay`.
+_DEPRECATED_POINT_STYLE_KWARGS = (
+    "point_color",
+    "point_size",
+    "point_label_color",
+    "point_label_size",
+    "pid_color",
+    "pid_size",
+)
+
+
+def _pop_first(
+    kwargs: dict, names: tuple[str, ...], default: Any
+) -> tuple[Any, str | None]:
+    """Pop every one of `names` present in `kwargs`; return the most-preferred value.
+
+    All matching keys are removed (not just the winner) so none of them
+    linger to fail the caller's subsequent strict `kwargs` validation --
+    e.g. `plot(points=arr, point_label_color=..., pid_color=...)` must pop
+    both, even though only `point_label_color`'s value is used.
+
+    Args:
+        kwargs: Dict to pop from; mutated in place.
+        names: Candidate keys, most-preferred first.
+        default: Value to return if none of `names` are present.
+
+    Returns:
+        tuple[Any, str | None]: The most-preferred present value (or
+            `default`), and the key it came from (`None` if none were
+            present).
+    """
+    present = [name for name in names if name in kwargs]
+    values = {name: kwargs.pop(name) for name in present}
+    if not present:
+        return default, None
+    winner = present[0]
+    return values[winner], winner
+
+
+def _resolve_point_overlay(
+    points: np.ndarray | PointOverlay | None, kwargs: dict
+) -> PointOverlay | None:
+    """Normalise `plot`/`animate`'s `points` argument into a `PointOverlay`.
+
+    Accepts the current calling convention (`points` is already a
+    `PointOverlay`, or `None`) as well as two deprecated generations
+    (`points` is a plain array, styled via separate `point_color` /
+    `point_size` / `point_label_color` / `point_label_size` keywords, or
+    the even older `pid_color` / `pid_size` for the label styling) -- any
+    of these emit a `DeprecationWarning` and are folded into a
+    `PointOverlay` here. Must be called *before* `plot`/`animate` validate
+    `kwargs` against `self.default_options`, which would otherwise reject
+    the deprecated keys outright.
+
+    Args:
+        points: The raw `points` argument as received by `plot`/`animate`:
+            a `PointOverlay`, a plain `(N, 3)` array, or `None`.
+        kwargs: The method's `**kwargs` dict; mutated in place (any
+            deprecated point-style keys are popped out).
+
+    Returns:
+        PointOverlay | None: `points` unchanged if it was already a
+            `PointOverlay` or `None`; otherwise a new `PointOverlay`
+            wrapping the array and the (possibly deprecated) style kwargs.
+    """
+    if isinstance(points, PointOverlay):
+        used_deprecated = [k for k in _DEPRECATED_POINT_STYLE_KWARGS if k in kwargs]
+        if used_deprecated:
+            warnings.warn(
+                f"{used_deprecated} are ignored when `points` is a "
+                "`PointOverlay` -- set them on the `PointOverlay` instance "
+                "instead.",
+                stacklevel=4,
+            )
+            for key in used_deprecated:
+                kwargs.pop(key)
+        return points
+    if points is None:
+        return None
+    color, color_key = _pop_first(kwargs, ("point_color",), "red")
+    size, size_key = _pop_first(kwargs, ("point_size",), 100)
+    label_color, label_color_key = _pop_first(
+        kwargs, ("point_label_color", "pid_color"), "blue"
+    )
+    label_size, label_size_key = _pop_first(
+        kwargs, ("point_label_size", "pid_size"), 10
+    )
+    used = [k for k in (color_key, size_key, label_color_key, label_size_key) if k]
+    if used:
+        warnings.warn(
+            f"Passing `points` as a plain array together with {used} is "
+            "deprecated; pass a `cleopatra.array_glyph.PointOverlay` instead.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+    return PointOverlay(
+        points, color=color, size=size, label_color=label_color, label_size=label_size
+    )
 
 
 class FacetGrid:
@@ -1960,11 +2127,7 @@ class ArrayGlyph(GeoMixin, Glyph):
 
     def plot(
         self,
-        points: np.ndarray = None,
-        point_color: str = "red",
-        point_size: int | float = 100,
-        point_label_color: str = "blue",
-        point_label_size: int | float = 10,
+        points: np.ndarray | PointOverlay | None = None,
         kind: str = "auto",
         ax: Axes | None = None,
         title: str | None = None,
@@ -1977,23 +2140,15 @@ class ArrayGlyph(GeoMixin, Glyph):
         It supports both regular arrays and RGB arrays.
 
         Args:
-            points: Points to display on the array, by default None.
-                Should be a 3-column array where:
-                - First column: values to display for each point
-                - Second column: row indices of the points in the array
-                - Third column: column indices of the points in the array
-            point_color: Color of the points, by default "red".
-                Any valid matplotlib color string.
-            point_size: Size of the points, by default 100.
-                Controls the marker size.
-            point_label_color: Color of the point value annotations, by
-                default "blue". Any valid matplotlib color string.
-                (Renamed from `pid_color`; the old name still works as a
-                keyword and emits a `DeprecationWarning`.)
-            point_label_size: Size of the point value annotations, by
-                default 10. Controls the font size of the annotations.
-                (Renamed from `pid_size`; the old name still works as a
-                keyword and emits a `DeprecationWarning`.)
+            points: Points to display on the array, by default None. A
+                `PointOverlay` (locations plus marker/label styling), or a
+                plain `(N, 3)` array of `[value, row, col]` per point (a
+                bare array is styled with `PointOverlay`'s own defaults).
+                (Styling `points` via separate `point_color` /
+                `point_size` / `point_label_color` / `point_label_size`
+                keywords is deprecated; pass a `PointOverlay` instead —
+                the old keywords still work as `**kwargs` and emit a
+                `DeprecationWarning`.)
             kind: Render kind, by default `"auto"`. One of:
 
                 - `"auto"` — picks the best renderer for the data.
@@ -2289,22 +2444,23 @@ class ArrayGlyph(GeoMixin, Glyph):
         - Plot points at specific locations in the array:
 
             - you can display points in specific cells in the array and also display a value for each of these points.
-                The point parameter takes an array with the first column as the values to be displayed on top of the
+                The point overlay's array has the first column as the values to be displayed on top of the
                 points, the second and third columns are the row and column index of the point in the array.
-            - The `point_color` and `point_size` parameters are used to customize the appearance of the points,
-                while the `point_label_color` and `point_label_size` parameters are used to customize the
-                appearance of each point's value label.
+            - A `PointOverlay`'s `color`/`size` customize the appearance of the points, while `label_color`/
+                `label_size` customize the appearance of each point's value label.
 
                 ```python
+                >>> from cleopatra.array_glyph import PointOverlay
                 >>> array = ArrayGlyph(arr, figsize=(6, 6), title="Display Points", title_size=14)
                 >>> points = np.array([[1, 0, 0], [2, 1, 1], [3, 2, 2]])
-                >>> fig, ax = array.plot(
-                ...     points=points,
-                ...     point_color="black",
-                ...     point_size=100,
-                ...     point_label_color="orange",
-                ...     point_label_size=30,
+                >>> overlay = PointOverlay(
+                ...     points,
+                ...     color="black",
+                ...     size=100,
+                ...     label_color="orange",
+                ...     label_size=30,
                 ... )
+                >>> fig, ax = array.plot(points=overlay)
 
                 ```
                 ![display-points](./../images/array_glyph/display-points.png)
@@ -2537,14 +2693,10 @@ class ArrayGlyph(GeoMixin, Glyph):
                 f"RGB compositing requires kind='imshow'. Got kind={kind!r}."
             )
 
-        # Resolve deprecated kwarg aliases before the strict `kwargs`
-        # validation below, which would otherwise reject them outright.
-        point_label_color = _resolve_renamed_kwarg(
-            kwargs, "pid_color", "point_label_color", point_label_color, "blue"
-        )
-        point_label_size = _resolve_renamed_kwarg(
-            kwargs, "pid_size", "point_label_size", point_label_size, 10
-        )
+        # Resolve `points` (a `PointOverlay`, or the deprecated plain-array +
+        # separate style kwargs) before the strict `kwargs` validation below,
+        # which would otherwise reject the deprecated keys outright.
+        points = _resolve_point_overlay(points, kwargs)
 
         for key, val in kwargs.items():
             if key not in self.default_options.keys():
@@ -2709,13 +2861,13 @@ class ArrayGlyph(GeoMixin, Glyph):
             )
 
         if points is not None and supports_overlay:
-            row = points[:, 1]
-            col = points[:, 2]
+            row = points.points[:, 1]
+            col = points.points[:, 2]
             optional_display["points_scatter"] = ax.scatter(
-                col, row, color=point_color, s=point_size
+                col, row, color=points.color, s=points.size
             )
             optional_display["points_id"] = self._plot_point_values(
-                ax, points, point_label_color, point_label_size
+                ax, points.points, points.label_color, points.label_size
             )
 
         # # Normalize the threshold to the image color range.
@@ -3010,14 +3162,10 @@ class ArrayGlyph(GeoMixin, Glyph):
     def animate(
         self,
         time: list[Any],
-        points: np.ndarray = None,
+        points: np.ndarray | PointOverlay | None = None,
         cell_value_text_colors: tuple[str, str] = ("white", "black"),
         interval: int = 200,
         label_location: list[Any, Any] = None,
-        point_color: str = "red",
-        point_size: int = 100,
-        point_label_color: str = "blue",
-        point_label_size: int = 10,
         *,
         label_color: str = "black",
         data_getter: Callable[[int], np.ndarray] | None = None,
@@ -3047,11 +3195,15 @@ class ArrayGlyph(GeoMixin, Glyph):
             time: A list containing labels for each frame in the animation.
                 These could be timestamps, frame numbers, or any other identifiers.
                 The length of this list should match the first dimension of the array.
-            points: Points to display on the array, by default None.
-                Should be a 3-column array where:
-                - First column: values to display for each point
-                - Second column: row indices of the points in the array
-                - Third column: column indices of the points in the array
+            points: Points to display on the array, by default None. A
+                `PointOverlay` (locations plus marker/label styling), or a
+                plain `(N, 3)` array of `[value, row, col]` per point (a
+                bare array is styled with `PointOverlay`'s own defaults).
+                (Styling `points` via separate `point_color` /
+                `point_size` / `point_label_color` / `point_label_size`
+                keywords is deprecated; pass a `PointOverlay` instead —
+                the old keywords still work as `**kwargs` and emit a
+                `DeprecationWarning`.)
             cell_value_text_colors: Two colors to be used for cell value
                 text, by default ("white", "black"). The first color is
                 used when the cell value is below the
@@ -3072,18 +3224,6 @@ class ArrayGlyph(GeoMixin, Glyph):
                 `cbar_label_size` in that case. (Renamed from `text_loc`;
                 the old name still works as a keyword and emits a
                 `DeprecationWarning`.)
-            point_color: Color of the points, by default "red".
-                Any valid matplotlib color string.
-            point_size: Size of the points, by default 100.
-                Controls the marker size.
-            point_label_color: Color of the point value annotations, by
-                default "blue". Any valid matplotlib color string.
-                (Renamed from `pid_color`; the old name still works as a
-                keyword and emits a `DeprecationWarning`.)
-            point_label_size: Size of the point value annotations, by
-                default 10. Controls the font size of the annotations.
-                (Renamed from `pid_size`; the old name still works as a
-                keyword and emits a `DeprecationWarning`.)
             label_color: Color of the frame label text, by default "black".
                 Any valid matplotlib color string. `ArrayGlyph`-only;
                 `MeshGlyph.animate()` does not yet expose this option.
@@ -3253,17 +3393,17 @@ class ArrayGlyph(GeoMixin, Glyph):
         ```
         Animation with points:
         ```python
-        >>> # Create points to display on the animation
-        >>> points = np.array([[1, 2, 3], [2, 5, 5], [3, 8, 8]])
-        >>> animated_array = ArrayGlyph(arr, figsize=(8, 8), title="Animated Array")
-        >>> anim_obj = animated_array.animate(
-        ...     frame_labels,
-        ...     points=points,
-        ...     point_color="black",
-        ...     point_size=150,
-        ...     point_label_color="white",
-        ...     point_label_size=12
+        >>> # Create a styled point overlay to display on the animation
+        >>> from cleopatra.array_glyph import PointOverlay
+        >>> overlay = PointOverlay(
+        ...     np.array([[1, 2, 3], [2, 5, 5], [3, 8, 8]]),
+        ...     color="black",
+        ...     size=150,
+        ...     label_color="white",
+        ...     label_size=12,
         ... )
+        >>> animated_array = ArrayGlyph(arr, figsize=(8, 8), title="Animated Array")
+        >>> anim_obj = animated_array.animate(frame_labels, points=overlay)
 
         ```
         Animation with cell values displayed:
@@ -3332,12 +3472,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         label_location = _resolve_renamed_kwarg(
             kwargs, "text_loc", "label_location", label_location, None
         )
-        point_label_color = _resolve_renamed_kwarg(
-            kwargs, "pid_color", "point_label_color", point_label_color, "blue"
-        )
-        point_label_size = _resolve_renamed_kwarg(
-            kwargs, "pid_size", "point_label_size", point_label_size, 10
-        )
+        points = _resolve_point_overlay(points, kwargs)
 
         label_location_is_default = label_location is None
         if label_location_is_default:
@@ -3565,11 +3700,11 @@ class ArrayGlyph(GeoMixin, Glyph):
             indices = np.array(indices)
 
         if points is not None:
-            row = points[:, 1]
-            col = points[:, 2]
-            points_scatter = ax.scatter(col, row, color=point_color, s=point_size)
+            row = points.points[:, 1]
+            col = points.points[:, 2]
+            points_scatter = ax.scatter(col, row, color=points.color, s=points.size)
             points_id = self._plot_point_values(
-                ax, points, point_label_color, point_label_size
+                ax, points.points, points.label_color, points.label_size
             )
 
         # Normalize the threshold to the image color range. With a
@@ -3680,7 +3815,7 @@ class ArrayGlyph(GeoMixin, Glyph):
             if points is not None:
                 points_scatter.set_offsets(np.c_[col, row])
                 output.append(points_scatter)
-                update_points = lambda x: points_id[x].set_text(points[x, 0])
+                update_points = lambda x: points_id[x].set_text(points.points[x, 0])
                 list(map(update_points, range(len(col))))
 
                 output += points_id
@@ -3708,7 +3843,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                 output.append(points_scatter)
 
                 for x in range(len(col)):
-                    points_id[x].set_text(points[x, 0])
+                    points_id[x].set_text(points.points[x, 0])
 
                 output += points_id
 

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -574,7 +574,7 @@ def _resolve_point_overlay(
                 f"{used_deprecated} are ignored when `points` is a "
                 "`PointOverlay` -- set them on the `PointOverlay` instance "
                 "instead.",
-                stacklevel=4,
+                stacklevel=3,
             )
             for key in used_deprecated:
                 kwargs.pop(key)
@@ -595,7 +595,7 @@ def _resolve_point_overlay(
             f"Passing `points` as a plain array together with {used} is "
             "deprecated; pass a `cleopatra.array_glyph.PointOverlay` instead.",
             DeprecationWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
     return PointOverlay(
         points, color=color, size=size, label_color=label_color, label_size=label_size

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -609,15 +609,19 @@ def _resolve_point_overlay(
 _DEPRECATED_FRAME_LABEL_KWARGS = ("label_location", "label_color", "text_loc")
 
 
-def _resolve_frame_label(frame_label: FrameLabel | None, kwargs: dict) -> FrameLabel:
+def _resolve_frame_label(frame_label: Any, kwargs: dict) -> FrameLabel:
     """Normalise `animate`'s `frame_label` argument into a `FrameLabel`.
 
     Accepts the current calling convention (`frame_label` is already a
-    `FrameLabel`, or `None` for the defaults) as well as the deprecated one
-    (separate `label_location` / `label_color` keywords, or the even older
-    `text_loc` for the location) -- the latter emit a `DeprecationWarning`
-    and are folded into a `FrameLabel` here. Unlike `_resolve_point_overlay`,
-    this never returns `None`: `animate` always draws a frame label, so
+    `FrameLabel`, or `None` for the defaults) as well as two deprecated
+    ones: separate `label_location` / `label_color` keywords (or the even
+    older `text_loc` for the location), and a bare `[x, y]` value at the
+    `frame_label` position itself -- the pre-`FrameLabel` calling shape,
+    still reachable positionally (`animate(time, None, colors, interval,
+    [x, y])`) even though `label_location`/`text_loc` were never
+    positional-only. Any of these emit a `DeprecationWarning` and are
+    folded into a `FrameLabel` here. Unlike `_resolve_point_overlay`, this
+    never returns `None`: `animate` always draws a frame label, so
     `frame_label=None` means "use `FrameLabel`'s own defaults", not "no
     label". Must be called *before* `animate` validates `kwargs` against
     `self.default_options`, which would otherwise reject the deprecated
@@ -625,14 +629,16 @@ def _resolve_frame_label(frame_label: FrameLabel | None, kwargs: dict) -> FrameL
 
     Args:
         frame_label: The raw `frame_label` argument as received by
-            `animate`: a `FrameLabel`, or `None`.
+            `animate`: a `FrameLabel`, `None`, or (deprecated) a plain
+            `[x, y]` value passed positionally.
         kwargs: The method's `**kwargs` dict; mutated in place (any
             deprecated frame-label keys are popped out).
 
     Returns:
         FrameLabel: `frame_label` unchanged if it was already a
             `FrameLabel`; otherwise a new `FrameLabel` built from the
-            (possibly deprecated) location/color kwargs, or the defaults.
+            positional value and/or the (possibly deprecated)
+            location/color kwargs, or the defaults.
     """
     if isinstance(frame_label, FrameLabel):
         used_deprecated = [k for k in _DEPRECATED_FRAME_LABEL_KWARGS if k in kwargs]
@@ -641,20 +647,29 @@ def _resolve_frame_label(frame_label: FrameLabel | None, kwargs: dict) -> FrameL
                 f"{used_deprecated} are ignored when `frame_label` is a "
                 "`FrameLabel` -- set them on the `FrameLabel` instance "
                 "instead.",
-                stacklevel=4,
+                stacklevel=3,
             )
             for key in used_deprecated:
                 kwargs.pop(key)
         return frame_label
-    location, location_key = _pop_first(kwargs, ("label_location", "text_loc"), None)
     color, color_key = _pop_first(kwargs, ("label_color",), "black")
+    # Drain the location kwargs unconditionally (so they never reach the
+    # strict `kwargs` validation), but a plain positional `frame_label`
+    # value below wins over them if both are somehow given at once.
+    kwarg_location, kwarg_location_key = _pop_first(
+        kwargs, ("label_location", "text_loc"), None
+    )
+    if frame_label is not None:
+        location, location_key = frame_label, "frame_label (positional)"
+    else:
+        location, location_key = kwarg_location, kwarg_location_key
     used = [k for k in (location_key, color_key) if k]
     if used:
         warnings.warn(
             f"Passing {used} directly is deprecated; pass a "
             "`cleopatra.array_glyph.FrameLabel` as `frame_label` instead.",
             DeprecationWarning,
-            stacklevel=4,
+            stacklevel=3,
         )
     return FrameLabel(location=location, color=color)
 

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -99,6 +99,30 @@ _COORD_SHAPE_MISMATCH = "coord array shape does not match the data array"
 _COORD_DTYPE_MISMATCH = "coord arrays must be numeric (integer or float)"
 
 
+class _Unset:
+    """Sentinel type for "the caller did not pass this explicit parameter".
+
+    A plain `object()` sentinel would work too, but this gives `help()` /
+    IDE signature tooltips a readable `<unset>` instead of
+    `<object object at 0x...>` for the parameter default that uses it
+    (`ArrayGlyph.animate`'s `cell_value_text_colors`).
+    """
+
+    def __repr__(self) -> str:
+        return "<unset>"
+
+
+#: Sentinel default for a renamed parameter whose *real* default is
+#: resolved inside `_resolve_renamed_kwarg` rather than in the method
+#: signature. Distinguishes "caller didn't pass this parameter" from
+#: "caller explicitly passed a value equal to its default" -- an ambiguity
+#: a plain equality-with-default check cannot resolve, which previously
+#: made the "both old and new given" conflict detection silently prefer
+#: the deprecated value in that case (the opposite of the documented
+#: "new wins" behaviour).
+_UNSET = _Unset()
+
+
 def _resolve_renamed_kwarg(
     kwargs: dict, old_name: str, new_name: str, new_value: Any, default: Any
 ) -> Any:
@@ -119,18 +143,20 @@ def _resolve_renamed_kwarg(
             `default_options` validation).
         old_name: The deprecated parameter name to look for in `kwargs`.
         new_name: The current parameter name, used in the warning message.
-        new_value: The value the caller's `new_name` argument resolved to
-            (whatever `plot`/`animate` received for it, default or not).
-        default: `new_name`'s own default value. Used only to detect a
-            caller passing *both* names at once (a non-default `new_value`
-            alongside the old name is ambiguous) -- not a fully reliable
-            signal (a caller could explicitly repeat the default), but
-            good enough to warn on the common conflicting case.
+        new_value: The value the caller's `new_name` argument resolved to.
+            `new_name`'s own signature default must be the `_UNSET`
+            sentinel (not a concrete value) so this can tell "the caller
+            didn't pass `new_name`" apart from "the caller explicitly
+            passed `new_name` equal to its real default" -- the two cases
+            a plain equality-with-default check cannot distinguish.
+        default: `new_name`'s real default value, substituted when
+            neither name was given.
 
     Returns:
         Any: `new_value` when `old_name` is absent from `kwargs`, or when
-            both names were given (new wins); otherwise the popped
-            `old_name` value.
+            both names were given (new wins, i.e. `new_value` is not
+            `_UNSET`); otherwise the popped `old_name` value, or `default`
+            when neither was given.
 
     Examples:
         - The old name is used and a `DeprecationWarning` is raised:
@@ -141,7 +167,7 @@ def _resolve_renamed_kwarg(
             ...     warnings.simplefilter("always")
             ...     resolved = _resolve_renamed_kwarg(
             ...         kwargs, "text_colors", "cell_value_text_colors",
-            ...         ("white", "black"), ("white", "black"),
+            ...         _UNSET, ("white", "black"),
             ...     )
             >>> resolved
             ('yellow', 'purple')
@@ -149,6 +175,18 @@ def _resolve_renamed_kwarg(
             False
             >>> issubclass(caught[0].category, DeprecationWarning)
             True
+
+            ```
+        - Both names given: the new one wins even when it is equal to its
+            own default (the false-negative a plain equality check would
+            miss):
+            ```python
+            >>> kwargs = {"text_colors": ("yellow", "purple")}
+            >>> _resolve_renamed_kwarg(
+            ...     kwargs, "text_colors", "cell_value_text_colors",
+            ...     ("white", "black"), ("white", "black"),
+            ... )
+            ('white', 'black')
 
             ```
         - With no old-name alias present, the new value passes through
@@ -166,14 +204,14 @@ def _resolve_renamed_kwarg(
             ```
     """
     if old_name not in kwargs:
-        return new_value
+        return default if new_value is _UNSET else new_value
     old_value = kwargs.pop(old_name)
     warnings.warn(
         f"`{old_name}` is deprecated; use `{new_name}` instead.",
         DeprecationWarning,
         stacklevel=3,
     )
-    if new_value != default:
+    if new_value is not _UNSET:
         warnings.warn(
             f"Both `{old_name}` (deprecated) and `{new_name}` were given; "
             f"`{new_name}` wins.",
@@ -3492,7 +3530,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         self,
         time: list[Any],
         points: np.ndarray | PointOverlay | None = None,
-        cell_value_text_colors: tuple[str, str] = ("white", "black"),
+        cell_value_text_colors: tuple[str, str] | _Unset = _UNSET,
         interval: int = 200,
         frame_label: FrameLabel | None = None,
         *,

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -99,6 +99,88 @@ _COORD_SHAPE_MISMATCH = "coord array shape does not match the data array"
 _COORD_DTYPE_MISMATCH = "coord arrays must be numeric (integer or float)"
 
 
+def _resolve_renamed_kwarg(
+    kwargs: dict, old_name: str, new_name: str, new_value: Any, default: Any
+) -> Any:
+    """Resolve a renamed keyword argument, honouring its deprecated alias.
+
+    Several `ArrayGlyph.plot`/`animate` parameters were renamed for
+    clarity (e.g. `pid_color` -> `point_label_color`). Since the old name
+    is no longer an explicit parameter, a caller still using it arrives
+    here through `**kwargs` instead -- this pops it out, emits a
+    `DeprecationWarning`, and returns its value. Must be called *before*
+    `plot`/`animate` validate `kwargs` against `self.default_options`
+    (the old name is never a valid option key, so it would otherwise raise
+    there instead of being resolved).
+
+    Args:
+        kwargs: The method's `**kwargs` dict; mutated in place (the old
+            key, if present, is popped so it never reaches the strict
+            `default_options` validation).
+        old_name: The deprecated parameter name to look for in `kwargs`.
+        new_name: The current parameter name, used in the warning message.
+        new_value: The value the caller's `new_name` argument resolved to
+            (whatever `plot`/`animate` received for it, default or not).
+        default: `new_name`'s own default value. Used only to detect a
+            caller passing *both* names at once (a non-default `new_value`
+            alongside the old name is ambiguous) -- not a fully reliable
+            signal (a caller could explicitly repeat the default), but
+            good enough to warn on the common conflicting case.
+
+    Returns:
+        Any: `new_value` when `old_name` is absent from `kwargs`, or when
+            both names were given (new wins); otherwise the popped
+            `old_name` value.
+
+    Examples:
+        - The old name is used and a `DeprecationWarning` is raised:
+            ```python
+            >>> import warnings
+            >>> kwargs = {"pid_color": "orange"}
+            >>> with warnings.catch_warnings(record=True) as caught:
+            ...     warnings.simplefilter("always")
+            ...     resolved = _resolve_renamed_kwarg(
+            ...         kwargs, "pid_color", "point_label_color", "blue", "blue"
+            ...     )
+            >>> resolved
+            'orange'
+            >>> "pid_color" in kwargs
+            False
+            >>> issubclass(caught[0].category, DeprecationWarning)
+            True
+
+            ```
+        - With no old-name alias present, the new value passes through
+            untouched and `kwargs` is unaffected:
+            ```python
+            >>> kwargs = {"cmap": "viridis"}
+            >>> _resolve_renamed_kwarg(
+            ...     kwargs, "pid_color", "point_label_color", "green", "blue"
+            ... )
+            'green'
+            >>> kwargs
+            {'cmap': 'viridis'}
+
+            ```
+    """
+    if old_name not in kwargs:
+        return new_value
+    old_value = kwargs.pop(old_name)
+    warnings.warn(
+        f"`{old_name}` is deprecated; use `{new_name}` instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    if new_value != default:
+        warnings.warn(
+            f"Both `{old_name}` (deprecated) and `{new_name}` were given; "
+            f"`{new_name}` wins.",
+            stacklevel=3,
+        )
+        return new_value
+    return old_value
+
+
 class FacetGrid:
     """Result object for a multi-subplot facet plot.
 
@@ -1881,8 +1963,8 @@ class ArrayGlyph(GeoMixin, Glyph):
         points: np.ndarray = None,
         point_color: str = "red",
         point_size: int | float = 100,
-        pid_color: str = "blue",
-        pid_size: int | float = 10,
+        point_label_color: str = "blue",
+        point_label_size: int | float = 10,
         kind: str = "auto",
         ax: Axes | None = None,
         title: str | None = None,
@@ -1904,10 +1986,14 @@ class ArrayGlyph(GeoMixin, Glyph):
                 Any valid matplotlib color string.
             point_size: Size of the points, by default 100.
                 Controls the marker size.
-            pid_color: Color of the point value annotations, by default "blue".
-                Any valid matplotlib color string.
-            pid_size: Size of the point value annotations, by default 10.
-                Controls the font size of the annotations.
+            point_label_color: Color of the point value annotations, by
+                default "blue". Any valid matplotlib color string.
+                (Renamed from `pid_color`; the old name still works as a
+                keyword and emits a `DeprecationWarning`.)
+            point_label_size: Size of the point value annotations, by
+                default 10. Controls the font size of the annotations.
+                (Renamed from `pid_size`; the old name still works as a
+                keyword and emits a `DeprecationWarning`.)
             kind: Render kind, by default `"auto"`. One of:
 
                 - `"auto"` — picks the best renderer for the data.
@@ -2206,8 +2292,8 @@ class ArrayGlyph(GeoMixin, Glyph):
                 The point parameter takes an array with the first column as the values to be displayed on top of the
                 points, the second and third columns are the row and column index of the point in the array.
             - The `point_color` and `point_size` parameters are used to customize the appearance of the points,
-                while the `pid_color` and `pid_size` parameters are used to customize the appearance of the point
-                IDs/text.
+                while the `point_label_color` and `point_label_size` parameters are used to customize the
+                appearance of each point's value label.
 
                 ```python
                 >>> array = ArrayGlyph(arr, figsize=(6, 6), title="Display Points", title_size=14)
@@ -2216,8 +2302,8 @@ class ArrayGlyph(GeoMixin, Glyph):
                 ...     points=points,
                 ...     point_color="black",
                 ...     point_size=100,
-                ...     pid_color="orange",
-                ...     pid_size=30,
+                ...     point_label_color="orange",
+                ...     point_label_size=30,
                 ... )
 
                 ```
@@ -2451,6 +2537,15 @@ class ArrayGlyph(GeoMixin, Glyph):
                 f"RGB compositing requires kind='imshow'. Got kind={kind!r}."
             )
 
+        # Resolve deprecated kwarg aliases before the strict `kwargs`
+        # validation below, which would otherwise reject them outright.
+        point_label_color = _resolve_renamed_kwarg(
+            kwargs, "pid_color", "point_label_color", point_label_color, "blue"
+        )
+        point_label_size = _resolve_renamed_kwarg(
+            kwargs, "pid_size", "point_label_size", point_label_size, 10
+        )
+
         for key, val in kwargs.items():
             if key not in self.default_options.keys():
                 raise ValueError(
@@ -2620,7 +2715,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                 col, row, color=point_color, s=point_size
             )
             optional_display["points_id"] = self._plot_point_values(
-                ax, points, pid_color, pid_size
+                ax, points, point_label_color, point_label_size
             )
 
         # # Normalize the threshold to the image color range.
@@ -2916,13 +3011,13 @@ class ArrayGlyph(GeoMixin, Glyph):
         self,
         time: list[Any],
         points: np.ndarray = None,
-        text_colors: tuple[str, str] = ("white", "black"),
+        cell_value_text_colors: tuple[str, str] = ("white", "black"),
         interval: int = 200,
-        text_loc: list[Any, Any] = None,
+        label_location: list[Any, Any] = None,
         point_color: str = "red",
         point_size: int = 100,
-        pid_color: str = "blue",
-        pid_size: int = 10,
+        point_label_color: str = "blue",
+        point_label_size: int = 10,
         *,
         label_color: str = "black",
         data_getter: Callable[[int], np.ndarray] | None = None,
@@ -2957,27 +3052,38 @@ class ArrayGlyph(GeoMixin, Glyph):
                 - First column: values to display for each point
                 - Second column: row indices of the points in the array
                 - Third column: column indices of the points in the array
-            text_colors: Two colors to be used for cell value text, by default ("white", "black").
-                The first color is used when the cell value is below the background_color_threshold,
-                and the second color is used when the cell value is above the threshold.
+            cell_value_text_colors: Two colors to be used for cell value
+                text, by default ("white", "black"). The first color is
+                used when the cell value is below the
+                background_color_threshold, and the second color is used
+                when the cell value is above the threshold. (Renamed from
+                `text_colors`; the old name still works as a keyword and
+                emits a `DeprecationWarning`.)
             interval: Delay between frames in milliseconds, by default 200.
                 Controls the speed of the animation (smaller values = faster animation).
-            text_loc: Location of the frame label text as [x, y] coordinates, by default None.
-                When None, the label is anchored just inside the top-left corner using
+            label_location: Location of the frame label text as [x, y]
+                coordinates, by default None. When None, the label is
+                anchored just inside the top-left corner using
                 axes-fraction coordinates, so it stays clear of the top/bottom edges
                 regardless of the array's shape or the axis orientation. A very narrow
                 axes can still overflow horizontally at the default font size, since no
                 anchor choice can fit a long label into less horizontal space than it
                 needs; pass an explicit [x, y] (data coordinates) or a smaller
-                `cbar_label_size` in that case.
+                `cbar_label_size` in that case. (Renamed from `text_loc`;
+                the old name still works as a keyword and emits a
+                `DeprecationWarning`.)
             point_color: Color of the points, by default "red".
                 Any valid matplotlib color string.
             point_size: Size of the points, by default 100.
                 Controls the marker size.
-            pid_color: Color of the point value annotations, by default "blue".
-                Any valid matplotlib color string.
-            pid_size: Size of the point value annotations, by default 10.
-                Controls the font size of the annotations.
+            point_label_color: Color of the point value annotations, by
+                default "blue". Any valid matplotlib color string.
+                (Renamed from `pid_color`; the old name still works as a
+                keyword and emits a `DeprecationWarning`.)
+            point_label_size: Size of the point value annotations, by
+                default 10. Controls the font size of the annotations.
+                (Renamed from `pid_size`; the old name still works as a
+                keyword and emits a `DeprecationWarning`.)
             label_color: Color of the frame label text, by default "black".
                 Any valid matplotlib color string. `ArrayGlyph`-only;
                 `MeshGlyph.animate()` does not yet expose this option.
@@ -3155,8 +3261,8 @@ class ArrayGlyph(GeoMixin, Glyph):
         ...     points=points,
         ...     point_color="black",
         ...     point_size=150,
-        ...     pid_color="white",
-        ...     pid_size=12
+        ...     point_label_color="white",
+        ...     point_label_size=12
         ... )
 
         ```
@@ -3167,7 +3273,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         ...     frame_labels,
         ...     display_cell_value=True,
         ...     num_size=10,
-        ...     text_colors=("yellow", "blue")
+        ...     cell_value_text_colors=("yellow", "blue")
         ... )
 
         ```
@@ -3214,13 +3320,32 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         ```
         """
-        text_loc_is_default = text_loc is None
-        if text_loc_is_default:
+        # Resolve deprecated kwarg aliases before the strict `kwargs`
+        # validation below, which would otherwise reject them outright.
+        cell_value_text_colors = _resolve_renamed_kwarg(
+            kwargs,
+            "text_colors",
+            "cell_value_text_colors",
+            cell_value_text_colors,
+            ("white", "black"),
+        )
+        label_location = _resolve_renamed_kwarg(
+            kwargs, "text_loc", "label_location", label_location, None
+        )
+        point_label_color = _resolve_renamed_kwarg(
+            kwargs, "pid_color", "point_label_color", point_label_color, "blue"
+        )
+        point_label_size = _resolve_renamed_kwarg(
+            kwargs, "pid_size", "point_label_size", point_label_size, 10
+        )
+
+        label_location_is_default = label_location is None
+        if label_location_is_default:
             # Axes-fraction anchor (not data coordinates): stays inside the
             # frame regardless of array shape or axis orientation, unlike a
             # fixed data-coordinate default. See `day_text` below for the
             # matching transform/alignment.
-            text_loc = [0.02, 0.95]
+            label_location = [0.02, 0.95]
 
         for key, val in kwargs.items():
             if key not in self.default_options.keys():
@@ -3443,7 +3568,9 @@ class ArrayGlyph(GeoMixin, Glyph):
             row = points[:, 1]
             col = points[:, 2]
             points_scatter = ax.scatter(col, row, color=point_color, s=point_size)
-            points_id = self._plot_point_values(ax, points, pid_color, pid_size)
+            points_id = self._plot_point_values(
+                ax, points, point_label_color, point_label_size
+            )
 
         # Normalize the threshold to the image color range. With a
         # lazy `data_getter` we only have `frame_0` available
@@ -3460,13 +3587,13 @@ class ArrayGlyph(GeoMixin, Glyph):
                 background_color_threshold = im.norm(np.nanmax(ref_for_threshold)) / 2.0
 
         day_text = ax.text(
-            text_loc[0],
-            text_loc[1],
+            label_location[0],
+            label_location[1],
             " ",
             fontsize=self.default_options["cbar_label_size"],
             color=label_color,
-            transform=ax.transAxes if text_loc_is_default else ax.transData,
-            va="top" if text_loc_is_default else "baseline",
+            transform=ax.transAxes if label_location_is_default else ax.transData,
+            va="top" if label_location_is_default else "baseline",
         )
         self._day_text = day_text
 
@@ -3592,7 +3719,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                     """Update cell value"""
                     val = round(vals[x], precision)
                     kw = {
-                        "color": text_colors[
+                        "color": cell_value_text_colors[
                             int(im.norm(vals[x]) > background_color_threshold)
                         ]
                     }

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -590,9 +590,13 @@ def _resolve_point_overlay(
     `point_size` / `point_label_color` / `point_label_size` keywords, or
     the even older `pid_color` / `pid_size` for the label styling) -- any
     of these emit a `DeprecationWarning` and are folded into a
-    `PointOverlay` here. Must be called *before* `plot`/`animate` validate
-    `kwargs` against `self.default_options`, which would otherwise reject
-    the deprecated keys outright.
+    `PointOverlay` here. The deprecated style keys are drained out of
+    `kwargs` even when `points` is `None` (a no-op, matching their
+    pre-`PointOverlay` behaviour as named parameters with defaults) so
+    they never reach the caller's strict `kwargs` validation. Must be
+    called *before* `plot`/`animate` validate `kwargs` against
+    `self.default_options`, which would otherwise reject the deprecated
+    keys outright.
 
     Args:
         points: The raw `points` argument as received by `plot`/`animate`:
@@ -618,6 +622,26 @@ def _resolve_point_overlay(
                 kwargs.pop(key)
         return points
     if points is None:
+        # Drain the deprecated point-style keys even with no `points` to
+        # style, matching their pre-PointOverlay behaviour (named
+        # parameters with defaults -- legal, if pointless, without
+        # `points`). Skipping this would leave them in `kwargs` to fail
+        # the caller's strict `default_options` validation, breaking the
+        # documented "old keywords still work as `**kwargs`" guarantee.
+        _, color_key = _pop_first(kwargs, ("point_color",), None)
+        _, size_key = _pop_first(kwargs, ("point_size",), None)
+        _, label_color_key = _pop_first(
+            kwargs, ("point_label_color", "pid_color"), None
+        )
+        _, label_size_key = _pop_first(kwargs, ("point_label_size", "pid_size"), None)
+        used = [k for k in (color_key, size_key, label_color_key, label_size_key) if k]
+        if used:
+            warnings.warn(
+                f"{used} have no effect without `points`; pass a "
+                "`cleopatra.array_glyph.PointOverlay` as `points` instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
         return None
     color, color_key = _pop_first(kwargs, ("point_color",), "red")
     size, size_key = _pop_first(kwargs, ("point_size",), 100)

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -722,10 +722,17 @@ def _resolve_frame_label(frame_label: Any, kwargs: dict) -> FrameLabel:
         kwargs, ("label_location", "text_loc"), None
     )
     if frame_label is not None:
-        location, location_key = frame_label, "frame_label (positional)"
+        location = frame_label
+        # Report both consumed aliases in this (unusual) combined case --
+        # the keyword is still drained above even though positional wins,
+        # so it must not go unmentioned in the warning.
+        location_keys = ["frame_label (positional)"]
+        if kwarg_location_key:
+            location_keys.append(kwarg_location_key)
     else:
-        location, location_key = kwarg_location, kwarg_location_key
-    used = [k for k in (location_key, color_key) if k]
+        location = kwarg_location
+        location_keys = [kwarg_location_key] if kwarg_location_key else []
+    used = location_keys + ([color_key] if color_key else [])
     if used:
         warnings.warn(
             f"Passing {used} directly is deprecated; pass a "

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -105,13 +105,13 @@ def _resolve_renamed_kwarg(
     """Resolve a renamed keyword argument, honouring its deprecated alias.
 
     Several `ArrayGlyph.animate` parameters were renamed for clarity
-    (e.g. `text_loc` -> `label_location`). Since the old name is no longer
-    an explicit parameter, a caller still using it arrives here through
-    `**kwargs` instead -- this pops it out, emits a `DeprecationWarning`,
-    and returns its value. Must be called *before* `plot`/`animate`
-    validate `kwargs` against `self.default_options` (the old name is
-    never a valid option key, so it would otherwise raise there instead of
-    being resolved).
+    (e.g. `text_colors` -> `cell_value_text_colors`). Since the old name is
+    no longer an explicit parameter, a caller still using it arrives here
+    through `**kwargs` instead -- this pops it out, emits a
+    `DeprecationWarning`, and returns its value. Must be called *before*
+    `plot`/`animate` validate `kwargs` against `self.default_options` (the
+    old name is never a valid option key, so it would otherwise raise
+    there instead of being resolved).
 
     Args:
         kwargs: The method's `**kwargs` dict; mutated in place (the old
@@ -136,15 +136,16 @@ def _resolve_renamed_kwarg(
         - The old name is used and a `DeprecationWarning` is raised:
             ```python
             >>> import warnings
-            >>> kwargs = {"text_loc": [0.1, 0.1]}
+            >>> kwargs = {"text_colors": ("yellow", "purple")}
             >>> with warnings.catch_warnings(record=True) as caught:
             ...     warnings.simplefilter("always")
             ...     resolved = _resolve_renamed_kwarg(
-            ...         kwargs, "text_loc", "label_location", None, None
+            ...         kwargs, "text_colors", "cell_value_text_colors",
+            ...         ("white", "black"), ("white", "black"),
             ...     )
             >>> resolved
-            [0.1, 0.1]
-            >>> "text_loc" in kwargs
+            ('yellow', 'purple')
+            >>> "text_colors" in kwargs
             False
             >>> issubclass(caught[0].category, DeprecationWarning)
             True
@@ -155,9 +156,10 @@ def _resolve_renamed_kwarg(
             ```python
             >>> kwargs = {"cmap": "viridis"}
             >>> _resolve_renamed_kwarg(
-            ...     kwargs, "text_loc", "label_location", [0.2, 0.2], None
+            ...     kwargs, "text_colors", "cell_value_text_colors",
+            ...     ("yellow", "purple"), ("white", "black"),
             ... )
-            [0.2, 0.2]
+            ('yellow', 'purple')
             >>> kwargs
             {'cmap': 'viridis'}
 
@@ -242,6 +244,56 @@ class PointOverlay:
         self.size = size
         self.label_color = label_color
         self.label_size = label_size
+
+
+class FrameLabel:
+    """Styling for the per-frame time label `ArrayGlyph.animate` draws.
+
+    Bundles the two frame-label parameters (`location`, `color`) that
+    `animate` previously accepted as separate `label_location` /
+    `label_color` arguments. Pass an instance as
+    `animate(frame_label=...)` instead.
+
+    Attributes:
+        location: `[x, y]` position for the label, by default `None`.
+            When `None`, the label is anchored just inside the top-left
+            corner using axes-fraction coordinates, so it stays clear of
+            the top/bottom edges regardless of the array's shape or the
+            axis orientation. A very narrow axes can still overflow
+            horizontally at the default font size, since no anchor choice
+            can fit a long label into less horizontal space than it
+            needs; pass an explicit `[x, y]` (data coordinates) in that
+            case.
+        color: Label text colour, by default `"black"`. Any valid
+            matplotlib colour string.
+
+    Examples:
+        - Build a frame label and pass it to `animate`:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.array_glyph import ArrayGlyph, FrameLabel
+            >>> stack = np.arange(3 * 9, dtype=float).reshape(3, 3, 3)
+            >>> label = FrameLabel(location=[0.1, 0.1], color="white")
+            >>> glyph = ArrayGlyph(stack)
+            >>> anim_obj = glyph.animate(["t0", "t1", "t2"], frame_label=label)
+            >>> label.color
+            'white'
+
+            ```
+    """
+
+    def __init__(
+        self, *, location: list[Any, Any] = None, color: str = "black"
+    ) -> None:
+        """Initialise a `FrameLabel`.
+
+        Args:
+            location: `[x, y]` label position, by default `None` (auto
+                top-left anchor -- see the class docstring).
+            color: Label text colour, by default `"black"`.
+        """
+        self.location = location
+        self.color = color
 
 
 #: Deprecated `plot`/`animate` kwargs that `_resolve_point_overlay` folds
@@ -346,6 +398,63 @@ def _resolve_point_overlay(
     return PointOverlay(
         points, color=color, size=size, label_color=label_color, label_size=label_size
     )
+
+
+#: Deprecated `animate` kwargs that `_resolve_frame_label` folds into a
+#: `FrameLabel` instead of the (now-removed) individual keywords.
+#: `text_loc` is the oldest generation (pre-dating `label_location`) and is
+#: honoured too.
+_DEPRECATED_FRAME_LABEL_KWARGS = ("label_location", "label_color", "text_loc")
+
+
+def _resolve_frame_label(frame_label: FrameLabel | None, kwargs: dict) -> FrameLabel:
+    """Normalise `animate`'s `frame_label` argument into a `FrameLabel`.
+
+    Accepts the current calling convention (`frame_label` is already a
+    `FrameLabel`, or `None` for the defaults) as well as the deprecated one
+    (separate `label_location` / `label_color` keywords, or the even older
+    `text_loc` for the location) -- the latter emit a `DeprecationWarning`
+    and are folded into a `FrameLabel` here. Unlike `_resolve_point_overlay`,
+    this never returns `None`: `animate` always draws a frame label, so
+    `frame_label=None` means "use `FrameLabel`'s own defaults", not "no
+    label". Must be called *before* `animate` validates `kwargs` against
+    `self.default_options`, which would otherwise reject the deprecated
+    keys outright.
+
+    Args:
+        frame_label: The raw `frame_label` argument as received by
+            `animate`: a `FrameLabel`, or `None`.
+        kwargs: The method's `**kwargs` dict; mutated in place (any
+            deprecated frame-label keys are popped out).
+
+    Returns:
+        FrameLabel: `frame_label` unchanged if it was already a
+            `FrameLabel`; otherwise a new `FrameLabel` built from the
+            (possibly deprecated) location/color kwargs, or the defaults.
+    """
+    if isinstance(frame_label, FrameLabel):
+        used_deprecated = [k for k in _DEPRECATED_FRAME_LABEL_KWARGS if k in kwargs]
+        if used_deprecated:
+            warnings.warn(
+                f"{used_deprecated} are ignored when `frame_label` is a "
+                "`FrameLabel` -- set them on the `FrameLabel` instance "
+                "instead.",
+                stacklevel=4,
+            )
+            for key in used_deprecated:
+                kwargs.pop(key)
+        return frame_label
+    location, location_key = _pop_first(kwargs, ("label_location", "text_loc"), None)
+    color, color_key = _pop_first(kwargs, ("label_color",), "black")
+    used = [k for k in (location_key, color_key) if k]
+    if used:
+        warnings.warn(
+            f"Passing {used} directly is deprecated; pass a "
+            "`cleopatra.array_glyph.FrameLabel` as `frame_label` instead.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
+    return FrameLabel(location=location, color=color)
 
 
 class FacetGrid:
@@ -3165,9 +3274,8 @@ class ArrayGlyph(GeoMixin, Glyph):
         points: np.ndarray | PointOverlay | None = None,
         cell_value_text_colors: tuple[str, str] = ("white", "black"),
         interval: int = 200,
-        label_location: list[Any, Any] = None,
+        frame_label: FrameLabel | None = None,
         *,
-        label_color: str = "black",
         data_getter: Callable[[int], np.ndarray] | None = None,
         **kwargs,
     ) -> FuncAnimation:
@@ -3213,20 +3321,17 @@ class ArrayGlyph(GeoMixin, Glyph):
                 emits a `DeprecationWarning`.)
             interval: Delay between frames in milliseconds, by default 200.
                 Controls the speed of the animation (smaller values = faster animation).
-            label_location: Location of the frame label text as [x, y]
-                coordinates, by default None. When None, the label is
-                anchored just inside the top-left corner using
-                axes-fraction coordinates, so it stays clear of the top/bottom edges
-                regardless of the array's shape or the axis orientation. A very narrow
-                axes can still overflow horizontally at the default font size, since no
-                anchor choice can fit a long label into less horizontal space than it
-                needs; pass an explicit [x, y] (data coordinates) or a smaller
-                `cbar_label_size` in that case. (Renamed from `text_loc`;
-                the old name still works as a keyword and emits a
-                `DeprecationWarning`.)
-            label_color: Color of the frame label text, by default "black".
-                Any valid matplotlib color string. `ArrayGlyph`-only;
+            frame_label: Styling for the per-frame time label, by default
+                None (a `FrameLabel` with its own defaults: auto-anchored
+                top-left, black text). See `FrameLabel` for the
+                `location`/`color` fields and the top-left anchoring
+                behaviour when `location` is left unset. `ArrayGlyph`-only;
                 `MeshGlyph.animate()` does not yet expose this option.
+                (Styling the frame label via separate `label_location` /
+                `label_color` keywords — or the even older `text_loc` for
+                the location — is deprecated; pass a `FrameLabel` instead —
+                the old keywords still work as `**kwargs` and emit a
+                `DeprecationWarning`.)
             data_getter: Optional callable `f(i) -> ndarray` that
                 returns the frame for index `i`, by default None.
                 When set, `self.arr` is no longer iterated; each
@@ -3469,18 +3574,21 @@ class ArrayGlyph(GeoMixin, Glyph):
             cell_value_text_colors,
             ("white", "black"),
         )
-        label_location = _resolve_renamed_kwarg(
-            kwargs, "text_loc", "label_location", label_location, None
-        )
+        frame_label = _resolve_frame_label(frame_label, kwargs)
         points = _resolve_point_overlay(points, kwargs)
 
-        label_location_is_default = label_location is None
+        # Resolved into a local rather than written back onto `frame_label`,
+        # so a `FrameLabel` instance the caller passed in (and might reuse
+        # across calls) is never mutated.
+        label_location_is_default = frame_label.location is None
         if label_location_is_default:
             # Axes-fraction anchor (not data coordinates): stays inside the
             # frame regardless of array shape or axis orientation, unlike a
             # fixed data-coordinate default. See `day_text` below for the
             # matching transform/alignment.
             label_location = [0.02, 0.95]
+        else:
+            label_location = frame_label.location
 
         for key, val in kwargs.items():
             if key not in self.default_options.keys():
@@ -3726,7 +3834,7 @@ class ArrayGlyph(GeoMixin, Glyph):
             label_location[1],
             " ",
             fontsize=self.default_options["cbar_label_size"],
-            color=label_color,
+            color=frame_label.color,
             transform=ax.transAxes if label_location_is_default else ax.transData,
             va="top" if label_location_is_default else "baseline",
         )

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import warnings
 from math import ceil
-from typing import Any, Callable, Sequence
+from typing import Any, Callable, Literal, Sequence, TypedDict, Unpack
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -181,6 +181,194 @@ def _resolve_renamed_kwarg(
         )
         return new_value
     return old_value
+
+
+#: Static typing for the **kwargs `plot`/`animate` accept -- purely a typing
+#: aid (see PEP 692 `Unpack`): with `from __future__ import annotations` the
+#: `**kwargs: Unpack[...]` annotations below are never evaluated at runtime,
+#: so this adds IDE autocomplete / type-checker typo-catching for `**kwargs`
+#: without changing the existing `self.default_options` merge-and-validate
+#: mechanism at all. Grouped to match the methods' own docstring sections;
+#: each group is shared by both methods except `XarrayColourOptions` and
+#: `ContourOptions`, which only `plot` documents (`animate` has no `kind`,
+#: so nothing routes to `contour`/`contourf`, and does not recompute
+#: `vmin`/`vmax` from `robust`/`center`).
+class TitleOption(TypedDict, total=False):
+    """The `title` kwarg -- `animate` only.
+
+    `plot` also accepts a title, but as an explicit named parameter (not
+    via `**kwargs`); mixing `title` into its `Unpack`'d TypedDict too would
+    overlap with that parameter. `animate` has no such parameter, so its
+    `**kwargs` is where `title` is actually reachable.
+
+    Attributes:
+        title: Plot title, by default `'Array Plot'`.
+    """
+
+    title: str | None
+
+
+class PlotAppearanceOptions(TypedDict, total=False):
+    """Colormap/colour-limit options shared by `plot` and `animate`.
+
+    Attributes:
+        title_size: Title font size, by default `15`.
+        cmap: Colormap name or `Colormap` instance, by default `'coolwarm_r'`.
+        vmin: Minimum value for colour scaling, by default `min(array)`.
+        vmax: Maximum value for colour scaling, by default `max(array)`.
+    """
+
+    title_size: int
+    cmap: str | Colormap
+    vmin: float | None
+    vmax: float | None
+
+
+class ColorbarOptions(TypedDict, total=False):
+    """Colorbar placement/label options shared by `plot` and `animate`.
+
+    Attributes:
+        add_colorbar: Whether to draw the glyph's own colorbar, by
+            default `True`.
+        cbar_orientation: Colorbar orientation, by default `'vertical'`.
+        cbar_label_rotation: Rotation angle of the colorbar label, by
+            default `-90`.
+        cbar_label_location: Location of the colorbar label, by default
+            `'bottom'`.
+        cbar_length: Ratio controlling the colorbar's height/width, by
+            default `0.75`.
+        ticks_spacing: Spacing between colorbar ticks, by default `2`.
+        cbar_label_size: Font size of the colorbar label, by default `12`.
+        cbar_label: Label text for the colorbar, by default `'Value'`.
+    """
+
+    add_colorbar: bool
+    cbar_orientation: Literal["vertical", "horizontal"]
+    cbar_label_rotation: float
+    cbar_label_location: Literal[
+        "top", "bottom", "center", "baseline", "center_baseline"
+    ]
+    cbar_length: float
+    ticks_spacing: float
+    cbar_label_size: int
+    cbar_label: str | None
+
+
+class ColorScaleOptions(TypedDict, total=False):
+    """Colour-scaling options shared by `plot` and `animate`.
+
+    Attributes:
+        color_scale: Colour scaling kind, by default `'linear'`. See
+            `cleopatra.styles.ColorScale`.
+        gamma: Exponent for the `'power'` colour scale, by default `0.5`.
+        line_threshold: Threshold for the `'sym-lognorm'` colour scale, by
+            default `0.0001`.
+        line_scale: Scale factor for the `'sym-lognorm'` colour scale, by
+            default `0.001`.
+        bounds: Boundaries for the `'boundary-norm'` colour scale, by
+            default `None`.
+        midpoint: Midpoint value for the `'midpoint'` colour scale, by
+            default `0`.
+    """
+
+    color_scale: ColorScale | str
+    gamma: float
+    line_threshold: float
+    line_scale: float
+    bounds: list[float] | None
+    midpoint: float
+
+
+class XarrayColourOptions(TypedDict, total=False):
+    """Xarray-aligned colour options -- `plot` only.
+
+    Attributes:
+        robust: When `True`, use the 2nd/98th percentile of the data for
+            `vmin`/`vmax`, matching xarray's `robust=True`, by default
+            `False`.
+        center: Diverging-colormap centring value, by default `None`.
+        extend: Colorbar arrow extension, by default `None` (auto-resolve).
+        cbar_kwargs: Extra keyword arguments forwarded to `fig.colorbar`,
+            by default `None`.
+    """
+
+    robust: bool
+    center: float | None
+    extend: Literal["neither", "both", "min", "max"] | None
+    cbar_kwargs: dict[str, Any] | None
+
+
+class ContourOptions(TypedDict, total=False):
+    """Contour-line and discretisation options -- `plot` only.
+
+    Attributes:
+        levels: Discrete colour levels (xarray-aligned), by default `None`.
+        labels: Draw inline numeric labels on a line `contour`'s isolines,
+            by default `False`.
+        label_kw: Extra keyword arguments forwarded to `ax.clabel` when
+            `labels=True`, by default `None`.
+    """
+
+    levels: int | Sequence[float] | None
+    labels: bool
+    label_kw: dict[str, Any] | None
+
+
+class CellValueOptions(TypedDict, total=False):
+    """Per-cell value-text display options shared by `plot` and `animate`.
+
+    Attributes:
+        display_cell_value: Whether to display each cell's value as text,
+            by default `False`.
+        num_size: Font size of the cell value text, by default `8`.
+        background_color_threshold: Threshold for the cell value text
+            colour, by default `None` (uses `max(array) / 2`).
+    """
+
+    display_cell_value: bool
+    num_size: int
+    background_color_threshold: float | None
+
+
+class DataStyleOptions(TypedDict, total=False):
+    """Named data-style preset / relief-shading options shared by `plot`
+    and `animate`.
+
+    Attributes:
+        style: Name of a `cleopatra.colors.DATA_STYLES` preset, by default
+            `None`.
+        hillshade: Relief-shade a regular-grid DEM; `True` for defaults,
+            or a dict tuning `vert_exag`/`azimuth`/`altitude`/
+            `blend_mode`/`multidirectional`. By default `False`.
+    """
+
+    style: str | None
+    hillshade: bool | dict[str, Any]
+
+
+class PlotKwargs(
+    PlotAppearanceOptions,
+    ColorbarOptions,
+    ColorScaleOptions,
+    XarrayColourOptions,
+    ContourOptions,
+    CellValueOptions,
+    DataStyleOptions,
+    total=False,
+):
+    """The full set of `**kwargs` `ArrayGlyph.plot` accepts."""
+
+
+class AnimateKwargs(
+    TitleOption,
+    PlotAppearanceOptions,
+    ColorbarOptions,
+    ColorScaleOptions,
+    CellValueOptions,
+    DataStyleOptions,
+    total=False,
+):
+    """The full set of `**kwargs` `ArrayGlyph.animate` accepts."""
 
 
 class PointOverlay:
@@ -2240,7 +2428,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         kind: str = "auto",
         ax: Axes | None = None,
         title: str | None = None,
-        **kwargs,
+        **kwargs: Unpack[PlotKwargs],
     ) -> tuple[Figure, Axes]:
         """Plot the array with customizable visualization options.
 
@@ -2805,7 +2993,10 @@ class ArrayGlyph(GeoMixin, Glyph):
         # Resolve `points` (a `PointOverlay`, or the deprecated plain-array +
         # separate style kwargs) before the strict `kwargs` validation below,
         # which would otherwise reject the deprecated keys outright.
-        points = _resolve_point_overlay(points, kwargs)
+        # `kwargs` is a real, mutable dict at runtime -- mypy's TypedDict
+        # model just does not have a variance-safe way to type "a dict this
+        # helper is allowed to pop deprecated keys from".
+        points = _resolve_point_overlay(points, kwargs)  # type: ignore[arg-type]
 
         for key, val in kwargs.items():
             if key not in self.default_options.keys():
@@ -3277,7 +3468,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         frame_label: FrameLabel | None = None,
         *,
         data_getter: Callable[[int], np.ndarray] | None = None,
-        **kwargs,
+        **kwargs: Unpack[AnimateKwargs],
     ) -> FuncAnimation:
         """Create an animation from a single-band or true-colour stack.
 
@@ -3567,15 +3758,18 @@ class ArrayGlyph(GeoMixin, Glyph):
         """
         # Resolve deprecated kwarg aliases before the strict `kwargs`
         # validation below, which would otherwise reject them outright.
+        # `kwargs` is a real, mutable dict at runtime -- mypy's TypedDict
+        # model just does not have a variance-safe way to type "a dict
+        # these helpers are allowed to pop deprecated keys from".
         cell_value_text_colors = _resolve_renamed_kwarg(
-            kwargs,
+            kwargs,  # type: ignore[arg-type]
             "text_colors",
             "cell_value_text_colors",
             cell_value_text_colors,
             ("white", "black"),
         )
-        frame_label = _resolve_frame_label(frame_label, kwargs)
-        points = _resolve_point_overlay(points, kwargs)
+        frame_label = _resolve_frame_label(frame_label, kwargs)  # type: ignore[arg-type]
+        points = _resolve_point_overlay(points, kwargs)  # type: ignore[arg-type]
 
         # Resolved into a local rather than written back onto `frame_label`,
         # so a `FrameLabel` instance the caller passed in (and might reuse

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -330,6 +330,19 @@ class CellValueOptions(TypedDict, total=False):
     background_color_threshold: float | None
 
 
+class AnimateCellValueOptions(TypedDict, total=False):
+    """Per-cell value-text option specific to `animate` -- `animate` only.
+
+    Attributes:
+        precision: Decimal places each frame's cell value text is rounded
+            to, by default `2`. `animate`-only: `plot`'s equivalent
+            per-cell text (`ArrayGlyph._plot_text`) always rounds to 2
+            decimal places internally and never reads this option.
+    """
+
+    precision: int
+
+
 class DataStyleOptions(TypedDict, total=False):
     """Named data-style preset / relief-shading options shared by `plot`
     and `animate`.
@@ -365,6 +378,7 @@ class AnimateKwargs(
     ColorbarOptions,
     ColorScaleOptions,
     CellValueOptions,
+    AnimateCellValueOptions,
     DataStyleOptions,
     total=False,
 ):
@@ -3606,6 +3620,11 @@ class ArrayGlyph(GeoMixin, Glyph):
                         Threshold for cell value text color, by default None.
                         If cell value > threshold, text is black; otherwise, text is white.
                         If None, uses max(array)/2 as the threshold.
+                    precision : int, optional
+                        Decimal places each frame's cell value text is
+                        rounded to, by default 2. `animate`-only; `plot`'s
+                        equivalent per-cell text always rounds to 2
+                        decimal places internally.
 
                 Data-style preset / relief options:
                     style : str, optional

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -471,7 +471,7 @@ class FrameLabel:
     """
 
     def __init__(
-        self, *, location: list[Any, Any] = None, color: str = "black"
+        self, *, location: list[float] | None = None, color: str = "black"
     ) -> None:
         """Initialise a `FrameLabel`.
 

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1356,7 +1356,9 @@ class Glyph:
                 self.ax.get_yaxis().set_visible(visible)
 
     @staticmethod
-    def _plot_point_values(ax, point_table: np.ndarray, pid_color, pid_size):
+    def _plot_point_values(
+        ax, point_table: np.ndarray, point_label_color, point_label_size
+    ):
         """Plot point value labels on the axes."""
         write_points = lambda x: ax.text(
             x[2],
@@ -1364,8 +1366,8 @@ class Glyph:
             x[0],
             ha="center",
             va="center",
-            color=pid_color,
-            fontsize=pid_size,
+            color=point_label_color,
+            fontsize=point_label_size,
         )
         return list(map(write_points, point_table))
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -350,6 +350,94 @@ class TestAnimate:
         # os.remove(path)
 
 
+class TestRenamedKwargAliases:
+    """The legacy `plot`/`animate` kwarg names still work but warn.
+
+    `pid_color`/`pid_size` were renamed to `point_label_color`/
+    `point_label_size`, `text_colors` to `cell_value_text_colors`, and
+    `text_loc` to `label_location`. Each old name is still accepted as a
+    keyword (routed through `**kwargs`), emits a `DeprecationWarning`
+    naming its replacement, and is forwarded to the same effective
+    behaviour as the new name.
+    """
+
+    def test_plot_pid_color_alias_still_works(self, arr: np.ndarray):
+        """`plot(pid_color=...)` warns and colours the point label."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(arr)
+        with pytest.warns(DeprecationWarning, match="point_label_color"):
+            fig, ax = array.plot(points=points, pid_color="lime")
+        label = [t for t in ax.texts if t.get_text() == "5"][0]
+        assert to_rgba(label.get_color()) == to_rgba("lime")
+
+    def test_plot_pid_size_alias_still_works(self, arr: np.ndarray):
+        """`plot(pid_size=...)` warns and sizes the point label."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(arr)
+        with pytest.warns(DeprecationWarning, match="point_label_size"):
+            fig, ax = array.plot(points=points, pid_size=42)
+        label = [t for t in ax.texts if t.get_text() == "5"][0]
+        assert label.get_fontsize() == 42
+
+    def test_plot_new_name_wins_over_deprecated_alias(self, arr: np.ndarray):
+        """Passing both names at once still warns, but the new name wins."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(arr)
+        with pytest.warns(DeprecationWarning, match="point_label_color"):
+            fig, ax = array.plot(
+                points=points, point_label_color="lime", pid_color="orange"
+            )
+        label = [t for t in ax.texts if t.get_text() == "5"][0]
+        assert to_rgba(label.get_color()) == to_rgba("lime")
+
+    def test_animate_pid_color_alias_still_works(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`animate(pid_color=...)` warns and colours the point label."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="point_label_color"):
+            array.animate(animate_time_list, points=points, pid_color="lime")
+
+    def test_animate_pid_size_alias_still_works(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`animate(pid_size=...)` warns and sizes the point label."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="point_label_size"):
+            array.animate(animate_time_list, points=points, pid_size=42)
+
+    def test_animate_text_colors_alias_still_works(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`animate(text_colors=...)` warns and is forwarded unchanged."""
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="cell_value_text_colors"):
+            array.animate(
+                animate_time_list,
+                display_cell_value=True,
+                text_colors=("yellow", "purple"),
+            )
+
+    def test_animate_text_loc_alias_still_works(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`animate(text_loc=...)` warns and positions the frame label."""
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="label_location"):
+            array.animate(animate_time_list, text_loc=[0.1, 0.1])
+        assert array._day_text.get_transform() is array.ax.transData
+
+    def test_no_warning_with_only_new_names(self, arr: np.ndarray):
+        """Using only the current names raises no deprecation warning."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(arr)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            array.plot(points=points, point_label_color="lime", point_label_size=42)
+
+
 @pytest.mark.plot
 class TestAnimateRGB:
     """RGB / true-colour animation support in `ArrayGlyph.animate` (issue #168)."""
@@ -3094,43 +3182,44 @@ class TestAnimateDataGetterEdgeCases:
         finally:
             plt.close(anim._fig)
 
-    def test_data_getter_explicit_text_loc(self) -> None:
-        """A user-supplied `text_loc` skips the default-init branch.
+    def test_data_getter_explicit_label_location(self) -> None:
+        """A user-supplied `label_location` skips the default-init branch.
 
         Test scenario:
-            Default `text_loc=None` is rewritten to an axes-fraction anchor;
-            passing an explicit value covers the alternate branch where the
-            rewrite is skipped and data coordinates are used instead.
+            Default `label_location=None` is rewritten to an axes-fraction
+            anchor; passing an explicit value covers the alternate branch
+            where the rewrite is skipped and data coordinates are used
+            instead.
         """
         stack = self._stack(n=3)
         glyph = ArrayGlyph(stack[0])
         anim = glyph.animate(
             time=list(range(3)),
             data_getter=lambda i: stack[i],
-            text_loc=[0.05, 0.05],
+            label_location=[0.05, 0.05],
         )
         try:
             assert isinstance(
                 anim, FuncAnimation
-            ), "explicit text_loc must produce an animation"
+            ), "explicit label_location must produce an animation"
             assert glyph._day_text.get_transform() is glyph.ax.transData
         finally:
             plt.close(glyph.fig)
 
-    def test_default_text_loc_label_stays_inside_axes(self) -> None:
+    def test_default_label_location_stays_inside_axes(self) -> None:
         """The default frame label must not clip past the axes bounds.
 
         Test scenario:
             Regression test for the inverted-Y-axis clipping bug: with no
-            explicit `text_loc`, the label's rendered bounding box must sit
-            fully within the axes bounding box on both axes, for a square
-            and a moderately rectangular array shape. Does not cover an
-            extremely narrow axes (e.g. a 20-column array), where the
-            label can still overflow horizontally simply because the
+            explicit `label_location`, the label's rendered bounding box
+            must sit fully within the axes bounding box on both axes, for
+            a square and a moderately rectangular array shape. Does not
+            cover an extremely narrow axes (e.g. a 20-column array), where
+            the label can still overflow horizontally simply because the
             available width is smaller than the label's rendered text at
             the default font size — a physical-space limit no anchor
             choice can fix; callers with very narrow images should pass
-            an explicit `text_loc` or a smaller `cbar_label_size`.
+            an explicit `label_location` or a smaller `cbar_label_size`.
         """
         for shape in [(4, 48, 48), (4, 100, 50)]:
             arr = np.zeros(shape)

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -541,6 +541,21 @@ class TestPointOverlayAliases:
             warnings.simplefilter("error", DeprecationWarning)
             array.animate(animate_time_list, points=overlay)
 
+    def test_deprecation_warning_attributes_to_caller(self, arr: np.ndarray):
+        """The `PointOverlay`-alias deprecation warning points at the caller's line.
+
+        Test scenario:
+            Regression for a `stacklevel` bug: the warning must name this
+            test file/line, not an internal frame (e.g. `warnings.py`).
+        """
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(arr)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            array.plot(points=points, pid_color="lime")
+        assert len(caught) == 1
+        assert caught[0].filename == __file__
+
 
 class TestKwargsTypedDicts:
     """`PlotKwargs`/`AnimateKwargs` should track every kwarg each method

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -511,6 +511,40 @@ class TestFrameLabelAliases:
         assert len(caught) == 1
         assert caught[0].filename == __file__
 
+    def test_positional_and_keyword_location_both_reported(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """Combining a positional legacy location with `label_location=` warns about both.
+
+        Test scenario:
+            Regression for a message-accuracy bug: when a bare `[x, y]` is
+            passed positionally at the old `text_loc` slot *and*
+            `label_location=` is also given, the keyword is drained (so it
+            can't fail the strict `kwargs` check) even though the
+            positional value wins -- but the warning previously only named
+            `frame_label (positional)`, silently omitting the also-consumed
+            `label_location`. Both must now appear in the message.
+        """
+        array = ArrayGlyph(coello_data)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            array.animate(
+                animate_time_list,
+                None,
+                ("white", "black"),
+                200,
+                [0.3, 0.3],
+                label_location=[0.5, 0.5],
+            )
+        messages = [str(w.message) for w in caught]
+        assert any(
+            "frame_label (positional)" in m and "label_location" in m for m in messages
+        ), f"Expected both aliases named in one message, got: {messages}"
+        assert array._day_text.get_position() == (
+            0.3,
+            0.3,
+        ), "The positional value must still win over the keyword"
+
 
 class TestPointOverlayAliases:
     """`PointOverlay` is the current way to style `points`; the flat

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -388,6 +388,34 @@ class TestRenamedKwargAliases:
                 frame_label=FrameLabel(location=[0.1, 0.1]),
             )
 
+    def test_both_given_new_wins_even_at_its_own_default(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`cell_value_text_colors` wins even when equal to its own default.
+
+        Test scenario:
+            Regression for a false-negative in the "both given" conflict
+            check: passing both the deprecated `text_colors=` and the
+            current `cell_value_text_colors=` -- with the current one
+            happening to equal its own default -- must still fire the
+            conflict warning (not silently prefer the deprecated value,
+            which a plain equality-with-default check cannot tell apart
+            from "the new name was never passed").
+        """
+        array = ArrayGlyph(coello_data)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            array.animate(
+                animate_time_list,
+                display_cell_value=True,
+                cell_value_text_colors=("white", "black"),
+                text_colors=("yellow", "purple"),
+            )
+        messages = [str(w.message) for w in caught]
+        assert any("is deprecated" in m for m in messages)
+        assert any("were given" in m and "wins" in m for m in messages)
+
+
 class TestFrameLabelAliases:
     """`FrameLabel` is the current way to style `animate`'s frame/time
     label; the flat keywords it replaces (`label_location`/`label_color`,

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -448,6 +448,39 @@ class TestFrameLabelAliases:
             )
         assert array._day_text.get_color() == "yellow"
 
+    def test_positional_legacy_location_still_works(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A plain `[x, y]` passed positionally at the old `text_loc` slot still works.
+
+        Test scenario:
+            On `main`, `animate`'s 5th positional-or-keyword parameter was
+            `text_loc` (a plain `[x, y]` list); it is now `frame_label`. A
+            stale positional call with a plain list at that position must
+            still position the label (not silently drop it) and warn.
+        """
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="FrameLabel"):
+            array.animate(animate_time_list, None, ("white", "black"), 200, [0.3, 0.3])
+        assert array._day_text.get_position() == (0.3, 0.3)
+        assert array._day_text.get_transform() is array.ax.transData
+
+    def test_deprecation_warning_attributes_to_caller(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """The `FrameLabel`-alias deprecation warning points at the caller's line.
+
+        Test scenario:
+            Regression for a `stacklevel` bug: the warning must name this
+            test file/line, not an internal frame (e.g. `warnings.py`).
+        """
+        array = ArrayGlyph(coello_data)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            array.animate(animate_time_list, label_color="yellow")
+        assert len(caught) == 1
+        assert caught[0].filename == __file__
+
 
 class TestPointOverlayAliases:
     """`PointOverlay` is the current way to style `points`; the flat

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -585,6 +585,50 @@ class TestPointOverlayAliases:
         label = [t for t in ax.texts if t.get_text() == "5"][0]
         assert to_rgba(label.get_color()) == to_rgba("lime")
 
+    def test_plot_point_color_without_points_does_not_raise(self, arr: np.ndarray):
+        """`plot(point_color=...)` with no `points` warns instead of raising.
+
+        Test scenario:
+            Regression for a bug where `_resolve_point_overlay` only
+            drained the deprecated point-style kwargs out of `kwargs`
+            when `points` was a plain array or `PointOverlay`, leaving
+            them to fail the strict `kwargs`-vs-`default_options`
+            validation when `points is None` -- contradicting the
+            documented "the old keywords still work as `**kwargs`"
+            guarantee (on `main`, these were named parameters, legal --
+            if pointless -- without `points`).
+        """
+        array = ArrayGlyph(arr)
+        with pytest.warns(DeprecationWarning, match="have no effect"):
+            fig, ax = array.plot(point_color="red")
+        assert fig is not None, "plot() must still succeed, not raise"
+
+    def test_plot_pid_size_without_points_does_not_raise(self, arr: np.ndarray):
+        """The oldest `pid_size` alias with no `points` also warns instead of raising."""
+        array = ArrayGlyph(arr)
+        with pytest.warns(DeprecationWarning, match="have no effect"):
+            fig, ax = array.plot(pid_size=42)
+        assert fig is not None, "plot() must still succeed, not raise"
+
+    def test_animate_point_label_color_without_points_does_not_raise(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`animate(point_label_color=...)` with no `points` warns instead of raising."""
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="have no effect"):
+            anim = array.animate(animate_time_list, point_label_color="lime")
+        assert anim is not None, "animate() must still succeed, not raise"
+
+    def test_plot_no_deprecated_kwargs_and_no_points_warns_nothing(
+        self, arr: np.ndarray
+    ):
+        """Neither `points` nor any deprecated point-style kwarg: no warning at all."""
+        array = ArrayGlyph(arr)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            fig, ax = array.plot()
+        assert fig is not None
+
     def test_animate_pid_size_oldest_alias_still_works(
         self, coello_data: np.ndarray, animate_time_list: list
     ):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -17,6 +17,7 @@ from cleopatra.array_glyph import (
     _COORD_SHAPE_MISMATCH,
     ArrayGlyph,
     FacetGrid,
+    PointOverlay,
 )
 
 
@@ -238,9 +239,7 @@ class TestPlotArray:
     ):
         array = ArrayGlyph(arr, exclude_value=[no_data_value])
         fig, ax = array.plot(
-            points=points,
-            point_color=gauge_color,
-            point_size=point_size,
+            points=PointOverlay(points, color=gauge_color, size=point_size),
             id_color=id_color,
             id_size=id_size,
             display_cell_value=display_cell_value,
@@ -353,60 +352,14 @@ class TestAnimate:
 class TestRenamedKwargAliases:
     """The legacy `plot`/`animate` kwarg names still work but warn.
 
-    `pid_color`/`pid_size` were renamed to `point_label_color`/
-    `point_label_size`, `text_colors` to `cell_value_text_colors`, and
-    `text_loc` to `label_location`. Each old name is still accepted as a
-    keyword (routed through `**kwargs`), emits a `DeprecationWarning`
-    naming its replacement, and is forwarded to the same effective
-    behaviour as the new name.
+    `text_colors` was renamed to `cell_value_text_colors`, and `text_loc`
+    to `label_location`. Each old name is still accepted as a keyword
+    (routed through `**kwargs`), emits a `DeprecationWarning` naming its
+    replacement, and is forwarded to the same effective behaviour as the
+    new name. The point-styling kwargs (`point_color`, `pid_color`, ...)
+    have since been superseded by `PointOverlay` -- see
+    `TestPointOverlayAliases`.
     """
-
-    def test_plot_pid_color_alias_still_works(self, arr: np.ndarray):
-        """`plot(pid_color=...)` warns and colours the point label."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="point_label_color"):
-            fig, ax = array.plot(points=points, pid_color="lime")
-        label = [t for t in ax.texts if t.get_text() == "5"][0]
-        assert to_rgba(label.get_color()) == to_rgba("lime")
-
-    def test_plot_pid_size_alias_still_works(self, arr: np.ndarray):
-        """`plot(pid_size=...)` warns and sizes the point label."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="point_label_size"):
-            fig, ax = array.plot(points=points, pid_size=42)
-        label = [t for t in ax.texts if t.get_text() == "5"][0]
-        assert label.get_fontsize() == 42
-
-    def test_plot_new_name_wins_over_deprecated_alias(self, arr: np.ndarray):
-        """Passing both names at once still warns, but the new name wins."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="point_label_color"):
-            fig, ax = array.plot(
-                points=points, point_label_color="lime", pid_color="orange"
-            )
-        label = [t for t in ax.texts if t.get_text() == "5"][0]
-        assert to_rgba(label.get_color()) == to_rgba("lime")
-
-    def test_animate_pid_color_alias_still_works(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`animate(pid_color=...)` warns and colours the point label."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="point_label_color"):
-            array.animate(animate_time_list, points=points, pid_color="lime")
-
-    def test_animate_pid_size_alias_still_works(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`animate(pid_size=...)` warns and sizes the point label."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="point_label_size"):
-            array.animate(animate_time_list, points=points, pid_size=42)
 
     def test_animate_text_colors_alias_still_works(
         self, coello_data: np.ndarray, animate_time_list: list
@@ -429,13 +382,109 @@ class TestRenamedKwargAliases:
             array.animate(animate_time_list, text_loc=[0.1, 0.1])
         assert array._day_text.get_transform() is array.ax.transData
 
-    def test_no_warning_with_only_new_names(self, arr: np.ndarray):
+    def test_no_warning_with_only_new_names(self, coello_data: np.ndarray):
         """Using only the current names raises no deprecation warning."""
+        array = ArrayGlyph(coello_data)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            array.animate(
+                ["t0", "t1", "t2"],
+                cell_value_text_colors=("yellow", "purple"),
+                label_location=[0.1, 0.1],
+            )
+
+
+class TestPointOverlayAliases:
+    """`PointOverlay` is the current way to style `points`; the flat
+    keywords it replaces (`point_color`/`point_size`/`point_label_color`/
+    `point_label_size`, and the older `pid_color`/`pid_size`) still work
+    on a plain array but warn.
+    """
+
+    def test_plain_array_uses_point_overlay_defaults(self, arr: np.ndarray):
+        """A bare array (no styling kwargs) needs no `PointOverlay` and warns nothing."""
         points = np.array([[5, 1, 1]])
         array = ArrayGlyph(arr)
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
-            array.plot(points=points, point_label_color="lime", point_label_size=42)
+            fig, ax = array.plot(points=points)
+        label = [t for t in ax.texts if t.get_text() == "5"][0]
+        assert to_rgba(label.get_color()) == to_rgba("blue")  # PointOverlay default
+
+    def test_plot_point_overlay_no_warning(self, arr: np.ndarray):
+        """Passing a `PointOverlay` is the current style and warns nothing."""
+        overlay = PointOverlay(np.array([[5, 1, 1]]), label_color="lime")
+        array = ArrayGlyph(arr)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            fig, ax = array.plot(points=overlay)
+        label = [t for t in ax.texts if t.get_text() == "5"][0]
+        assert to_rgba(label.get_color()) == to_rgba("lime")
+
+    def test_plot_point_color_alias_still_works(self, arr: np.ndarray):
+        """`plot(points=array, point_color=...)` warns and colours the marker."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(arr)
+        with pytest.warns(DeprecationWarning, match="PointOverlay"):
+            fig, ax = array.plot(points=points, point_color="lime")
+        assert to_rgba(ax.collections[0].get_facecolor()[0]) == to_rgba("lime")
+
+    def test_plot_point_label_color_alias_still_works(self, arr: np.ndarray):
+        """`plot(points=array, point_label_color=...)` warns and colours the label."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(arr)
+        with pytest.warns(DeprecationWarning, match="PointOverlay"):
+            fig, ax = array.plot(points=points, point_label_color="lime")
+        label = [t for t in ax.texts if t.get_text() == "5"][0]
+        assert to_rgba(label.get_color()) == to_rgba("lime")
+
+    def test_plot_pid_color_oldest_alias_still_works(self, arr: np.ndarray):
+        """The oldest `pid_color` alias still resolves to the label colour."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(arr)
+        with pytest.warns(DeprecationWarning, match="PointOverlay"):
+            fig, ax = array.plot(points=points, pid_color="lime")
+        label = [t for t in ax.texts if t.get_text() == "5"][0]
+        assert to_rgba(label.get_color()) == to_rgba("lime")
+
+    def test_plot_point_label_color_wins_over_pid_color(self, arr: np.ndarray):
+        """When both label-colour generations are given, the newer one wins."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(arr)
+        with pytest.warns(DeprecationWarning, match="PointOverlay"):
+            fig, ax = array.plot(
+                points=points, point_label_color="lime", pid_color="orange"
+            )
+        label = [t for t in ax.texts if t.get_text() == "5"][0]
+        assert to_rgba(label.get_color()) == to_rgba("lime")
+
+    def test_plot_deprecated_kwargs_ignored_with_point_overlay(self, arr: np.ndarray):
+        """A deprecated kwarg alongside a `PointOverlay` is ignored, with a warning."""
+        overlay = PointOverlay(np.array([[5, 1, 1]]), label_color="lime")
+        array = ArrayGlyph(arr)
+        with pytest.warns(UserWarning, match="ignored"):
+            fig, ax = array.plot(points=overlay, point_label_color="orange")
+        label = [t for t in ax.texts if t.get_text() == "5"][0]
+        assert to_rgba(label.get_color()) == to_rgba("lime")
+
+    def test_animate_pid_size_oldest_alias_still_works(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`animate(points=array, pid_size=...)` warns and sizes the label."""
+        points = np.array([[5, 1, 1]])
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="PointOverlay"):
+            array.animate(animate_time_list, points=points, pid_size=42)
+
+    def test_animate_point_overlay_no_warning(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """Passing a `PointOverlay` to `animate` is the current style and warns nothing."""
+        overlay = PointOverlay(np.array([[5, 1, 1]]), size=42)
+        array = ArrayGlyph(coello_data)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            array.animate(animate_time_list, points=overlay)
 
 
 @pytest.mark.plot

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -15,9 +15,11 @@ from PIL import Image
 from cleopatra.array_glyph import (
     _COORD_DTYPE_MISMATCH,
     _COORD_SHAPE_MISMATCH,
+    AnimateKwargs,
     ArrayGlyph,
     FacetGrid,
     FrameLabel,
+    PlotKwargs,
     PointOverlay,
 )
 
@@ -386,7 +388,6 @@ class TestRenamedKwargAliases:
                 frame_label=FrameLabel(location=[0.1, 0.1]),
             )
 
-
 class TestFrameLabelAliases:
     """`FrameLabel` is the current way to style `animate`'s frame/time
     label; the flat keywords it replaces (`label_location`/`label_color`,
@@ -539,6 +540,50 @@ class TestPointOverlayAliases:
         with warnings.catch_warnings():
             warnings.simplefilter("error", DeprecationWarning)
             array.animate(animate_time_list, points=overlay)
+
+
+class TestKwargsTypedDicts:
+    """`PlotKwargs`/`AnimateKwargs` should track every kwarg each method
+    actually reads and uses -- a regression test for the kind of drift
+    that let `precision` (a real, animate()-only option) go unmodelled.
+    """
+
+    def test_animate_kwargs_includes_precision(self):
+        """`precision` is animate()-only and genuinely used; must be modelled."""
+        assert "precision" in AnimateKwargs.__annotations__
+
+    def test_plot_kwargs_excludes_precision(self):
+        """`plot()` never reads `precision`, so `PlotKwargs` correctly omits it."""
+        assert "precision" not in PlotKwargs.__annotations__
+
+    def test_plot_kwargs_excludes_explicit_params(self):
+        """`title`/`kind` are explicit `plot()` params, unreachable via its `**kwargs`."""
+        assert "title" not in PlotKwargs.__annotations__
+        assert "kind" not in PlotKwargs.__annotations__
+
+    def test_animate_kwargs_includes_title(self):
+        """`animate()` has no explicit `title` param, so it IS `**kwargs`-reachable."""
+        assert "title" in AnimateKwargs.__annotations__
+
+    def test_precision_is_actually_honoured_by_animate(self):
+        """`precision` (now typed) still rounds the rendered cell-value text.
+
+        Test scenario:
+            Confirms the TypedDict addition didn't just paper over a dead
+            option: a lower `precision` renders fewer decimal places for
+            the same underlying data.
+        """
+        frame = np.array([[1.23456, 2.34567], [3.45678, 4.56789]])
+        stack = np.stack([frame, frame + 0.001])
+        array = ArrayGlyph(stack)
+        array.animate(list(range(2)), display_cell_value=True, precision=1)
+        array.anim._func(0)
+        cell_texts = {
+            t.get_text()
+            for t in array.ax.texts
+            if t.get_text().startswith(("1", "2", "3", "4"))
+        }
+        assert cell_texts == {"1.2", "2.3", "3.5", "4.6"}
 
 
 @pytest.mark.plot

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -15,12 +15,14 @@ from PIL import Image
 from cleopatra.array_glyph import (
     _COORD_DTYPE_MISMATCH,
     _COORD_SHAPE_MISMATCH,
+    _UNSET,
     AnimateKwargs,
     ArrayGlyph,
     FacetGrid,
     FrameLabel,
     PlotKwargs,
     PointOverlay,
+    _pop_first,
 )
 
 
@@ -660,6 +662,161 @@ class TestKwargsTypedDicts:
             if t.get_text().startswith(("1", "2", "3", "4"))
         }
         assert cell_texts == {"1.2", "2.3", "3.5", "4.6"}
+
+
+class TestUnsetSentinel:
+    """`_Unset`/`_UNSET`: the sentinel distinguishing "not passed" from
+    "passed, equal to its default" for `_resolve_renamed_kwarg`'s
+    `new_value` parameter.
+    """
+
+    def test_repr_is_readable(self):
+        """`repr(_UNSET)` reads `<unset>`, not the default `object()` repr.
+
+        Test scenario:
+            The class docstring's whole reason for existing over a plain
+            `object()` sentinel is a readable `help()`/IDE tooltip; a
+            regression here (e.g. deleting `__repr__`) would silently
+            fall back to `<cleopatra.array_glyph._Unset object at 0x...>`.
+        """
+        assert repr(_UNSET) == "<unset>", f"Unexpected repr: {repr(_UNSET)!r}"
+
+    def test_is_singleton_identity(self):
+        """`_UNSET` is a single shared instance, compared with `is` not `==`.
+
+        Test scenario:
+            `_resolve_renamed_kwarg` tests `new_value is _UNSET`; a second
+            `_Unset()` instance must NOT be `is _UNSET` (no `__eq__`
+            override makes two instances equal either), confirming the
+            sentinel can only be obtained by importing `_UNSET` itself.
+        """
+        from cleopatra.array_glyph import _Unset
+
+        other = _Unset()
+        assert other is not _UNSET, "A fresh _Unset() must not be the _UNSET singleton"
+        assert other != _UNSET, "Two distinct _Unset instances must not compare equal"
+
+
+class TestPopFirst:
+    """Direct unit tests for `_pop_first`, the helper `_resolve_point_overlay`
+    and `_resolve_frame_label` use to drain every deprecated alias out of
+    `kwargs` while keeping only the highest-priority value.
+    """
+
+    def test_no_names_present_returns_default(self):
+        """None of `names` in `kwargs`: returns `(default, None)`, `kwargs` untouched."""
+        kwargs = {"cmap": "viridis"}
+        value, key = _pop_first(kwargs, ("point_color", "pid_color"), "red")
+        assert (value, key) == (
+            "red",
+            None,
+        ), f"Expected ('red', None), got {(value, key)}"
+        assert kwargs == {
+            "cmap": "viridis"
+        }, f"kwargs should be untouched, got {kwargs}"
+
+    def test_single_name_present_pops_it(self):
+        """Exactly one of `names` present: it is popped and returned with its key."""
+        kwargs = {"point_color": "lime", "cmap": "viridis"}
+        value, key = _pop_first(kwargs, ("point_color",), "red")
+        assert (value, key) == ("lime", "point_color"), f"Got {(value, key)}"
+        assert "point_color" not in kwargs, "The matched key must be popped"
+        assert kwargs == {
+            "cmap": "viridis"
+        }, f"Unrelated keys must survive, got {kwargs}"
+
+    def test_multiple_names_present_pops_all_returns_highest_priority(self):
+        """Two aliases present: both are popped, but the first-listed one wins.
+
+        Test scenario:
+            Regression for a bug where only the winning name was popped,
+            leaving the loser in `kwargs` to fail the caller's subsequent
+            strict `kwargs`-vs-`default_options` validation.
+        """
+        kwargs = {"point_label_color": "lime", "pid_color": "orange"}
+        value, key = _pop_first(kwargs, ("point_label_color", "pid_color"), "blue")
+        assert (value, key) == ("lime", "point_label_color"), f"Got {(value, key)}"
+        assert kwargs == {}, f"Both aliases must be popped, got {kwargs}"
+
+    def test_priority_order_is_names_order_not_insertion_order(self):
+        """The winner is the first name in `names`, regardless of `kwargs` insertion order.
+
+        Test scenario:
+            `pid_color` is inserted into `kwargs` before `point_label_color`,
+            but `names=("point_label_color", "pid_color")` still prefers
+            `point_label_color` -- priority is positional in `names`, not
+            dict insertion order.
+        """
+        kwargs = {"pid_color": "orange", "point_label_color": "lime"}
+        value, key = _pop_first(kwargs, ("point_label_color", "pid_color"), "blue")
+        assert (value, key) == ("lime", "point_label_color"), f"Got {(value, key)}"
+
+    def test_empty_names_returns_default(self):
+        """An empty `names` tuple always returns `(default, None)`."""
+        kwargs = {"cmap": "viridis"}
+        value, key = _pop_first(kwargs, (), "red")
+        assert (value, key) == (
+            "red",
+            None,
+        ), f"Expected ('red', None), got {(value, key)}"
+        assert kwargs == {
+            "cmap": "viridis"
+        }, f"kwargs should be untouched, got {kwargs}"
+
+
+class TestPointOverlay:
+    """Direct unit tests for `PointOverlay.__init__`'s defaults and
+    attribute assignment, independent of `plot`/`animate` rendering.
+    """
+
+    def test_defaults(self):
+        """Only `points` given: the four styling attributes take their documented defaults."""
+        points = np.array([[5.0, 1, 1]])
+        overlay = PointOverlay(points)
+        assert overlay.points is points, "points must be stored as given, not copied"
+        assert (
+            overlay.color == "red"
+        ), f"Expected default color 'red', got {overlay.color!r}"
+        assert overlay.size == 100, f"Expected default size 100, got {overlay.size!r}"
+        assert (
+            overlay.label_color == "blue"
+        ), f"Expected default label_color 'blue', got {overlay.label_color!r}"
+        assert (
+            overlay.label_size == 10
+        ), f"Expected default label_size 10, got {overlay.label_size!r}"
+
+    def test_explicit_values_stored_verbatim(self):
+        """All four styling keywords, when given, are stored unchanged."""
+        points = np.array([[5.0, 1, 1]])
+        overlay = PointOverlay(
+            points, color="lime", size=42, label_color="orange", label_size=7
+        )
+        assert overlay.color == "lime", f"Got {overlay.color!r}"
+        assert overlay.size == 42, f"Got {overlay.size!r}"
+        assert overlay.label_color == "orange", f"Got {overlay.label_color!r}"
+        assert overlay.label_size == 7, f"Got {overlay.label_size!r}"
+
+
+class TestFrameLabel:
+    """Direct unit tests for `FrameLabel.__init__`'s defaults and attribute
+    assignment, independent of `animate` rendering.
+    """
+
+    def test_defaults(self):
+        """No arguments given: `location` is `None` and `color` is `'black'`."""
+        label = FrameLabel()
+        assert (
+            label.location is None
+        ), f"Expected default location None, got {label.location!r}"
+        assert (
+            label.color == "black"
+        ), f"Expected default color 'black', got {label.color!r}"
+
+    def test_explicit_values_stored_verbatim(self):
+        """Both keywords, when given, are stored unchanged."""
+        label = FrameLabel(location=[0.3, 0.4], color="yellow")
+        assert label.location == [0.3, 0.4], f"Got {label.location!r}"
+        assert label.color == "yellow", f"Got {label.color!r}"
 
 
 @pytest.mark.plot

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -17,6 +17,7 @@ from cleopatra.array_glyph import (
     _COORD_SHAPE_MISMATCH,
     ArrayGlyph,
     FacetGrid,
+    FrameLabel,
     PointOverlay,
 )
 
@@ -352,13 +353,14 @@ class TestAnimate:
 class TestRenamedKwargAliases:
     """The legacy `plot`/`animate` kwarg names still work but warn.
 
-    `text_colors` was renamed to `cell_value_text_colors`, and `text_loc`
-    to `label_location`. Each old name is still accepted as a keyword
-    (routed through `**kwargs`), emits a `DeprecationWarning` naming its
-    replacement, and is forwarded to the same effective behaviour as the
-    new name. The point-styling kwargs (`point_color`, `pid_color`, ...)
-    have since been superseded by `PointOverlay` -- see
-    `TestPointOverlayAliases`.
+    `text_colors` was renamed to `cell_value_text_colors`. The old name is
+    still accepted as a keyword (routed through `**kwargs`), emits a
+    `DeprecationWarning` naming its replacement, and is forwarded to the
+    same effective behaviour as the new name. The point-styling kwargs
+    (`point_color`, `pid_color`, ...) have since been superseded by
+    `PointOverlay` -- see `TestPointOverlayAliases`; the frame-label
+    kwargs (`label_location`, `label_color`, `text_loc`) by `FrameLabel`
+    -- see `TestFrameLabelAliases`.
     """
 
     def test_animate_text_colors_alias_still_works(
@@ -373,15 +375,6 @@ class TestRenamedKwargAliases:
                 text_colors=("yellow", "purple"),
             )
 
-    def test_animate_text_loc_alias_still_works(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`animate(text_loc=...)` warns and positions the frame label."""
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="label_location"):
-            array.animate(animate_time_list, text_loc=[0.1, 0.1])
-        assert array._day_text.get_transform() is array.ax.transData
-
     def test_no_warning_with_only_new_names(self, coello_data: np.ndarray):
         """Using only the current names raises no deprecation warning."""
         array = ArrayGlyph(coello_data)
@@ -390,8 +383,69 @@ class TestRenamedKwargAliases:
             array.animate(
                 ["t0", "t1", "t2"],
                 cell_value_text_colors=("yellow", "purple"),
-                label_location=[0.1, 0.1],
+                frame_label=FrameLabel(location=[0.1, 0.1]),
             )
+
+
+class TestFrameLabelAliases:
+    """`FrameLabel` is the current way to style `animate`'s frame/time
+    label; the flat keywords it replaces (`label_location`/`label_color`,
+    and the older `text_loc`) still work but warn.
+    """
+
+    def test_frame_label_no_warning(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """Passing a `FrameLabel` is the current style and warns nothing."""
+        array = ArrayGlyph(coello_data)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            array.animate(
+                animate_time_list,
+                frame_label=FrameLabel(location=[0.1, 0.1], color="yellow"),
+            )
+        assert array._day_text.get_color() == "yellow"
+        assert array._day_text.get_transform() is array.ax.transData
+
+    def test_label_location_alias_still_works(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`animate(label_location=...)` warns and positions the frame label."""
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="FrameLabel"):
+            array.animate(animate_time_list, label_location=[0.1, 0.1])
+        assert array._day_text.get_transform() is array.ax.transData
+
+    def test_text_loc_oldest_alias_still_works(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`animate(text_loc=...)` (the oldest name) warns and positions the label."""
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="FrameLabel"):
+            array.animate(animate_time_list, text_loc=[0.1, 0.1])
+        assert array._day_text.get_transform() is array.ax.transData
+
+    def test_label_color_alias_still_works(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """`animate(label_color=...)` warns and colours the frame label."""
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(DeprecationWarning, match="FrameLabel"):
+            array.animate(animate_time_list, label_color="yellow")
+        assert array._day_text.get_color() == "yellow"
+
+    def test_deprecated_kwargs_ignored_with_frame_label(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A deprecated kwarg alongside a `FrameLabel` is ignored, with a warning."""
+        array = ArrayGlyph(coello_data)
+        with pytest.warns(UserWarning, match="ignored"):
+            array.animate(
+                animate_time_list,
+                frame_label=FrameLabel(color="yellow"),
+                label_color="orange",
+            )
+        assert array._day_text.get_color() == "yellow"
 
 
 class TestPointOverlayAliases:
@@ -1448,25 +1502,13 @@ class TestAnimateEdgeCases:
         assert anim is not None
         assert glyph.default_options["ticks_spacing"] == 50.0
 
-    def test_animate_with_label_color(
+    def test_data_getter_is_keyword_only(
         self,
         coello_data: np.ndarray,
         animate_time_list: list,
         no_data_value: float,
     ):
-        """`animate(label_color=...)` sets the frame label's text color."""
-        glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
-        anim = glyph.animate(animate_time_list, label_color="yellow")
-        assert anim is not None
-        assert glyph._day_text.get_color() == "yellow"
-
-    def test_label_color_is_keyword_only(
-        self,
-        coello_data: np.ndarray,
-        animate_time_list: list,
-        no_data_value: float,
-    ):
-        """`label_color` must be keyword-only so no positional argument shifts."""
+        """`data_getter` must be keyword-only so no positional argument shifts."""
         glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
         with pytest.raises(TypeError):
             glyph.animate(
@@ -1475,11 +1517,7 @@ class TestAnimateEdgeCases:
                 ("white", "black"),
                 200,
                 None,
-                "red",
-                100,
-                "blue",
-                10,
-                "yellow",
+                lambda i: coello_data,
             )
 
 
@@ -3231,36 +3269,36 @@ class TestAnimateDataGetterEdgeCases:
         finally:
             plt.close(anim._fig)
 
-    def test_data_getter_explicit_label_location(self) -> None:
-        """A user-supplied `label_location` skips the default-init branch.
+    def test_data_getter_explicit_frame_label_location(self) -> None:
+        """A user-supplied `FrameLabel(location=...)` skips the default-init branch.
 
         Test scenario:
-            Default `label_location=None` is rewritten to an axes-fraction
-            anchor; passing an explicit value covers the alternate branch
-            where the rewrite is skipped and data coordinates are used
-            instead.
+            Default `frame_label=None` resolves to an axes-fraction anchor;
+            passing an explicit `FrameLabel` location covers the alternate
+            branch where the rewrite is skipped and data coordinates are
+            used instead.
         """
         stack = self._stack(n=3)
         glyph = ArrayGlyph(stack[0])
         anim = glyph.animate(
             time=list(range(3)),
             data_getter=lambda i: stack[i],
-            label_location=[0.05, 0.05],
+            frame_label=FrameLabel(location=[0.05, 0.05]),
         )
         try:
             assert isinstance(
                 anim, FuncAnimation
-            ), "explicit label_location must produce an animation"
+            ), "explicit frame_label location must produce an animation"
             assert glyph._day_text.get_transform() is glyph.ax.transData
         finally:
             plt.close(glyph.fig)
 
-    def test_default_label_location_stays_inside_axes(self) -> None:
+    def test_default_frame_label_location_stays_inside_axes(self) -> None:
         """The default frame label must not clip past the axes bounds.
 
         Test scenario:
             Regression test for the inverted-Y-axis clipping bug: with no
-            explicit `label_location`, the label's rendered bounding box
+            explicit `frame_label`, the label's rendered bounding box
             must sit fully within the axes bounding box on both axes, for
             a square and a moderately rectangular array shape. Does not
             cover an extremely narrow axes (e.g. a 20-column array), where
@@ -3268,7 +3306,8 @@ class TestAnimateDataGetterEdgeCases:
             available width is smaller than the label's rendered text at
             the default font size — a physical-space limit no anchor
             choice can fix; callers with very narrow images should pass
-            an explicit `label_location` or a smaller `cbar_label_size`.
+            an explicit `FrameLabel(location=...)` or a smaller
+            `cbar_label_size`.
         """
         for shape in [(4, 48, 48), (4, 100, 50)]:
             arr = np.zeros(shape)


### PR DESCRIPTION
# Description

Cleans up `ArrayGlyph.plot()`/`animate()`'s keyword-argument API, found while auditing the two methods for
descriptive naming. All of it is backward-compatible: every removed name still works via `**kwargs` and emits a
`DeprecationWarning`.

- Renames ambiguous names: `pid_color`/`pid_size` (read as "process ID", actually the point-*value* label style)
  to `point_label_color`/`point_label_size`; `animate()`'s `text_colors` to `cell_value_text_colors`; `text_loc`
  to `label_location`.
- Bundles the five point-overlay parameters (`points`, `point_color`, `point_size`, `point_label_color`,
  `point_label_size`) into a single `PointOverlay` object.
- Bundles `animate()`'s two frame-label parameters (`label_location`, `label_color`) into a single `FrameLabel`
  object.
- Types the remaining `**kwargs` on both methods via `TypedDict` + `Unpack` (PEP 692) — a static-typing aid only,
  inert at runtime, giving IDE autocomplete and typo-catching for kwargs that used to be untyped.
- `Glyph._plot_point_values`'s `pid_color`/`pid_size` params are renamed too (private, no alias needed).

**Backward compatibility mechanism:** deprecated names/shapes are resolved by module-level helpers
(`_resolve_renamed_kwarg`, `_resolve_point_overlay`, `_resolve_frame_label`) that pop them out of `**kwargs`
before the strict `default_options` validation (which would otherwise reject them outright), fold them into the
new objects, and emit a `DeprecationWarning` naming the replacement.

**Found and fixed during two independent rounds of adversarial review** (`/review-rounds`, each round a fresh
subagent pass over the full diff):
- A silent regression where `animate()`'s old positional `text_loc` slot (now `frame_label`) dropped a bare
  `[x, y]` value with no warning and no error.
- Wrong `stacklevel` on several deprecation warnings, misattributing them to an internal frame instead of the
  caller.
- A false-negative in the "both old and new name given" conflict check when the new name happened to equal its
  own default — fixed with an `_Unset` sentinel distinguishing "not passed" from "passed, equal to default".
- `precision` (a real, `animate()`-only option) missing from the new `AnimateKwargs` TypedDict.
- A regression where `plot()`/`animate()` raised `ValueError` on a deprecated point-style kwarg (e.g.
  `point_color`) passed *without* `points` — contradicting the "old keywords still work" guarantee.
- The example notebook still taught the deprecated point-styling kwargs instead of `PointOverlay`.
- A deprecation-warning message under-reporting which alias was consumed in one combined-call edge case.

**Out of scope, found along the way (not touched here):**
- `ARRAY_DEFAULT_OPTIONS` has `id_color`/`id_size` (defaults `"green"`/`20`) that are declared but never read
  anywhere — dead options, confusingly similar to the old `pid_color`/`pid_size` names.
- `MeshGlyph.animate()` has its own separate `text_loc` parameter, unaffected by this change — now inconsistently
  named versus `ArrayGlyph`'s new `label_location`.

**Dependencies:** none (`typing.Unpack` is stdlib since Python 3.11, matching this repo's floor).

# Issues

- Closes #208 — clean up `ArrayGlyph.plot()`/`animate()`'s kwarg API

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Run against the external uv env (`VIRTUAL_ENV=C:/python-environments/uv/cleopatra`, `PYTHONPATH=src` pinned to
this checkout, `uv run --active`):

- [x] Full suite green: `pytest tests/` -> **1584 passed**.
- [x] Doctests green across the whole package, including every new/changed example in `array_glyph.py`.
- [x] `test_array_glyph.py` gained extensive new coverage: deprecated-alias regression tests for every rename,
      `PointOverlay`/`FrameLabel` bundling, the `_Unset` sentinel, and the `TypedDict` groups — coverage on
      `array_glyph.py` is 99% line+branch, with the remaining gaps pre-existing and unrelated to this PR.
- [x] Two full rounds of independent adversarial review (`/review-rounds`) — each round a fresh subagent with no
      knowledge of the previous round's findings — with every must-fix/should-fix finding resolved and verified
      by direct reproduction (not just re-reading), see the review's own findings above.
- [x] mypy on `array_glyph.py` compared before/after every fix via `git stash`: zero new errors introduced by
      this PR (pre-existing, unrelated errors carried over unchanged).
- [x] black / isort / flake8 clean on every line this PR touches (pre-existing formatting/lint drift elsewhere in
      `array_glyph.py`/`test_array_glyph.py`, unrelated to this change, confirmed via `git stash` to predate it).
- [x] Every example notebook using `ArrayGlyph.plot`/`animate` (`array_glyph_examples.ipynb`,
      `rgb_animation.ipynb`) updated to `PointOverlay`/`FrameLabel` and re-executed cleanly against scratch
      copies — no other tracked notebook used the deprecated kwargs.

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
