### PR TITLE
fix(glyph): remove orphaned artists on shared Axes reuse across all glyph classes

### DIFF
--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -4004,10 +4004,6 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         fig, ax = self.fig, self.ax
 
-        self.cbar = None
-        self.im = None
-        self._day_text = None
-
         # Per-frame RGBA recipe for a continuous `style` (cmap, colour norm,
         # alpha norm, constant alpha), set in the style branch below and
         # consumed by `_display_frame`. `None` when no style is active.

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -2761,22 +2761,22 @@ class ArrayGlyph(GeoMixin, Glyph):
                 - fig: The matplotlib Figure object
                 - ax: The matplotlib Axes object
 
-            The colour-mapped artist (the ``ScalarMappable`` — e.g. the
-            ``AxesImage`` for ``imshow``, the ``QuadMesh`` for
-            ``pcolormesh``, the ``QuadContourSet`` for
-            ``contour``/``contourf``, or the RGB ``AxesImage``) is also
-            stored on the instance as ``self.im`` after this call, so a
+            The colour-mapped artist (the `ScalarMappable` — e.g. the
+            `AxesImage` for `imshow`, the `QuadMesh` for
+            `pcolormesh`, the `QuadContourSet` for
+            `contour`/`contourf`, or the RGB `AxesImage`) is also
+            stored on the instance as `self.im` after this call, so a
             caller can attach a colorbar/legend or query the colour
-            limits without scraping ``ax.images``/``ax.collections``.
+            limits without scraping `ax.images`/`ax.collections`.
 
         Raises:
             ValueError: If an invalid keyword argument is provided.
 
         Notes:
-            This method does not call ``plt.show()``; it returns the Figure and Axes so
+            This method does not call `plt.show()`; it returns the Figure and Axes so
             the caller can compose, save, or display them. In an interactive session call
-            ``plt.show()`` yourself (or ``fig.savefig(...)`` to write the plot to disk)
-            after ``plot()`` returns.
+            `plt.show()` yourself (or `fig.savefig(...)` to write the plot to disk)
+            after `plot()` returns.
 
         Examples:
         - Basic array plot:
@@ -3774,8 +3774,8 @@ class ArrayGlyph(GeoMixin, Glyph):
                 in a notebook or saved to a file.
 
             As with `plot`, the first-frame colour-mapped artist is stored on
-            the instance as ``self.im`` (and the colorbar, when drawn, on
-            ``self.cbar``), so a caller can attach a host-owned
+            the instance as `self.im` (and the colorbar, when drawn, on
+            `self.cbar`), so a caller can attach a host-owned
             colorbar/legend without scraping the axes.
 
         Raises:
@@ -3793,9 +3793,9 @@ class ArrayGlyph(GeoMixin, Glyph):
             For example, if the array has shape (10, 20, 30), the animation will have 10 frames,
             each showing a 20x30 slice of the array.
 
-            This method does not call ``plt.show()``; it returns the ``FuncAnimation`` so the
+            This method does not call `plt.show()`; it returns the `FuncAnimation` so the
             caller controls display. In an interactive (non-notebook) session call
-            ``plt.show()`` yourself to play it, or use ``save_animation`` to write it to a file.
+            `plt.show()` yourself to play it, or use `save_animation` to write it to a file.
 
             To display the animation in a Jupyter notebook, you may need to use:
             ```python

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -1214,6 +1214,11 @@ class ArrayGlyph(GeoMixin, Glyph):
         # reachable as public attributes, even before the first render.
         self.im = None
         self.cbar = None
+        # Per-frame time-label artist from the most recent `animate()`
+        # call, if any -- initialised here (like `im`/`cbar` above) so
+        # `animate()` can always check it before creating a new one,
+        # regardless of whether this is the first call.
+        self._day_text = None
         # Inline contour-label artists from the most recent
         # `plot(kind="contour", labels=True)`, or `None` when labelling
         # was not requested (the default, and for every non-contour
@@ -3962,6 +3967,30 @@ class ArrayGlyph(GeoMixin, Glyph):
             self.fig, self.ax = self.create_figure_axes()
 
         fig, ax = self.fig, self.ax
+
+        # A prior animate() call on this same glyph (e.g. a caller
+        # re-animating a glyph that already went through animate() once,
+        # such as pyramids' DatasetCollection.plot(mode="animate") followed
+        # by its own animate() call) leaves that call's image/colorbar/
+        # frame-label artists on `ax` -- `ax.imshow()` always adds a new
+        # artist rather than replacing one, and the init_func marks it
+        # `animated=True` (blit-owned), so normal redraws silently skip it
+        # and nothing ever removes it once this glyph's `self.im`/`self.anim`
+        # move on to the new call's artists. Remove any such leftovers
+        # before creating this call's own, so they don't linger orphaned in
+        # `ax.images`/`ax.texts`. The colorbar must be removed *before* the
+        # image it is attached to -- `Colorbar.remove()` reads
+        # `self.mappable.axes` to restore the image axes' gridspec position,
+        # which is only valid while the image artist is still attached.
+        if self.cbar is not None:
+            self.cbar.remove()
+            self.cbar = None
+        if self.im is not None:
+            self.im.remove()
+            self.im = None
+        if self._day_text is not None:
+            self._day_text.remove()
+            self._day_text = None
 
         # Per-frame RGBA recipe for a continuous `style` (cmap, colour norm,
         # alpha norm, constant alpha), set in the style branch below and

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -743,6 +743,73 @@ def _resolve_frame_label(frame_label: Any, kwargs: dict) -> FrameLabel:
     return FrameLabel(location=location, color=color)
 
 
+def _clear_prior_render_artists(ax: Axes) -> None:
+    """Remove a prior `plot`/`animate` call's image/colorbar/frame-label artists from `ax`.
+
+    `plot`/`animate` each create a fresh image artist (`ax.imshow(...)` or
+    equivalent) and colorbar on every call rather than reusing one, so
+    calling either method again on the same `Axes` -- from the same glyph
+    instance, or a *different* one sharing it via `ArrayGlyph(ax=...,
+    fig=...)` (e.g. the `ax=`/`fig=` passthrough `pyramids`'
+    `Dataset`/`NetCDF`/`Analysis`.plot(ax=..., fig=...) expose) -- would
+    otherwise leave the previous call's artists orphaned: still in
+    `ax.images`/`ax.texts`, marked `animated=True` by `animate`'s
+    `init_func` when applicable (so normal redraws silently skip them),
+    and driven by nothing once the owning glyph's `self.im`/`self.anim`
+    move on to the new call's objects. Ownership is tracked on `ax`
+    itself (not on any glyph instance) via a private marker, precisely so
+    this catches both cases. Must be called before creating this call's
+    own artists.
+
+    Args:
+        ax: The axes a `plot`/`animate` call is about to render onto.
+    """
+    prior = getattr(ax, "_cleo_render_artists", None)
+    if prior is None:
+        return
+    # The colorbar must be removed *before* the image it is attached to --
+    # `Colorbar.remove()` reads `self.mappable.axes` to restore the image
+    # axes' gridspec position, which is only valid while the image artist
+    # is still attached. Each removal is best-effort: another code path
+    # (e.g. `Glyph._reset_axes_for_restyle`, used by `apply_style`, or a
+    # caller's own `ax.clear()`) may already have removed these same
+    # artists before this marker was consulted -- matplotlib raises
+    # `KeyError` for a colorbar axes no longer on the figure's axes stack,
+    # or `NotImplementedError` for any other artist already detached from
+    # its axes, neither of which should stop this call's own render.
+    for artist in (prior.get("cbar"), prior.get("im"), prior.get("day_text")):
+        if artist is None:
+            continue
+        try:
+            artist.remove()
+        except (KeyError, NotImplementedError):
+            pass
+    ax._cleo_render_artists = None  # type: ignore[attr-defined]
+
+
+def _mark_render_artists(ax: Axes, im: Any, cbar: Any, day_text: Any = None) -> None:
+    """Record this `plot`/`animate` call's artists on `ax` for the next call's cleanup.
+
+    Args:
+        ax: The axes this call rendered onto.
+        im: The image artist this call created, or `None`.
+        cbar: The colorbar this call created, or `None` (e.g. a data-style
+            preset draws a swatch legend instead).
+        day_text: The frame-label `Text` artist this call created, or
+            `None` (`plot` has no frame label; only `animate` sets this).
+    """
+    # `Axes` declares no such attribute -- this is a deliberate, private
+    # marker cleopatra stamps onto the caller's Axes object itself (not a
+    # cleopatra-owned type), matching the same # type: ignore[attr-defined]
+    # trade-off as `getattr(ax, "_cleo_render_artists", None)` in
+    # `_clear_prior_render_artists` above.
+    ax._cleo_render_artists = {  # type: ignore[attr-defined]
+        "im": im,
+        "cbar": cbar,
+        "day_text": day_text,
+    }
+
+
 class FacetGrid:
     """Result object for a multi-subplot facet plot.
 
@@ -2322,6 +2389,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         self.ax.set_title(
             self.default_options["title"], fontsize=self.default_options["title_size"]
         )
+        _mark_render_artists(self.ax, self.im, self.cbar)
         return self.fig, self.ax
 
     def apply_colormap(self, cmap: Colormap | str) -> np.ndarray:
@@ -3137,6 +3205,16 @@ class ArrayGlyph(GeoMixin, Glyph):
         arr = self.arr
         fig, ax = self.fig, self.ax
 
+        # See `_clear_prior_render_artists`: a prior `plot`/`animate` call on
+        # this Axes (this glyph's own, or a different glyph sharing it via
+        # `ArrayGlyph(ax=..., fig=...)`) leaves its image/colorbar/frame-label
+        # artists orphaned unless removed first. Cleared here, before the
+        # style-preset dispatch below, so both `plot()`'s own render path and
+        # `_plot_with_style` are covered.
+        _clear_prior_render_artists(ax)
+        self.im = None
+        self.cbar = None
+
         # Named data-style preset: resolve the preset's cmap/norm/vmin/vmax/
         # center/categories (and alpha glow / categorical legend) by delegating
         # to `cleopatra.colors.apply_data_style`, so the full preset semantics
@@ -3278,6 +3356,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         #     im.norm(self.default_options["background_color_threshold"])
         # else:
         #     im.norm(self.vmax) / 2.0
+        _mark_render_artists(ax, self.im, self.cbar)
         return fig, ax
 
     def facet(
@@ -3968,34 +4047,11 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         fig, ax = self.fig, self.ax
 
-        # A prior animate() call on this Axes leaves its image/colorbar/
-        # frame-label artists behind -- `ax.imshow()` always adds a new
-        # artist rather than replacing one, and the init_func marks it
-        # `animated=True` (blit-owned), so normal redraws silently skip it
-        # and nothing removes it once the owning glyph's `self.im`/`self.anim`
-        # move on to a new call's artists. This is tracked per-*Axes* (via a
-        # private marker on `ax`), not per-glyph-instance, because the prior
-        # call may have come from a *different* `ArrayGlyph` sharing this
-        # Axes -- e.g. `ArrayGlyph(arr2, ax=glyph1.ax, fig=glyph1.fig)`, the
-        # pattern pyramids' `Dataset`/`NetCDF`/`Analysis`.plot(ax=..., fig=...)
-        # passthrough exposes. Checking only `self.im`/`self.cbar` would miss
-        # that case, since a fresh glyph instance's own attributes start out
-        # `None` regardless of what is already sitting on the shared Axes.
-        # Remove any such leftovers before creating this call's own, so they
-        # don't linger orphaned in `ax.images`/`ax.texts`. The colorbar must
-        # be removed *before* the image it is attached to -- `Colorbar.remove()`
-        # reads `self.mappable.axes` to restore the image axes' gridspec
-        # position, which is only valid while the image artist is still
-        # attached.
-        prior_artists = getattr(ax, "_cleo_animate_artists", None)
-        if prior_artists is not None:
-            if prior_artists.get("cbar") is not None:
-                prior_artists["cbar"].remove()
-            if prior_artists.get("im") is not None:
-                prior_artists["im"].remove()
-            if prior_artists.get("day_text") is not None:
-                prior_artists["day_text"].remove()
-            ax._cleo_animate_artists = None
+        # See `_clear_prior_render_artists`: a prior `plot`/`animate` call on
+        # this Axes (this glyph's own, or a different glyph sharing it)
+        # leaves its image/colorbar/frame-label artists orphaned unless
+        # removed first.
+        _clear_prior_render_artists(ax)
         self.cbar = None
         self.im = None
         self._day_text = None
@@ -4321,15 +4377,10 @@ class ArrayGlyph(GeoMixin, Glyph):
             blit=True,
         )
         self._anim = anim
-        # Record this call's artists on the Axes itself (not just on
-        # `self`) so a later animate() call -- from this glyph or a
-        # different one sharing this Axes -- can find and remove them.
-        # See the cleanup block near the top of this method.
-        ax._cleo_animate_artists = {
-            "im": self.im,
-            "cbar": self.cbar,
-            "day_text": self._day_text,
-        }
+        # See `_mark_render_artists`: record this call's artists on the
+        # Axes itself so a later plot()/animate() call -- from this glyph
+        # or a different one sharing this Axes -- can find and remove them.
+        _mark_render_artists(ax, self.im, self.cbar, self._day_text)
         return anim
 
     # @staticmethod

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -2274,6 +2274,11 @@ class ArrayGlyph(GeoMixin, Glyph):
             tuple[Figure, Axes]: The figure and axes drawn on.
         """
         layer = self._resolve_style_layer(style)
+        # See `_clear_prior_render_artists`: cleared only once the style
+        # name is known valid, so a prior *valid* render survives a bad
+        # `style` on this call instead of being torn down for a call that
+        # never completes.
+        _clear_prior_render_artists(self.ax)
         # Cast to float BEFORE filling: `ma.filled(int_array, np.nan)` raises
         # `TypeError: Cannot convert fill_value nan to dtype int64` for an
         # integer masked array -- exactly the integer-coded categorical raster
@@ -3143,16 +3148,6 @@ class ArrayGlyph(GeoMixin, Glyph):
         arr = self.arr
         fig, ax = self.fig, self.ax
 
-        # See `_clear_prior_render_artists`: a prior `plot`/`animate` call on
-        # this Axes (this glyph's own, or a different glyph sharing it via
-        # `ArrayGlyph(ax=..., fig=...)`) leaves its image/colorbar/frame-label
-        # artists orphaned unless removed first. Cleared here, before the
-        # style-preset dispatch below, so both `plot()`'s own render path and
-        # `_plot_with_style` are covered.
-        _clear_prior_render_artists(ax)
-        self.im = None
-        self.cbar = None
-
         # Named data-style preset: resolve the preset's cmap/norm/vmin/vmax/
         # center/categories (and alpha glow / categorical legend) by delegating
         # to `cleopatra.colors.apply_data_style`, so the full preset semantics
@@ -3186,6 +3181,11 @@ class ArrayGlyph(GeoMixin, Glyph):
                 return self._plot_with_style(style)
 
         if self.rgb:
+            # See `_clear_prior_render_artists`: cleared only once nothing
+            # above this point could still raise, so a prior *valid* render
+            # survives a validation failure instead of being torn down for
+            # a call that never completes.
+            _clear_prior_render_artists(ax)
             self.im = ax.imshow(arr, extent=self.extent)
             self.cbar = None
         else:
@@ -3234,6 +3234,18 @@ class ArrayGlyph(GeoMixin, Glyph):
 
             # creating the ticks/bounds
             ticks = self.get_ticks()
+            # Pre-flight the norm/cbar-kwarg resolution (e.g. an invalid
+            # `color_scale`) before clearing -- it is the actual validation
+            # surface `_plot_im_get_cbar_kw` bundles together with drawing
+            # a few lines below, and is pure (reads `default_options` only,
+            # no `ax` mutation), so calling it here to fail fast costs
+            # nothing beyond `_plot_im_get_cbar_kw` recomputing the same
+            # result. See `_clear_prior_render_artists`: only cleared once
+            # this can no longer raise, so a prior *valid* render survives
+            # a validation failure instead of being torn down for a call
+            # that never completes.
+            self._create_norm_and_cbar_kw(ticks)
+            _clear_prior_render_artists(ax)
             im, cbar_kw = self._plot_im_get_cbar_kw(ax, arr, ticks, kind=effective_kind)
             self.im = im
 
@@ -3992,11 +4004,6 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         fig, ax = self.fig, self.ax
 
-        # See `_clear_prior_render_artists`: a prior `plot`/`animate` call on
-        # this Axes (this glyph's own, or a different glyph sharing it)
-        # leaves its image/colorbar/frame-label artists orphaned unless
-        # removed first.
-        _clear_prior_render_artists(ax)
         self.cbar = None
         self.im = None
         self._day_text = None
@@ -4011,12 +4018,22 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         if rgb_frames:
             # True-colour frames go straight through imshow — no norm,
-            # colormap or colorbar (mirrors `plot`'s RGB branch).
+            # colormap or colorbar (mirrors `plot`'s RGB branch). See
+            # `_clear_prior_render_artists`: cleared only once nothing
+            # above this point could still raise, so a prior *valid*
+            # render survives a validation failure instead of being torn
+            # down for a call that never completes.
+            _clear_prior_render_artists(ax)
             im = ax.imshow(frame_0, extent=self.extent)
             self.im = im
             self.cbar = None
         else:
             ticks = self.get_ticks()
+            # Pre-flight the norm/cbar-kwarg resolution (e.g. an invalid
+            # `color_scale`) before clearing -- see the matching comment
+            # in `plot()`.
+            self._create_norm_and_cbar_kw(ticks)
+            _clear_prior_render_artists(ax)
             im, cbar_kw = self._plot_im_get_cbar_kw(ax, frame_0, ticks)
             self.im = im
 

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -3294,7 +3294,14 @@ class ArrayGlyph(GeoMixin, Glyph):
         #     im.norm(self.default_options["background_color_threshold"])
         # else:
         #     im.norm(self.vmax) / 2.0
-        _mark_render_artists(ax, self.cbar, self.im)
+        _mark_render_artists(
+            ax,
+            self.cbar,
+            self.im,
+            optional_display.get("points_scatter"),
+            *(optional_display.get("points_id") or []),
+            *(optional_display.get("cell_text_value") or []),
+        )
         return fig, ax
 
     def facet(
@@ -4128,6 +4135,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         ax.set_xticks([])
         ax.set_yticks([])
 
+        cell_text_value: list = []
         if show_cell_value:
             indices = get_indices2(frame_0, [np.nan])
             cell_text_value = self._plot_text(
@@ -4135,6 +4143,8 @@ class ArrayGlyph(GeoMixin, Glyph):
             )
             indices = np.array(indices)
 
+        points_scatter = None
+        points_id: list = []
         if points is not None:
             row = points.points[:, 1]
             col = points.points[:, 2]
@@ -4317,8 +4327,21 @@ class ArrayGlyph(GeoMixin, Glyph):
         self._anim = anim
         # See `_mark_render_artists`: record this call's artists on the
         # Axes itself so a later plot()/animate() call -- from this glyph
-        # or a different one sharing this Axes -- can find and remove them.
-        _mark_render_artists(ax, self.cbar, self.im, self._day_text)
+        # or a different one sharing this Axes -- can find and remove
+        # them. points_scatter/points_id/cell_text_value are mutated in
+        # place per frame (`.set_offsets()`/`.set_text()` inside
+        # animate_a() below), not swapped for new objects each frame
+        # (unlike MeshGlyph's mappable), so marking them once here stays
+        # valid for the whole animation.
+        _mark_render_artists(
+            ax,
+            self.cbar,
+            self.im,
+            self._day_text,
+            points_scatter,
+            *points_id,
+            *cell_text_value,
+        )
         return anim
 
     # @staticmethod

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -3968,29 +3968,37 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         fig, ax = self.fig, self.ax
 
-        # A prior animate() call on this same glyph (e.g. a caller
-        # re-animating a glyph that already went through animate() once,
-        # such as pyramids' DatasetCollection.plot(mode="animate") followed
-        # by its own animate() call) leaves that call's image/colorbar/
-        # frame-label artists on `ax` -- `ax.imshow()` always adds a new
+        # A prior animate() call on this Axes leaves its image/colorbar/
+        # frame-label artists behind -- `ax.imshow()` always adds a new
         # artist rather than replacing one, and the init_func marks it
         # `animated=True` (blit-owned), so normal redraws silently skip it
-        # and nothing ever removes it once this glyph's `self.im`/`self.anim`
-        # move on to the new call's artists. Remove any such leftovers
-        # before creating this call's own, so they don't linger orphaned in
-        # `ax.images`/`ax.texts`. The colorbar must be removed *before* the
-        # image it is attached to -- `Colorbar.remove()` reads
-        # `self.mappable.axes` to restore the image axes' gridspec position,
-        # which is only valid while the image artist is still attached.
-        if self.cbar is not None:
-            self.cbar.remove()
-            self.cbar = None
-        if self.im is not None:
-            self.im.remove()
-            self.im = None
-        if self._day_text is not None:
-            self._day_text.remove()
-            self._day_text = None
+        # and nothing removes it once the owning glyph's `self.im`/`self.anim`
+        # move on to a new call's artists. This is tracked per-*Axes* (via a
+        # private marker on `ax`), not per-glyph-instance, because the prior
+        # call may have come from a *different* `ArrayGlyph` sharing this
+        # Axes -- e.g. `ArrayGlyph(arr2, ax=glyph1.ax, fig=glyph1.fig)`, the
+        # pattern pyramids' `Dataset`/`NetCDF`/`Analysis`.plot(ax=..., fig=...)
+        # passthrough exposes. Checking only `self.im`/`self.cbar` would miss
+        # that case, since a fresh glyph instance's own attributes start out
+        # `None` regardless of what is already sitting on the shared Axes.
+        # Remove any such leftovers before creating this call's own, so they
+        # don't linger orphaned in `ax.images`/`ax.texts`. The colorbar must
+        # be removed *before* the image it is attached to -- `Colorbar.remove()`
+        # reads `self.mappable.axes` to restore the image axes' gridspec
+        # position, which is only valid while the image artist is still
+        # attached.
+        prior_artists = getattr(ax, "_cleo_animate_artists", None)
+        if prior_artists is not None:
+            if prior_artists.get("cbar") is not None:
+                prior_artists["cbar"].remove()
+            if prior_artists.get("im") is not None:
+                prior_artists["im"].remove()
+            if prior_artists.get("day_text") is not None:
+                prior_artists["day_text"].remove()
+            ax._cleo_animate_artists = None
+        self.cbar = None
+        self.im = None
+        self._day_text = None
 
         # Per-frame RGBA recipe for a continuous `style` (cmap, colour norm,
         # alpha norm, constant alpha), set in the style branch below and
@@ -4313,6 +4321,15 @@ class ArrayGlyph(GeoMixin, Glyph):
             blit=True,
         )
         self._anim = anim
+        # Record this call's artists on the Axes itself (not just on
+        # `self`) so a later animate() call -- from this glyph or a
+        # different one sharing this Axes -- can find and remove them.
+        # See the cleanup block near the top of this method.
+        ax._cleo_animate_artists = {
+            "im": self.im,
+            "cbar": self.cbar,
+            "day_text": self._day_text,
+        }
         return anim
 
     # @staticmethod

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -49,7 +49,12 @@ from cleopatra.colors import (
 )
 from cleopatra.geo import GeoMixin
 from cleopatra.hillshade import resolve_hillshade, shade_grid, shade_rgb
-from cleopatra.glyph import Glyph, _root_figure
+from cleopatra.glyph import (
+    Glyph,
+    _clear_prior_render_artists,
+    _mark_render_artists,
+    _root_figure,
+)
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale  # re-exported for convenience  # noqa: F401
 from cleopatra.styles import disjoint_legend, swatch_legend
@@ -741,73 +746,6 @@ def _resolve_frame_label(frame_label: Any, kwargs: dict) -> FrameLabel:
             stacklevel=3,
         )
     return FrameLabel(location=location, color=color)
-
-
-def _clear_prior_render_artists(ax: Axes) -> None:
-    """Remove a prior `plot`/`animate` call's image/colorbar/frame-label artists from `ax`.
-
-    `plot`/`animate` each create a fresh image artist (`ax.imshow(...)` or
-    equivalent) and colorbar on every call rather than reusing one, so
-    calling either method again on the same `Axes` -- from the same glyph
-    instance, or a *different* one sharing it via `ArrayGlyph(ax=...,
-    fig=...)` (e.g. the `ax=`/`fig=` passthrough `pyramids`'
-    `Dataset`/`NetCDF`/`Analysis`.plot(ax=..., fig=...) expose) -- would
-    otherwise leave the previous call's artists orphaned: still in
-    `ax.images`/`ax.texts`, marked `animated=True` by `animate`'s
-    `init_func` when applicable (so normal redraws silently skip them),
-    and driven by nothing once the owning glyph's `self.im`/`self.anim`
-    move on to the new call's objects. Ownership is tracked on `ax`
-    itself (not on any glyph instance) via a private marker, precisely so
-    this catches both cases. Must be called before creating this call's
-    own artists.
-
-    Args:
-        ax: The axes a `plot`/`animate` call is about to render onto.
-    """
-    prior = getattr(ax, "_cleo_render_artists", None)
-    if prior is None:
-        return
-    # The colorbar must be removed *before* the image it is attached to --
-    # `Colorbar.remove()` reads `self.mappable.axes` to restore the image
-    # axes' gridspec position, which is only valid while the image artist
-    # is still attached. Each removal is best-effort: another code path
-    # (e.g. `Glyph._reset_axes_for_restyle`, used by `apply_style`, or a
-    # caller's own `ax.clear()`) may already have removed these same
-    # artists before this marker was consulted -- matplotlib raises
-    # `KeyError` for a colorbar axes no longer on the figure's axes stack,
-    # or `NotImplementedError` for any other artist already detached from
-    # its axes, neither of which should stop this call's own render.
-    for artist in (prior.get("cbar"), prior.get("im"), prior.get("day_text")):
-        if artist is None:
-            continue
-        try:
-            artist.remove()
-        except (KeyError, NotImplementedError):
-            pass
-    ax._cleo_render_artists = None  # type: ignore[attr-defined]
-
-
-def _mark_render_artists(ax: Axes, im: Any, cbar: Any, day_text: Any = None) -> None:
-    """Record this `plot`/`animate` call's artists on `ax` for the next call's cleanup.
-
-    Args:
-        ax: The axes this call rendered onto.
-        im: The image artist this call created, or `None`.
-        cbar: The colorbar this call created, or `None` (e.g. a data-style
-            preset draws a swatch legend instead).
-        day_text: The frame-label `Text` artist this call created, or
-            `None` (`plot` has no frame label; only `animate` sets this).
-    """
-    # `Axes` declares no such attribute -- this is a deliberate, private
-    # marker cleopatra stamps onto the caller's Axes object itself (not a
-    # cleopatra-owned type), matching the same # type: ignore[attr-defined]
-    # trade-off as `getattr(ax, "_cleo_render_artists", None)` in
-    # `_clear_prior_render_artists` above.
-    ax._cleo_render_artists = {  # type: ignore[attr-defined]
-        "im": im,
-        "cbar": cbar,
-        "day_text": day_text,
-    }
 
 
 class FacetGrid:
@@ -2389,7 +2327,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         self.ax.set_title(
             self.default_options["title"], fontsize=self.default_options["title_size"]
         )
-        _mark_render_artists(self.ax, self.im, self.cbar)
+        _mark_render_artists(self.ax, self.cbar, self.im)
         return self.fig, self.ax
 
     def apply_colormap(self, cmap: Colormap | str) -> np.ndarray:
@@ -3356,7 +3294,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         #     im.norm(self.default_options["background_color_threshold"])
         # else:
         #     im.norm(self.vmax) / 2.0
-        _mark_render_artists(ax, self.im, self.cbar)
+        _mark_render_artists(ax, self.cbar, self.im)
         return fig, ax
 
     def facet(
@@ -4380,7 +4318,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         # See `_mark_render_artists`: record this call's artists on the
         # Axes itself so a later plot()/animate() call -- from this glyph
         # or a different one sharing this Axes -- can find and remove them.
-        _mark_render_artists(ax, self.im, self.cbar, self._day_text)
+        _mark_render_artists(ax, self.cbar, self.im, self._day_text)
         return anim
 
     # @staticmethod

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -119,6 +119,72 @@ def _immediate_figure(ax: Axes) -> Figure:
     return get_figure()
 
 
+def _clear_prior_render_artists(ax: Axes) -> None:
+    """Remove a prior render call's tracked artists from `ax`.
+
+    Every glyph's `plot`/`animate`-style method creates a fresh set of
+    drawing artists (an image, a colorbar, a frame-label `Text`, a line
+    collection, ...) on every call rather than reusing one -- matplotlib
+    has no "replace the previous artist" primitive for `ax.imshow()`,
+    `fig.colorbar()`, `ax.add_collection()`, etc.; each call always adds a
+    new artist. Calling the method again on the same `Axes` -- from the
+    same glyph instance, or a *different* one sharing it via
+    `SomeGlyph(ax=..., fig=...)` (e.g. the `ax=`/`fig=` passthrough
+    `pyramids`' `Dataset`/`NetCDF`/`Analysis`/`UgridDataset`.plot(ax=...,
+    fig=...) expose) -- would otherwise leave the previous call's artists
+    orphaned: still attached to the `Axes`/`Figure`, and driven by nothing
+    once the owning glyph's own attributes move on to the new call's
+    objects. Ownership is tracked on `ax` itself (not on any glyph
+    instance) via a private marker, precisely so this catches both cases.
+    Must be called before creating this call's own artists.
+
+    Args:
+        ax: The axes a render call is about to draw onto.
+    """
+    prior = getattr(ax, "_cleo_render_artists", None)
+    if prior is None:
+        return
+    # Each removal is best-effort: another code path (e.g.
+    # `Glyph._reset_axes_for_restyle`, used by `apply_style`, or a
+    # caller's own `ax.clear()`) may already have removed one of these
+    # same artists before this marker was consulted -- matplotlib raises
+    # `KeyError` for a colorbar axes no longer on the figure's axes
+    # stack, or `NotImplementedError` for any other artist already
+    # detached from its axes, neither of which should stop this call's
+    # own render.
+    for artist in prior:
+        try:
+            artist.remove()
+        except (KeyError, NotImplementedError):
+            pass
+    ax._cleo_render_artists = None  # type: ignore[attr-defined]
+
+
+def _mark_render_artists(ax: Axes, *artists: Any) -> None:
+    """Record this render call's artists on `ax` for the next call's cleanup.
+
+    Args:
+        ax: The axes this call rendered onto.
+        *artists: The artists this call created, in the order they must be
+            removed on the next call (e.g. a colorbar before the image it
+            is attached to -- `Colorbar.remove()` reads
+            `self.mappable.axes` to restore the image axes' gridspec
+            position, which is only valid while the image artist is
+            still attached). `None` entries (an artist this call didn't
+            create, e.g. no colorbar when `add_colorbar=False`) are
+            dropped.
+    """
+    # `Axes` declares no such attribute -- this is a deliberate, private
+    # marker cleopatra stamps onto the caller's Axes object itself (not a
+    # cleopatra-owned type), matching the same
+    # # type: ignore[attr-defined] trade-off as
+    # `getattr(ax, "_cleo_render_artists", None)` in
+    # `_clear_prior_render_artists` above.
+    ax._cleo_render_artists = [  # type: ignore[attr-defined]
+        a for a in artists if a is not None
+    ]
+
+
 class Glyph:
     """Base class for cleopatra visualization glyphs.
 

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -147,15 +147,22 @@ def _clear_prior_render_artists(ax: Axes) -> None:
     # Each removal is best-effort: another code path (e.g.
     # `Glyph._reset_axes_for_restyle`, used by `apply_style`, or a
     # caller's own `ax.clear()`) may already have removed one of these
-    # same artists before this marker was consulted -- matplotlib raises
+    # same artists -- or, for a colorbar, only the *image* it is attached
+    # to -- before this marker was consulted. Matplotlib's failure mode
+    # varies by artist kind and by how much of it is already gone:
     # `KeyError` for a colorbar axes no longer on the figure's axes
-    # stack, or `NotImplementedError` for any other artist already
-    # detached from its axes, neither of which should stop this call's
-    # own render.
+    # stack, `NotImplementedError` for any other artist already detached
+    # from its axes, or `AttributeError` for a colorbar whose mappable
+    # was detached out from under it (`Colorbar.remove()` reads
+    # `self.mappable.axes`, which is `None` in that case, then calls
+    # `.set_subplotspec()` on it) -- e.g. exactly the `ax.clear()` case
+    # above, since `ax.clear()` detaches the image but leaves the
+    # colorbar's own (sibling) axes untouched. None of these should stop
+    # this call's own render.
     for artist in prior:
         try:
             artist.remove()
-        except (KeyError, NotImplementedError):
+        except (KeyError, NotImplementedError, AttributeError):
             pass
     ax._cleo_render_artists = None  # type: ignore[attr-defined]
 

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -1014,14 +1014,6 @@ class MeshGlyph(GeoMixin, Glyph):
         elif self.fig is None:
             self.fig, self.ax = self.create_figure_axes()
 
-        # See `_clear_prior_render_artists`: a prior `plot`/`animate`/
-        # `plot_outline` call on this Axes (this glyph's own, or a
-        # different glyph sharing it via `MeshGlyph(ax=..., fig=...)`)
-        # leaves its image/colorbar artists orphaned unless removed first.
-        _clear_prior_render_artists(self.ax)
-        self.im = None
-        self._cbar = None
-
         ticks = self.get_ticks()
         norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
 
@@ -1076,10 +1068,22 @@ class MeshGlyph(GeoMixin, Glyph):
                 raise ValueError(
                     "hillshade needs node-centered elevation; pass location='node'"
                 )
+            # See `_clear_prior_render_artists`: a prior `plot`/`animate`/
+            # `plot_outline` call on this Axes (this glyph's own, or a
+            # different glyph sharing it via `MeshGlyph(ax=..., fig=...)`)
+            # leaves its image/colorbar artists orphaned unless removed
+            # first. Deferred until here -- after every check above that can
+            # raise -- so a failed call leaves the previous render intact.
+            _clear_prior_render_artists(self.ax)
+            self.im = None
+            self._cbar = None
             tpc = self._render_shaded_relief(
                 self.ax, data, edgecolor, norm, hillshade, **render_kwargs
             )
         else:
+            _clear_prior_render_artists(self.ax)
+            self.im = None
+            self._cbar = None
             tpc = self._render_mesh(
                 self.ax,
                 data,
@@ -1241,14 +1245,6 @@ class MeshGlyph(GeoMixin, Glyph):
             self.fig, self.ax = self.create_figure_axes()
         fig, ax = self.fig, self.ax
 
-        # See `_clear_prior_render_artists`: a prior `plot`/`animate`/
-        # `plot_outline` call on this Axes (this glyph's own, or a
-        # different glyph sharing it) leaves its image/colorbar/
-        # frame-label artists orphaned unless removed first.
-        _clear_prior_render_artists(ax)
-        self.im = None
-        self._cbar = None
-
         ticks = self.get_ticks()
         norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
 
@@ -1256,6 +1252,16 @@ class MeshGlyph(GeoMixin, Glyph):
         # `self.contour_labels` by a previous `plot(labels=True)` call rather
         # than letting stale label artists leak into the animation state.
         self.contour_labels = None
+
+        # See `_clear_prior_render_artists`: a prior `plot`/`animate`/
+        # `plot_outline` call on this Axes (this glyph's own, or a
+        # different glyph sharing it) leaves its image/colorbar/
+        # frame-label artists orphaned unless removed first. Deferred until
+        # here -- after every check above that can raise -- so a failed call
+        # leaves the previous render intact.
+        _clear_prior_render_artists(ax)
+        self.im = None
+        self._cbar = None
 
         # Render the first frame.
         tpc = self._render_mesh(

--- a/src/cleopatra/mesh_glyph.py
+++ b/src/cleopatra/mesh_glyph.py
@@ -45,7 +45,7 @@ from cleopatra.colors import (
     resolve_style_norm,
 )
 from cleopatra.geo import GeoMixin
-from cleopatra.glyph import Glyph
+from cleopatra.glyph import Glyph, _clear_prior_render_artists, _mark_render_artists
 from cleopatra.hillshade import resolve_hillshade, shade_faces
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import disjoint_legend
@@ -169,6 +169,9 @@ class MeshGlyph(GeoMixin, Glyph):
         #: Colour-mapped artist from the most recent `plot` call (the
         #: `tripcolor`/`tricontour(f)` mappable); `None` before first render.
         self.im = None
+        #: Per-frame time-label `Text` artist from the most recent
+        #: `animate` call, if any; `None` before any `animate` call.
+        self._day_text = None
         #: Inline contour-label `Text` artists from the most recent
         #: `plot(location="node", filled=False, labels=True)`, or `None`
         #: when labelling was not requested (the default, and for
@@ -1011,6 +1014,14 @@ class MeshGlyph(GeoMixin, Glyph):
         elif self.fig is None:
             self.fig, self.ax = self.create_figure_axes()
 
+        # See `_clear_prior_render_artists`: a prior `plot`/`animate`/
+        # `plot_outline` call on this Axes (this glyph's own, or a
+        # different glyph sharing it via `MeshGlyph(ax=..., fig=...)`)
+        # leaves its image/colorbar artists orphaned unless removed first.
+        _clear_prior_render_artists(self.ax)
+        self.im = None
+        self._cbar = None
+
         ticks = self.get_ticks()
         norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
 
@@ -1103,11 +1114,6 @@ class MeshGlyph(GeoMixin, Glyph):
             }
             self.contour_labels = self.ax.clabel(tpc, **label_kw)
 
-        # Remove previous colorbar before adding a new one.
-        if self._cbar is not None:
-            self._cbar.remove()
-            self._cbar = None
-
         if colorbar:
             self._cbar = self.create_color_bar(self.ax, tpc, cbar_kw)
 
@@ -1125,6 +1131,7 @@ class MeshGlyph(GeoMixin, Glyph):
             )
         self.ax.set_aspect("equal")
 
+        _mark_render_artists(self.ax, self._cbar, self.im)
         return self.fig, self.ax
 
     def animate(
@@ -1234,6 +1241,14 @@ class MeshGlyph(GeoMixin, Glyph):
             self.fig, self.ax = self.create_figure_axes()
         fig, ax = self.fig, self.ax
 
+        # See `_clear_prior_render_artists`: a prior `plot`/`animate`/
+        # `plot_outline` call on this Axes (this glyph's own, or a
+        # different glyph sharing it) leaves its image/colorbar/
+        # frame-label artists orphaned unless removed first.
+        _clear_prior_render_artists(ax)
+        self.im = None
+        self._cbar = None
+
         ticks = self.get_ticks()
         norm, cbar_kw = self._create_norm_and_cbar_kw(ticks)
 
@@ -1250,7 +1265,8 @@ class MeshGlyph(GeoMixin, Glyph):
             edgecolor=edgecolor,
             norm=norm,
         )
-        self.create_color_bar(ax, tpc, cbar_kw)
+        self.im = tpc
+        self._cbar = self.create_color_bar(ax, tpc, cbar_kw)
 
         if self.default_options["title"]:
             ax.set_title(
@@ -1266,9 +1282,11 @@ class MeshGlyph(GeoMixin, Glyph):
             fontsize=self.default_options["cbar_label_size"],
             transform=ax.transAxes,
         )
+        self._day_text = day_text
 
         # Track the current mappable so we can remove it cleanly.
         current_mappable = [tpc]
+        _mark_render_artists(ax, self._cbar, self.im, self._day_text)
 
         def _update(i):
             """Update the plot for frame i."""
@@ -1286,6 +1304,14 @@ class MeshGlyph(GeoMixin, Glyph):
                 norm=norm,
             )
             day_text.set_text(str(time[i]))
+            # Keep the public `self.im` and the Axes-level cleanup marker
+            # pointing at the artist actually attached right now -- each
+            # frame replaces the previous mappable outright (tripcolor/
+            # tricontour can't update in place the way imshow can), so the
+            # frame-0 reference recorded further above goes stale the
+            # moment frame 1 renders.
+            self.im = current_mappable[0]
+            _mark_render_artists(ax, self._cbar, self.im, self._day_text)
 
         plt.tight_layout()
         anim = FuncAnimation(
@@ -1351,6 +1377,14 @@ class MeshGlyph(GeoMixin, Glyph):
         elif self.fig is None:
             self.fig, self.ax = plt.subplots(1, 1, figsize=figsize)
 
+        # See `_clear_prior_render_artists`: a prior `plot`/`animate`/
+        # `plot_outline` call on this Axes (this glyph's own, or a
+        # different glyph sharing it) leaves its image/colorbar/outline
+        # artists orphaned unless removed first.
+        _clear_prior_render_artists(self.ax)
+        self.im = None
+        self._cbar = None
+
         segments = self._build_edge_segments()
 
         lc = mcoll.LineCollection(
@@ -1360,9 +1394,10 @@ class MeshGlyph(GeoMixin, Glyph):
         self.ax.autoscale()
         self.ax.set_aspect("equal")
 
-        # An outline carries no scalar mapping, so clear any colour-mapped
-        # artist left on `self.im` by a previous `plot()` call.
-        self.im = None
+        # An outline carries no scalar mapping, so `self.im` stays `None`
+        # (already reset above); only the outline collection is tracked
+        # for the next call's cleanup.
+        _mark_render_artists(self.ax, lc)
 
         return self.fig, self.ax
 

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -543,12 +543,6 @@ class StatisticalGlyph:
         else:
             fig, ax = plt.subplots(figsize=self.default_options["figsize"])
 
-        # See `_clear_prior_render_artists`: a prior `histogram`/`boxplot`/
-        # `multiboxplot`/`stripes` call on this Axes (this glyph's own, or
-        # a different glyph sharing it via `StatisticalGlyph(ax=..., ...)`)
-        # leaves its bars/boxes orphaned unless removed first.
-        _clear_prior_render_artists(ax)
-
         n = []
         bins = []
         patches = []
@@ -564,6 +558,15 @@ class StatisticalGlyph:
                 )
         else:
             num_samples = 1
+
+        # See `_clear_prior_render_artists`: a prior `histogram`/`boxplot`/
+        # `multiboxplot`/`stripes` call on this Axes (this glyph's own, or
+        # a different glyph sharing it via `StatisticalGlyph(ax=..., ...)`)
+        # leaves its bars/boxes orphaned unless removed first. Deferred
+        # until here -- after the `color`/`num_samples` check above, this
+        # call's only validation that can raise -- so a failed call leaves
+        # the previous render intact.
+        _clear_prior_render_artists(ax)
 
         for i in range(num_samples):
             if self.values.ndim == 1:

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -66,6 +66,7 @@ from matplotlib.colors import Normalize
 from matplotlib.container import BarContainer
 from matplotlib.figure import Figure
 
+from cleopatra.glyph import _clear_prior_render_artists, _mark_render_artists
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 
 STATISTICAL_DEFAULT_OPTIONS = {
@@ -542,6 +543,12 @@ class StatisticalGlyph:
         else:
             fig, ax = plt.subplots(figsize=self.default_options["figsize"])
 
+        # See `_clear_prior_render_artists`: a prior `histogram`/`boxplot`/
+        # `multiboxplot`/`stripes` call on this Axes (this glyph's own, or
+        # a different glyph sharing it via `StatisticalGlyph(ax=..., ...)`)
+        # leaves its bars/boxes orphaned unless removed first.
+        _clear_prior_render_artists(ax)
+
         n = []
         bins = []
         patches = []
@@ -587,6 +594,7 @@ class StatisticalGlyph:
         ax.tick_params(axis="x", labelsize=self.default_options["xtick_font_size"])
         ax.tick_params(axis="y", labelsize=self.default_options["ytick_font_size"])
         hist = {"n": n, "bins": bins, "patches": patches}
+        _mark_render_artists(ax, *patches)
         return fig, ax, hist
 
     @staticmethod
@@ -709,6 +717,11 @@ class StatisticalGlyph:
         """
         self._reject_fig_kwarg(kwargs)
         fig, ax = self._resolve_fig_ax(ax)
+        # See `_clear_prior_render_artists`: a prior `histogram`/`boxplot`/
+        # `multiboxplot`/`stripes` call on this Axes (this glyph's own, or
+        # a different glyph sharing it) leaves its bars/boxes orphaned
+        # unless removed first.
+        _clear_prior_render_artists(ax)
         columns = self._columns()
         tick_labels = (
             list(labels)
@@ -738,6 +751,7 @@ class StatisticalGlyph:
             box.set_alpha(self.default_options["alpha"])
         ax.grid(axis="y", alpha=self.default_options["grid_alpha"])
         self._apply_axis_labels(ax)
+        _mark_render_artists(ax, *(a for artists in bp.values() for a in artists))
         return fig, ax, bp
 
     def multiboxplot(
@@ -812,6 +826,11 @@ class StatisticalGlyph:
             )
 
         fig, ax = self._resolve_fig_ax(ax)
+        # See `_clear_prior_render_artists`: a prior `histogram`/`boxplot`/
+        # `multiboxplot`/`stripes` call on this Axes (this glyph's own, or
+        # a different glyph sharing it) leaves its bars/boxes orphaned
+        # unless removed first.
+        _clear_prior_render_artists(ax)
         bp = ax.boxplot(
             columns,
             positions=list(positions),
@@ -829,6 +848,7 @@ class StatisticalGlyph:
         )
         ax.grid(axis="y", alpha=self.default_options["grid_alpha"])
         self._apply_axis_labels(ax)
+        _mark_render_artists(ax, *(a for artists in bp.values() for a in artists))
         return fig, ax, bp
 
     def stripes(
@@ -882,6 +902,11 @@ class StatisticalGlyph:
         if values.ndim != 1:
             raise ValueError(f"stripes requires 1D values; got {values.ndim}D.")
         fig, ax = self._resolve_fig_ax(ax)
+        # See `_clear_prior_render_artists`: a prior `histogram`/`boxplot`/
+        # `multiboxplot`/`stripes` call on this Axes (this glyph's own, or
+        # a different glyph sharing it) leaves its bars/boxes orphaned
+        # unless removed first.
+        _clear_prior_render_artists(ax)
         cmap = cmap if cmap is not None else self.default_options["cmap"]
         cmap_obj = mpl.colormaps[cmap] if isinstance(cmap, str) else cmap
         lo = float(np.nanmin(values)) if vmin is None else vmin
@@ -898,4 +923,5 @@ class StatisticalGlyph:
         ax.set_yticks([])
         ax.set_xlim(-0.5, values.size - 0.5)
         self._apply_axis_labels(ax)
+        _mark_render_artists(ax, bars)
         return fig, ax, bars

--- a/src/cleopatra/statistical_glyph.py
+++ b/src/cleopatra/statistical_glyph.py
@@ -430,24 +430,24 @@ class StatisticalGlyph:
             ValueError: If an invalid keyword argument is provided.
             ValueError: If the number of colors provided doesn't match the number of data series
                 (columns) in 2D data.
-            ValueError: If a ``fig`` was supplied without an ``ax`` and that figure already
-                contains axes (pass the target ``ax`` explicitly in that case).
+            ValueError: If a `fig` was supplied without an `ax` and that figure already
+                contains axes (pass the target `ax` explicitly in that case).
 
         Notes:
             For 2D data, multiple histograms will be overlaid on the same plot with
             different colors. The transparency (alpha) can be adjusted to make overlapping
             regions visible.
 
-            The figure and axes used depend on what was passed to ``__init__``:
+            The figure and axes used depend on what was passed to `__init__`:
 
-            - ``ax`` given: the histogram is drawn into that axes; the returned
-              figure is the one explicitly passed as ``fig`` if any, otherwise
+            - `ax` given: the histogram is drawn into that axes; the returned
+              figure is the one explicitly passed as `fig` if any, otherwise
               the axes' own parent figure.
-            - ``fig`` given without ``ax``: a new axes is added to that figure
+            - `fig` given without `ax`: a new axes is added to that figure
               and used for drawing (the figure is reused, not replaced). The
-              figure must be empty; if it already contains axes a ``ValueError``
-              is raised so the caller passes the target ``ax`` explicitly.
-            - neither given: a new figure and axes are created with ``figsize``.
+              figure must be empty; if it already contains axes a `ValueError`
+              is raised so the caller passes the target `ax` explicitly.
+            - neither given: a new figure and axes are created with `figsize`.
 
         Examples:
             - 1D data.

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -34,7 +34,7 @@ from matplotlib.figure import Figure
 from matplotlib.quiver import QuiverKey
 
 from cleopatra.geo import GeoMixin
-from cleopatra.glyph import Glyph
+from cleopatra.glyph import Glyph, _clear_prior_render_artists, _mark_render_artists
 from cleopatra.styles import CLASSIFY_OPTIONS
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 
@@ -119,6 +119,9 @@ class VectorGlyph(GeoMixin, Glyph):
                 f"and {self.v.shape}."
             )
         self.cbar = None
+        #: The `Quiver`/`Barbs`/streamplot `LineCollection` mappable from
+        #: the most recent `plot` call; `None` before first render.
+        self.im = None
 
     @property
     def magnitude(self) -> np.ndarray:
@@ -203,6 +206,14 @@ class VectorGlyph(GeoMixin, Glyph):
         ax = self.ax
         opts = self.default_options
 
+        # See `_clear_prior_render_artists`: a prior `plot` call on this
+        # Axes (this glyph's own, or a different glyph sharing it via
+        # `VectorGlyph(ax=..., fig=...)`) leaves its mappable/colorbar
+        # orphaned unless removed first.
+        _clear_prior_render_artists(ax)
+        self.im = None
+        self.cbar = None
+
         if title is not None:
             opts["title"] = title
         # Resolve the colorbar choice for this call only (a plot-time
@@ -214,6 +225,7 @@ class VectorGlyph(GeoMixin, Glyph):
         cmap = opts["cmap"]
         clim = {} if norm else {"clim": (ticks[0], ticks[-1])}
 
+        arrow_patches: tuple = ()
         if kind == "quiver":
             im = ax.quiver(
                 self.x,
@@ -238,6 +250,15 @@ class VectorGlyph(GeoMixin, Glyph):
                 **clim,
             )
         else:  # streamplot
+            # `stream.arrows` (a `PatchCollection`) is never actually
+            # attached to the axes -- matplotlib adds each constituent
+            # `FancyArrowPatch` directly via `ax.add_patch()` instead (its
+            # own source comment: "Adding the collection itself is
+            # broken; see #2341"), so `stream.arrows.remove()` raises
+            # `NotImplementedError` and leaves the arrowheads behind.
+            # Diff `ax.patches` before/after to find the actual arrow
+            # artists that were added, so a later cleanup can remove them.
+            patches_before = set(ax.patches)
             stream = ax.streamplot(
                 self.x,
                 self.y,
@@ -248,6 +269,7 @@ class VectorGlyph(GeoMixin, Glyph):
                 norm=norm,
                 density=opts["density"],
             )
+            arrow_patches = tuple(set(ax.patches) - patches_before)
             im = stream.lines
             if im.get_array() is None:
                 im.set_array(np.asarray(mag).ravel())
@@ -257,12 +279,14 @@ class VectorGlyph(GeoMixin, Glyph):
             if norm is None:
                 im.set_clim(ticks[0], ticks[-1])
 
+        self.im = im
         if draw_colorbar:
             self.cbar = self.create_color_bar(ax, im, cbar_kw)
 
         if opts["title"]:
             ax.set_title(opts["title"], fontsize=opts["title_size"])
 
+        _mark_render_artists(ax, self.cbar, self.im, *arrow_patches)
         return self.fig, ax, im
 
     def add_key(

--- a/src/cleopatra/vector_glyph.py
+++ b/src/cleopatra/vector_glyph.py
@@ -206,14 +206,6 @@ class VectorGlyph(GeoMixin, Glyph):
         ax = self.ax
         opts = self.default_options
 
-        # See `_clear_prior_render_artists`: a prior `plot` call on this
-        # Axes (this glyph's own, or a different glyph sharing it via
-        # `VectorGlyph(ax=..., fig=...)`) leaves its mappable/colorbar
-        # orphaned unless removed first.
-        _clear_prior_render_artists(ax)
-        self.im = None
-        self.cbar = None
-
         if title is not None:
             opts["title"] = title
         # Resolve the colorbar choice for this call only (a plot-time
@@ -224,6 +216,17 @@ class VectorGlyph(GeoMixin, Glyph):
         norm, cbar_kw, ticks = self._prepare_scalar_mapping(mag)
         cmap = opts["cmap"]
         clim = {} if norm else {"clim": (ticks[0], ticks[-1])}
+
+        # See `_clear_prior_render_artists`: a prior `plot` call on this
+        # Axes (this glyph's own, or a different glyph sharing it via
+        # `VectorGlyph(ax=..., fig=...)`) leaves its mappable/colorbar
+        # orphaned unless removed first. Deferred until here -- after
+        # `_prepare_scalar_mapping` (the call's only validation that can
+        # raise) succeeds -- so a failed call leaves the previous render
+        # intact.
+        _clear_prior_render_artists(ax)
+        self.im = None
+        self.cbar = None
 
         arrow_patches: tuple = ()
         if kind == "quiver":

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -1794,6 +1794,122 @@ class TestPlotIdempotenceAndPurity:
         assert len(ax2.collections) >= 1
 
 
+class TestSharedAxesArtistCleanup:
+    """`plot`/`animate` must not stack image/colorbar artists on a shared `Axes`.
+
+    Regression coverage for issue #210, generalised beyond `animate()`:
+    the same orphaned-artist defect exists in `plot()`, and in every
+    `plot()`/`animate()` combination, reachable through the documented
+    `ArrayGlyph(ax=..., fig=...)` construction-time binding that
+    pyramids' `Dataset`/`NetCDF`/`Analysis`/`UgridDataset`.plot(ax=...,
+    fig=...) passthrough exposes.
+    """
+
+    def test_replot_same_axes_without_reset_does_not_stack_image(self):
+        """`plot()` called twice on the same glyph, same axes, replaces the image.
+
+        Test scenario:
+            Unlike `test_replot_same_kind_does_not_raise` above, this does
+            NOT reset `glyph.fig`/`glyph.ax` between calls -- exactly the
+            case that used to accumulate artists.
+        """
+        arr = np.arange(25, dtype=float).reshape(5, 5)
+        glyph = ArrayGlyph(arr)
+        glyph.plot()
+        old_im = glyph.im
+        glyph.plot()
+        assert (
+            len(glyph.ax.images) == 1
+        ), f"Expected exactly one image artist, got {len(glyph.ax.images)}"
+        assert old_im not in glyph.ax.images, "The first call's image must be removed"
+
+    def test_two_glyphs_sharing_axes_via_plot_do_not_stack_image_artists(self):
+        """A second, different glyph's `plot()` onto a shared axes still cleans up.
+
+        Test scenario:
+            `ArrayGlyph(arr2, ax=glyph1.ax, fig=glyph1.fig)` -- the
+            `ax=`/`fig=` passthrough pyramids' `Dataset`/`NetCDF`/
+            `Analysis`.plot(ax=..., fig=...) exposes -- lets a *second*,
+            independently constructed glyph plot onto the same axes as a
+            first. Checking only `self.im`/`self.cbar` (both fresh `None`
+            on the new instance) would miss the first glyph's leftover
+            image; cleanup must be tracked per-axes.
+        """
+        glyph1 = ArrayGlyph(np.random.default_rng(0).random((8, 8)))
+        glyph1.plot()
+        old_im = glyph1.im
+        axes_count_after_first = len(glyph1.fig.axes)
+
+        glyph2 = ArrayGlyph(
+            np.random.default_rng(1).random((8, 8)), ax=glyph1.ax, fig=glyph1.fig
+        )
+        glyph2.plot()
+
+        assert (
+            len(glyph1.ax.images) == 1
+        ), f"Expected exactly one image artist, got {len(glyph1.ax.images)}"
+        assert old_im not in glyph1.ax.images, "The first glyph's image must be removed"
+        assert len(glyph1.fig.axes) == axes_count_after_first, (
+            f"Expected {axes_count_after_first} axes after the second glyph's call, "
+            f"got {len(glyph1.fig.axes)}"
+        )
+
+    def test_plot_then_animate_on_shared_axes_does_not_stack(
+        self, animate_time_list: list
+    ):
+        """A second glyph's `animate()` cleans up a first glyph's `plot()` image."""
+        glyph1 = ArrayGlyph(np.random.default_rng(0).random((8, 8)))
+        glyph1.plot()
+        old_im = glyph1.im
+
+        glyph2 = ArrayGlyph(
+            np.random.default_rng(0).random((3, 8, 8)), ax=glyph1.ax, fig=glyph1.fig
+        )
+        glyph2.animate(animate_time_list)
+
+        assert (
+            len(glyph1.ax.images) == 1
+        ), f"Expected exactly one image artist, got {len(glyph1.ax.images)}"
+        assert old_im not in glyph1.ax.images, "The first call's image must be removed"
+
+    def test_animate_then_plot_on_shared_axes_does_not_stack(
+        self, animate_time_list: list
+    ):
+        """A second glyph's `plot()` cleans up a first glyph's `animate()` image."""
+        glyph1 = ArrayGlyph(np.random.default_rng(0).random((3, 8, 8)))
+        glyph1.animate(animate_time_list)
+        old_im = glyph1.im
+
+        glyph2 = ArrayGlyph(
+            np.random.default_rng(0).random((8, 8)), ax=glyph1.ax, fig=glyph1.fig
+        )
+        glyph2.plot()
+
+        assert (
+            len(glyph1.ax.images) == 1
+        ), f"Expected exactly one image artist, got {len(glyph1.ax.images)}"
+        assert old_im not in glyph1.ax.images, "The first call's image must be removed"
+
+    def test_apply_style_after_plot_does_not_raise(self):
+        """`apply_style()` after a plain `plot()` cleans up without crashing.
+
+        Test scenario:
+            Regression for an interaction bug hit while building the
+            shared-axes cleanup: `apply_style()` calls
+            `Glyph._reset_axes_for_restyle()`, which already removes the
+            previous colorbar/artists itself before `plot()` runs -- the
+            shared-axes cleanup must tolerate an already-removed artist
+            (matplotlib raises `KeyError`/`NotImplementedError` for that)
+            rather than crashing on the second removal attempt.
+        """
+        glyph = ArrayGlyph(np.abs(np.random.default_rng(0).normal(size=(20, 20))))
+        glyph.plot()
+        fig, ax = glyph.apply_style("flow_accumulation")
+        assert (
+            len(ax.images) == 1
+        ), f"Expected exactly one image artist, got {len(ax.images)}"
+
+
 @pytest.mark.plot
 class TestPlotRoundTripSavefig:
     """Round-trip test: rendered figure -> savefig -> non-empty PNG file."""

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -1947,6 +1947,82 @@ class TestSharedAxesArtistCleanup:
             len(glyph.ax.images) == 1
         ), f"Expected one image, got {len(glyph.ax.images)}"
 
+    def test_repeated_plot_display_cell_value_does_not_stack_texts(self):
+        """A second `plot(display_cell_value=True)` call replaces the cell-value texts.
+
+        Test scenario:
+            Regression: only the colorbar/image were tracked by the
+            shared-axes cleanup; the per-cell value `Text` artists
+            (`_plot_text`) were not, so they doubled on a second call.
+        """
+        arr = np.arange(100.0).reshape(10, 10)
+        glyph = ArrayGlyph(arr)
+        glyph.plot(display_cell_value=True)
+        texts_after_first = len(glyph.ax.texts)
+        glyph.plot(display_cell_value=True)
+        assert len(glyph.ax.texts) == texts_after_first, (
+            f"Expected {texts_after_first} cell-value texts after the second call, "
+            f"got {len(glyph.ax.texts)}"
+        )
+
+    def test_repeated_plot_with_points_does_not_stack_overlay(self):
+        """A second `plot(points=...)` call replaces the scatter/label overlay.
+
+        Test scenario:
+            Regression: only the colorbar/image were tracked by the
+            shared-axes cleanup; the point-overlay scatter
+            (`ax.scatter`) and per-point value labels
+            (`_plot_point_values`) were not, so both doubled on a
+            second call.
+        """
+        arr = np.arange(25.0).reshape(5, 5)
+        points = np.array([[5.0, 1, 1], [6.0, 2, 2]])
+        glyph = ArrayGlyph(arr)
+        glyph.plot(points=points)
+        collections_after_first = len(glyph.ax.collections)
+        texts_after_first = len(glyph.ax.texts)
+        glyph.plot(points=points)
+        assert len(glyph.ax.collections) == collections_after_first, (
+            f"Expected {collections_after_first} scatter collections after the "
+            f"second call, got {len(glyph.ax.collections)}"
+        )
+        assert len(glyph.ax.texts) == texts_after_first, (
+            f"Expected {texts_after_first} point-label texts after the second "
+            f"call, got {len(glyph.ax.texts)}"
+        )
+
+    def test_repeated_animate_display_cell_value_does_not_stack_texts(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A second `animate(display_cell_value=True)` call replaces the cell-value texts."""
+        glyph = ArrayGlyph(coello_data)
+        glyph.animate(animate_time_list, display_cell_value=True)
+        texts_after_first = len(glyph.ax.texts)
+        glyph.animate(animate_time_list, display_cell_value=True)
+        assert len(glyph.ax.texts) == texts_after_first, (
+            f"Expected {texts_after_first} texts after the second call, "
+            f"got {len(glyph.ax.texts)}"
+        )
+
+    def test_repeated_animate_with_points_does_not_stack_overlay(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A second `animate(points=...)` call replaces the scatter/label overlay."""
+        points = np.array([[5.0, 1, 1], [6.0, 2, 2]])
+        glyph = ArrayGlyph(coello_data)
+        glyph.animate(animate_time_list, points=points)
+        collections_after_first = len(glyph.ax.collections)
+        texts_after_first = len(glyph.ax.texts)
+        glyph.animate(animate_time_list, points=points)
+        assert len(glyph.ax.collections) == collections_after_first, (
+            f"Expected {collections_after_first} scatter collections after the "
+            f"second call, got {len(glyph.ax.collections)}"
+        )
+        assert len(glyph.ax.texts) == texts_after_first, (
+            f"Expected {texts_after_first} texts after the second call, "
+            f"got {len(glyph.ax.texts)}"
+        )
+
 
 @pytest.mark.plot
 class TestPlotRoundTripSavefig:

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -1876,6 +1876,88 @@ class TestAnimateEdgeCases:
                 lambda i: coello_data,
             )
 
+    def test_repeated_call_replaces_not_stacks_image_artist(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A second `animate()` call on the same glyph replaces `self.im`, not stacks it.
+
+        Test scenario:
+            Regression for issue #210: a caller re-animating a glyph that
+            already went through `animate()` once (e.g. a downstream
+            consumer's helper that internally calls `animate()`, followed
+            by the caller's own `animate()` call) left the first call's
+            image artist orphaned in `ax.images` -- `ax.imshow()` always
+            adds a new artist rather than replacing one, and nothing
+            removed the old one once `self.im` moved on to the new call's
+            artist. Only one image artist must remain, and it must not be
+            the first call's.
+        """
+        glyph = ArrayGlyph(coello_data)
+        glyph.animate(animate_time_list)
+        old_im = glyph.im
+        glyph.animate(animate_time_list)
+        assert (
+            len(glyph.ax.images) == 1
+        ), f"Expected exactly one image artist, got {len(glyph.ax.images)}"
+        assert old_im not in glyph.ax.images, "The first call's image must be removed"
+        assert glyph.im is not old_im, "self.im must point at the second call's artist"
+
+    def test_repeated_call_on_rgb_stack_replaces_image_artist(self, animate_time_list):
+        """The same replace-not-stack guarantee holds for the RGB/true-colour path.
+
+        Test scenario:
+            The originally reported freeze used a 4-D RGB stack, going
+            through `animate()`'s `rgb_frames` branch (`ax.imshow(frame_0,
+            extent=self.extent)`) rather than the scalar/colormap branch --
+            confirm the same cleanup applies there too.
+        """
+        colours = [(255, 0, 0), (0, 255, 0), (0, 0, 255)]
+        stack = np.stack([np.full((5, 5, 3), c, dtype="uint8") for c in colours])
+        glyph = ArrayGlyph(stack)
+        glyph.animate(animate_time_list)
+        old_im = glyph.im
+        glyph.animate(animate_time_list)
+        assert (
+            len(glyph.ax.images) == 1
+        ), f"Expected exactly one image artist, got {len(glyph.ax.images)}"
+        assert old_im not in glyph.ax.images, "The first call's image must be removed"
+
+    def test_repeated_call_replaces_not_stacks_colorbar(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A second `animate()` call replaces the colorbar axes, not adds another.
+
+        Test scenario:
+            `self.cbar = None` before creating a new colorbar only drops
+            the Python reference -- it does not remove the previous
+            `Colorbar`'s own axes from the figure. Confirm `fig.axes`
+            count stays stable (main axes + one colorbar axes) across
+            repeated calls, not growing by one colorbar axes each time.
+        """
+        glyph = ArrayGlyph(coello_data)
+        glyph.animate(animate_time_list)
+        axes_count_after_first = len(glyph.fig.axes)
+        glyph.animate(animate_time_list)
+        assert len(glyph.fig.axes) == axes_count_after_first, (
+            f"Expected {axes_count_after_first} axes after the second call, "
+            f"got {len(glyph.fig.axes)}"
+        )
+
+    def test_repeated_call_replaces_not_stacks_frame_label_text(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A second `animate()` call replaces the frame-label text, not adds another."""
+        glyph = ArrayGlyph(coello_data)
+        glyph.animate(animate_time_list)
+        old_day_text = glyph._day_text
+        glyph.animate(animate_time_list)
+        assert (
+            len(glyph.ax.texts) == 1
+        ), f"Expected exactly one frame-label text, got {len(glyph.ax.texts)}"
+        assert (
+            old_day_text not in glyph.ax.texts
+        ), "The first call's label must be removed"
+
 
 @pytest.mark.plot
 class TestNanNoDataConvention:

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2058,6 +2058,29 @@ class TestSharedAxesArtistCleanup:
             len(glyph.fig.axes) == axes_count
         ), f"Expected {axes_count} axes preserved, got {len(glyph.fig.axes)}"
 
+    def test_animate_validation_failure_preserves_im_and_cbar_attributes(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A failed `animate()` call must not reset `self.im`/`self.cbar` to `None`.
+
+        Test scenario:
+            Regression: an early, unconditional `self.im = None; self.cbar
+            = None; self._day_text = None` ran before the color_scale/norm
+            validation that can raise, so a caught exception left these
+            documented public attributes `None` even though the previous
+            image was still visibly attached to the axes.
+        """
+        glyph = ArrayGlyph(coello_data)
+        glyph.animate(animate_time_list)
+        old_im, old_cbar, old_day_text = glyph.im, glyph.cbar, glyph._day_text
+        with pytest.raises(ValueError):
+            glyph.animate(animate_time_list, color_scale="not-a-real-scale")
+        assert glyph.im is old_im, "self.im must still reference the prior render"
+        assert glyph.cbar is old_cbar, "self.cbar must still reference the prior render"
+        assert (
+            glyph._day_text is old_day_text
+        ), "self._day_text must still reference the prior render"
+
 
 @pytest.mark.plot
 class TestPlotRoundTripSavefig:

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2023,6 +2023,41 @@ class TestSharedAxesArtistCleanup:
             f"got {len(glyph.ax.texts)}"
         )
 
+    def test_plot_validation_failure_preserves_prior_render(self):
+        """A failed `plot()` call must not tear down the previous valid render.
+
+        Test scenario:
+            Regression: `_clear_prior_render_artists` used to run before
+            the new call's inputs were validated, so a bad `color_scale`
+            destroyed the last-good chart along with propagating the
+            `ValueError`.
+        """
+        arr = np.arange(25.0).reshape(5, 5)
+        glyph = ArrayGlyph(arr)
+        fig, ax = glyph.plot()
+        axes_count = len(fig.axes)
+        with pytest.raises(ValueError):
+            glyph.plot(color_scale="not-a-real-scale")
+        assert len(ax.images) == 1, f"Expected the prior image, got {len(ax.images)}"
+        assert (
+            len(fig.axes) == axes_count
+        ), f"Expected {axes_count} axes preserved, got {len(fig.axes)}"
+
+    def test_animate_validation_failure_preserves_prior_render(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A failed `animate()` call must not tear down the previous valid render."""
+        glyph = ArrayGlyph(coello_data)
+        glyph.animate(animate_time_list)
+        ax = glyph.ax
+        axes_count = len(glyph.fig.axes)
+        with pytest.raises(ValueError):
+            glyph.animate(animate_time_list, color_scale="not-a-real-scale")
+        assert len(ax.images) == 1, f"Expected the prior image, got {len(ax.images)}"
+        assert (
+            len(glyph.fig.axes) == axes_count
+        ), f"Expected {axes_count} axes preserved, got {len(glyph.fig.axes)}"
+
 
 @pytest.mark.plot
 class TestPlotRoundTripSavefig:

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -1909,6 +1909,44 @@ class TestSharedAxesArtistCleanup:
             len(ax.images) == 1
         ), f"Expected exactly one image artist, got {len(ax.images)}"
 
+    def test_ax_clear_before_replot_does_not_raise(self):
+        """A caller's own `ax.clear()` before the next `plot()` call doesn't crash.
+
+        Test scenario:
+            Regression: `ax.clear()` detaches the image but leaves the
+            colorbar's own (sibling) axes untouched, since a colorbar
+            lives on a separate `Axes` that `ax.clear()` never reaches.
+            The next `plot()` call's cleanup then tried to remove that
+            colorbar via a mappable whose `.axes` was already `None` --
+            `Colorbar.remove()` reads `self.mappable.axes` and calls
+            `.set_subplotspec()` on it, raising `AttributeError` instead
+            of the `KeyError`/`NotImplementedError` the cleanup already
+            tolerated. `ax.clear()` is an ordinary matplotlib idiom (an
+            interactive-update/GUI-refresh pattern), so it must not crash
+            the next render.
+        """
+        glyph = ArrayGlyph(np.arange(25.0).reshape(5, 5))
+        fig, ax = glyph.plot()
+        ax.clear()
+        fig2, ax2 = glyph.plot()
+        assert len(ax2.images) == 1, f"Expected one image, got {len(ax2.images)}"
+        assert (
+            len(fig2.axes) == 2
+        ), f"Expected 2 axes (plot + colorbar), got {len(fig2.axes)}"
+
+    def test_ax_clear_before_re_animate_does_not_raise(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A caller's own `ax.clear()` before the next `animate()` call doesn't crash."""
+        glyph = ArrayGlyph(coello_data)
+        glyph.animate(animate_time_list)
+        glyph.ax.clear()
+        anim = glyph.animate(animate_time_list)
+        assert anim is not None
+        assert (
+            len(glyph.ax.images) == 1
+        ), f"Expected one image, got {len(glyph.ax.images)}"
+
 
 @pytest.mark.plot
 class TestPlotRoundTripSavefig:

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -1958,6 +1958,38 @@ class TestAnimateEdgeCases:
             old_day_text not in glyph.ax.texts
         ), "The first call's label must be removed"
 
+    def test_two_glyphs_sharing_one_axes_do_not_stack_image_artists(
+        self, coello_data: np.ndarray, animate_time_list: list
+    ):
+        """A second, *different* glyph animating onto a shared axes still cleans up.
+
+        Test scenario:
+            Regression for issue #210's underlying bug class, generalised:
+            `ArrayGlyph(arr2, ax=glyph1.ax, fig=glyph1.fig)` -- the
+            `ax=`/`fig=` passthrough pyramids' `Dataset`/`NetCDF`/
+            `Analysis`.plot(ax=..., fig=...) exposes -- lets a *second*,
+            independently constructed glyph animate onto the same Axes as
+            a first. Checking only `self.im`/`self.cbar` (both fresh
+            `None` on the new instance) would miss the first glyph's
+            leftover image; cleanup must be tracked per-Axes.
+        """
+        glyph1 = ArrayGlyph(coello_data)
+        glyph1.animate(animate_time_list)
+        old_im = glyph1.im
+        axes_count_after_first = len(glyph1.fig.axes)
+
+        glyph2 = ArrayGlyph(coello_data, ax=glyph1.ax, fig=glyph1.fig)
+        glyph2.animate(animate_time_list)
+
+        assert (
+            len(glyph1.ax.images) == 1
+        ), f"Expected exactly one image artist, got {len(glyph1.ax.images)}"
+        assert old_im not in glyph1.ax.images, "The first glyph's image must be removed"
+        assert len(glyph1.fig.axes) == axes_count_after_first, (
+            f"Expected {axes_count_after_first} axes after the second glyph's call, "
+            f"got {len(glyph1.fig.axes)}"
+        )
+
 
 @pytest.mark.plot
 class TestNanNoDataConvention:

--- a/tests/test_glyph.py
+++ b/tests/test_glyph.py
@@ -18,7 +18,13 @@ from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure
 
 import cleopatra.glyph as glyph_mod
-from cleopatra.glyph import MAX_DISCRETE_LEVELS, SUPPORTED_VIDEO_FORMAT, Glyph
+from cleopatra.glyph import (
+    MAX_DISCRETE_LEVELS,
+    SUPPORTED_VIDEO_FORMAT,
+    Glyph,
+    _clear_prior_render_artists,
+    _mark_render_artists,
+)
 from cleopatra.styles import DEFAULT_OPTIONS as STYLE_DEFAULTS
 from cleopatra.styles import ColorScale, MidpointNormalize
 
@@ -1553,3 +1559,98 @@ class TestGetTicksDegenerateRange:
             8.0,
             10.0,
         ], "ticks changed"
+
+
+class TestClearAndMarkRenderArtists:
+    """Direct unit tests for the shared render-artist cleanup helpers.
+
+    Regression coverage for review finding L1 (issue #210): these helpers
+    were previously only exercised indirectly through each glyph's
+    `plot()`/`animate()` integration tests.
+    """
+
+    @staticmethod
+    def _dummy_artist(remove_error: type[Exception] | None = None):
+        """Build a bare object with a `.remove()` that succeeds or raises `remove_error`."""
+
+        class _Artist:
+            def __init__(self):
+                self.removed = False
+
+            def remove(self):
+                if remove_error is not None:
+                    raise remove_error("boom")
+                self.removed = True
+
+        return _Artist()
+
+    def test_clear_on_axes_without_marker_is_a_no_op(self):
+        """No `_cleo_render_artists` marker set means nothing happens, no raise."""
+        fig, ax = plt.subplots()
+        try:
+            _clear_prior_render_artists(ax)
+            assert getattr(ax, "_cleo_render_artists", None) is None
+        finally:
+            plt.close(fig)
+
+    def test_mark_stores_artists_and_filters_none(self):
+        """`_mark_render_artists` stores the given artists, dropping `None` entries."""
+        fig, ax = plt.subplots()
+        try:
+            a1, a2 = self._dummy_artist(), self._dummy_artist()
+            _mark_render_artists(ax, a1, None, a2)
+            assert ax._cleo_render_artists == [a1, a2]
+        finally:
+            plt.close(fig)
+
+    def test_clear_removes_marked_artists_and_resets_marker(self):
+        """`_clear_prior_render_artists` removes every marked artist and clears the marker."""
+        fig, ax = plt.subplots()
+        try:
+            a1, a2 = self._dummy_artist(), self._dummy_artist()
+            _mark_render_artists(ax, a1, a2)
+            _clear_prior_render_artists(ax)
+            assert a1.removed and a2.removed, "both artists must be removed"
+            assert ax._cleo_render_artists is None
+        finally:
+            plt.close(fig)
+
+    @pytest.mark.parametrize("error", [KeyError, NotImplementedError, AttributeError])
+    def test_clear_tolerates_already_removed_artist(self, error):
+        """A `.remove()` failure from an already-partially-removed artist doesn't stop cleanup.
+
+        Test scenario:
+            Locks in H1's fix: matplotlib raises a different exception type
+            depending on how much of the artist is already detached
+            (`KeyError` for a colorbar axes off the figure's axes stack,
+            `NotImplementedError` for any other artist already detached,
+            `AttributeError` for a colorbar whose mappable was detached out
+            from under it). All three must be swallowed, and the other
+            marked artist must still be removed.
+        """
+        fig, ax = plt.subplots()
+        try:
+            bad = self._dummy_artist(remove_error=error)
+            good = self._dummy_artist()
+            _mark_render_artists(ax, bad, good)
+            _clear_prior_render_artists(ax)
+            assert good.removed, "the other artist must still be removed"
+            assert ax._cleo_render_artists is None
+        finally:
+            plt.close(fig)
+
+    def test_clear_propagates_unexpected_exception_types(self):
+        """An exception outside the tolerated set is not swallowed.
+
+        Test scenario:
+            Guards the narrow scope of the tolerated exception set --
+            `_clear_prior_render_artists` must not turn into a blanket
+            `except Exception: pass` that would hide genuine bugs.
+        """
+        fig, ax = plt.subplots()
+        try:
+            _mark_render_artists(ax, self._dummy_artist(remove_error=RuntimeError))
+            with pytest.raises(RuntimeError):
+                _clear_prior_render_artists(ax)
+        finally:
+            plt.close(fig)

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1367,6 +1367,43 @@ class TestSharedAxesArtistCleanup:
             len(fig2.axes) == 2
         ), f"Expected 2 axes (plot + colorbar), got {len(fig2.axes)}"
 
+    def test_plot_validation_failure_preserves_prior_render(self):
+        """A failed `plot()` call must not tear down the previous valid render.
+
+        Test scenario:
+            Regression: `_clear_prior_render_artists` used to run before
+            the new call's inputs were validated, so a bad `color_scale`
+            destroyed the last-good chart along with propagating the
+            `ValueError`.
+        """
+        mg = _make_tri_mg()
+        fig, ax = mg.plot(np.array([1.0, 2.0]))
+        axes_count = len(fig.axes)
+        with pytest.raises(ValueError):
+            mg.plot(np.array([1.0, 2.0]), color_scale="not-a-real-scale")
+        assert (
+            len(ax.collections) == 1
+        ), f"Expected the prior mesh artist, got {len(ax.collections)}"
+        assert (
+            len(fig.axes) == axes_count
+        ), f"Expected {axes_count} axes preserved, got {len(fig.axes)}"
+
+    def test_animate_validation_failure_preserves_prior_render(self):
+        """A failed `animate()` call must not tear down the previous valid render."""
+        mg = _make_tri_mg()
+        frames = np.array([[1.0, 2.0], [3.0, 4.0]])
+        mg.animate(frames, time=["t0", "t1"])
+        ax = mg.ax
+        axes_count = len(mg.fig.axes)
+        with pytest.raises(ValueError):
+            mg.animate(frames, time=["t0", "t1"], color_scale="not-a-real-scale")
+        assert (
+            len(ax.collections) == 1
+        ), f"Expected the prior mesh artist, got {len(ax.collections)}"
+        assert (
+            len(mg.fig.axes) == axes_count
+        ), f"Expected {axes_count} axes preserved, got {len(mg.fig.axes)}"
+
 
 class TestAnimate:
     """Tests for MeshGlyph.animate()."""

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1342,6 +1342,31 @@ class TestSharedAxesArtistCleanup:
             len(ax.collections) == 1
         ), f"Expected exactly one mesh artist, got {len(ax.collections)}"
 
+    def test_ax_clear_before_replot_does_not_raise(self):
+        """A caller's own `ax.clear()` before the next `plot()` call doesn't crash.
+
+        Test scenario:
+            Regression: `ax.clear()` detaches the mesh mappable but
+            leaves the colorbar's own (sibling) axes untouched, since a
+            colorbar lives on a separate `Axes`. The next `plot()`
+            call's cleanup then tried to remove that colorbar via a
+            mappable whose `.axes` was already `None` -- `Colorbar.
+            remove()` raises `AttributeError` instead of the
+            `KeyError`/`NotImplementedError` the cleanup already
+            tolerated. `ax.clear()` is an ordinary matplotlib idiom, so
+            it must not crash the next render.
+        """
+        mg = _make_tri_mg()
+        fig, ax = mg.plot(np.array([1.0, 2.0]))
+        ax.clear()
+        fig2, ax2 = mg.plot(np.array([3.0, 4.0]))
+        assert (
+            len(ax2.collections) == 1
+        ), f"Expected one mesh artist, got {len(ax2.collections)}"
+        assert (
+            len(fig2.axes) == 2
+        ), f"Expected 2 axes (plot + colorbar), got {len(fig2.axes)}"
+
 
 class TestAnimate:
     """Tests for MeshGlyph.animate()."""

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1226,6 +1226,122 @@ class TestPlotReuse:
             mg.default_options["cmap"] == "coolwarm_r"
         ), f"Should reset to default coolwarm_r, got {mg.default_options['cmap']}"
 
+    def test_no_image_artist_accumulation(self):
+        """Repeated `plot()` calls replace the tripcolor/tricontour mappable, not stack it.
+
+        Test scenario:
+            Regression for issue #210's underlying bug class: `plot()`
+            always creates a fresh `tripcolor`/`tricontour(f)` artist via
+            `_render_mesh`, but only the colorbar had cleanup
+            (`test_no_colorbar_accumulation` above) -- the mappable
+            itself was never removed, so `ax.collections` grew by one
+            every call.
+        """
+        mg = _make_tri_mg()
+        mg.plot(np.array([1.0, 2.0]))
+        old_im = mg.im
+        mg.plot(np.array([3.0, 4.0]))
+        assert (
+            len(mg.ax.collections) == 1
+        ), f"Expected exactly one mesh artist, got {len(mg.ax.collections)}"
+        assert (
+            old_im not in mg.ax.collections
+        ), "The first call's mappable must be removed"
+
+    def test_plot_outline_repeated_does_not_stack_lines(self):
+        """Repeated `plot_outline()` calls replace the wireframe, not stack it."""
+        mg = _make_tri_mg()
+        mg.plot_outline()
+        mg.plot_outline()
+        assert (
+            len(mg.ax.collections) == 1
+        ), f"Expected exactly one outline artist, got {len(mg.ax.collections)}"
+
+
+class TestSharedAxesArtistCleanup:
+    """`plot`/`animate`/`plot_outline` must not stack artists on a shared `Axes`.
+
+    Regression coverage for issue #210, generalised beyond `ArrayGlyph`:
+    the same orphaned-artist defect existed in `MeshGlyph`, reachable
+    through the documented `MeshGlyph(ax=..., fig=...)` construction-time
+    binding that pyramids' `UgridDataset.plot`/`.plot_outline`
+    `ax=`/`fig=` passthrough exposes.
+    """
+
+    def test_two_glyphs_sharing_axes_via_plot_do_not_stack(self):
+        """A second, different glyph's `plot()` onto a shared axes still cleans up."""
+        mg1 = _make_tri_mg()
+        mg1.plot(np.array([1.0, 2.0]))
+        old_im = mg1.im
+        axes_count_after_first = len(mg1.fig.axes)
+
+        mg2 = _make_tri_mg()
+        mg2.plot(np.array([3.0, 4.0]), ax=mg1.ax)
+
+        assert (
+            len(mg1.ax.collections) == 1
+        ), f"Expected exactly one mesh artist, got {len(mg1.ax.collections)}"
+        assert (
+            old_im not in mg1.ax.collections
+        ), "The first glyph's mappable must be removed"
+        assert len(mg1.fig.axes) == axes_count_after_first, (
+            f"Expected {axes_count_after_first} axes after the second glyph's call, "
+            f"got {len(mg1.fig.axes)}"
+        )
+
+    def test_plot_then_animate_on_shared_axes_does_not_stack(self):
+        """A second glyph's `animate()` cleans up a first glyph's `plot()` mappable."""
+        mg1 = _make_tri_mg()
+        mg1.plot(np.array([1.0, 2.0]))
+        old_im = mg1.im
+
+        mg2 = _make_tri_mg()
+        frames = np.array([[1.0, 2.0], [3.0, 4.0]])
+        mg2.ax = mg1.ax
+        mg2.fig = mg1.fig
+        mg2.animate(frames, time=["t0", "t1"])
+
+        assert (
+            len(mg1.ax.collections) == 1
+        ), f"Expected exactly one mesh artist, got {len(mg1.ax.collections)}"
+        assert (
+            old_im not in mg1.ax.collections
+        ), "The first call's mappable must be removed"
+
+    def test_animate_then_plot_on_shared_axes_does_not_stack(self):
+        """A second glyph's `plot()` cleans up a first glyph's `animate()` mappable."""
+        mg1 = _make_tri_mg()
+        frames = np.array([[1.0, 2.0], [3.0, 4.0]])
+        mg1.animate(frames, time=["t0", "t1"])
+        old_im = mg1.im
+
+        mg2 = _make_tri_mg()
+        mg2.plot(np.array([3.0, 4.0]), ax=mg1.ax)
+
+        assert (
+            len(mg1.ax.collections) == 1
+        ), f"Expected exactly one mesh artist, got {len(mg1.ax.collections)}"
+        assert (
+            old_im not in mg1.ax.collections
+        ), "The first call's mappable must be removed"
+
+    def test_apply_style_after_plot_does_not_raise(self):
+        """`apply_style()` after a plain `plot()` cleans up without crashing.
+
+        Test scenario:
+            Regression for an interaction bug: `apply_style()` calls
+            `Glyph._reset_axes_for_restyle()`, which already removes the
+            previous colorbar/artists itself before `plot()` runs -- the
+            shared-axes cleanup must tolerate an already-removed artist
+            rather than crashing on the second removal attempt.
+        """
+        mg = _make_tri_mg()
+        mg.plot(np.array([1.0, 2.0]))
+        fig, ax = mg.apply_style("flow_accumulation")
+        assert (
+            len(ax.collections) == 1
+        ), f"Expected exactly one mesh artist, got {len(ax.collections)}"
+
 
 class TestAnimate:
     """Tests for MeshGlyph.animate()."""
@@ -1241,6 +1357,42 @@ class TestAnimate:
         anim = mg.animate(frames, time=["t0", "t1", "t2"])
         assert anim is not None, "Should return a FuncAnimation"
         assert mg.anim is anim, "Should store animation on instance"
+
+    def test_animate_populates_im_cbar_day_text(self):
+        """`animate()` stores its mappable/colorbar/frame-label on the instance.
+
+        Test scenario:
+            Regression: `animate()` previously discarded
+            `create_color_bar(...)`'s return value and never assigned
+            `self.im`/`self._day_text` at all, so they stayed `None`
+            after an animation -- unlike `plot()`, which always populated
+            them. All three must be set once `animate()` returns.
+        """
+        mg = _make_tri_mg()
+        frames = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        mg.animate(frames, time=["t0", "t1", "t2"])
+        assert mg.im is not None, "self.im must be set after animate()"
+        assert mg._cbar is not None, "self._cbar must be set after animate()"
+        assert mg._day_text is not None, "self._day_text must be set after animate()"
+
+    def test_repeated_animate_does_not_stack_artists(self):
+        """A second `animate()` call on the same instance replaces, not stacks, artists."""
+        mg = _make_tri_mg()
+        frames = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        mg.animate(frames, time=["t0", "t1", "t2"])
+        old_im = mg.im
+        axes_count_after_first = len(mg.fig.axes)
+        mg.animate(frames, time=["t0", "t1", "t2"])
+        assert (
+            len(mg.ax.collections) == 1
+        ), f"Expected exactly one mesh artist, got {len(mg.ax.collections)}"
+        assert (
+            old_im not in mg.ax.collections
+        ), "The first call's mappable must be removed"
+        assert len(mg.fig.axes) == axes_count_after_first, (
+            f"Expected {axes_count_after_first} axes after the second call, "
+            f"got {len(mg.fig.axes)}"
+        )
 
     def test_node_animation(self):
         """Test node-centered animation."""

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -571,6 +571,28 @@ class TestSharedAxesArtistCleanup:
             len(bars2) == 3
         ), f"Expected the returned container to hold 3, got {len(bars2)}"
 
+    def test_histogram_validation_failure_preserves_prior_render(self):
+        """A failed `histogram()` call must not tear down the previous valid render.
+
+        Test scenario:
+            Regression: `_clear_prior_render_artists` used to run before
+            the `color` length vs. `num_samples` check, so a mismatched
+            `color` list destroyed the last-good histogram along with
+            propagating the `ValueError`.
+        """
+        sg = StatisticalGlyph(
+            np.random.default_rng(0).normal(size=(50, 2)), color=["r", "g"]
+        )
+        fig, ax, hist = sg.histogram()
+        bars_after_first = len(ax.patches)
+        sg.default_options["color"] = ["r", "g", "b"]
+        with pytest.raises(ValueError):
+            sg.histogram()
+        assert len(ax.patches) == bars_after_first, (
+            f"Expected {bars_after_first} bars preserved after the failed call, "
+            f"got {len(ax.patches)}"
+        )
+
 
 class TestFigParameterRemovedFromRenderers:
     """`fig` is no longer a per-call parameter on the box/stripe renderers.

--- a/tests/test_statistical_glyph.py
+++ b/tests/test_statistical_glyph.py
@@ -497,6 +497,81 @@ class TestStripes:
         ), f"Unexpected resolved return hint: {hints['return']}"
 
 
+class TestSharedAxesArtistCleanup:
+    """`histogram`/`boxplot`/`multiboxplot`/`stripes` must not stack artists on a shared `Axes`.
+
+    Regression coverage for issue #210, generalised beyond `ArrayGlyph`:
+    the same orphaned-artist defect existed in `StatisticalGlyph`,
+    reachable through the documented `StatisticalGlyph(ax=...)`
+    construction-time binding that pyramids' `Analysis.plot_histogram`/
+    `plot_vector_field` `ax=` passthrough exposes.
+    """
+
+    def test_histogram_two_glyphs_sharing_axes_does_not_stack(self):
+        """A second, different glyph's `histogram()` onto a shared axes replaces the bars."""
+        sg1 = StatisticalGlyph(np.random.default_rng(0).normal(size=100))
+        fig1, ax1, _ = sg1.histogram()
+        bars_after_first = len(ax1.patches)
+
+        sg2 = StatisticalGlyph(np.random.default_rng(1).normal(size=100), ax=ax1)
+        sg2.histogram()
+
+        assert len(ax1.patches) == bars_after_first, (
+            f"Expected {bars_after_first} bars after the second glyph's call, "
+            f"got {len(ax1.patches)}"
+        )
+
+    def test_boxplot_repeated_on_same_instance_does_not_stack(self):
+        """A second `boxplot()` call on the same instance replaces, not stacks, the boxes."""
+        sg = StatisticalGlyph(
+            np.random.default_rng(0).normal(size=(50, 3)), color=["r", "g", "b"]
+        )
+        fig, ax, _ = sg.boxplot()
+        children_after_first = len(ax.get_children())
+        fig, ax, _ = sg.boxplot()
+        assert len(ax.get_children()) == children_after_first, (
+            f"Expected {children_after_first} axes children after the second call, "
+            f"got {len(ax.get_children())}"
+        )
+
+    def test_multiboxplot_two_glyphs_sharing_axes_does_not_stack(self):
+        """A second, different glyph's `multiboxplot()` onto a shared axes replaces the boxes."""
+        sg1 = StatisticalGlyph(
+            np.random.default_rng(0).normal(size=(40, 3)), color=["r", "g", "b"]
+        )
+        fig, ax, _ = sg1.multiboxplot(positions=[1, 2, 4])
+        boxes_after_first = len(ax.patches)
+
+        sg2 = StatisticalGlyph(
+            np.random.default_rng(1).normal(size=(40, 3)), color=["r", "g", "b"]
+        )
+        sg2.multiboxplot(positions=[1, 2, 4], ax=ax)
+
+        assert len(ax.patches) == boxes_after_first, (
+            f"Expected {boxes_after_first} boxes after the second glyph's call, "
+            f"got {len(ax.patches)}"
+        )
+
+    def test_stripes_two_glyphs_sharing_axes_does_not_stack(self):
+        """A second, different glyph's `stripes()` onto a shared axes replaces the bars.
+
+        Test scenario:
+            The second glyph has *fewer* values than the first (3 vs 6) --
+            if the first call's stripes were left orphaned, the axes
+            would end up with 9 bars instead of 3.
+        """
+        sg1 = StatisticalGlyph(np.array([0.1, 0.3, 0.2, 0.6, 0.9, 0.7]))
+        fig, ax, _ = sg1.stripes(cmap="coolwarm")
+
+        sg2 = StatisticalGlyph(np.array([0.2, 0.4, 0.1]))
+        fig, ax, bars2 = sg2.stripes(cmap="coolwarm", ax=ax)
+
+        assert len(ax.patches) == 3, f"Expected 3 bars, got {len(ax.patches)}"
+        assert (
+            len(bars2) == 3
+        ), f"Expected the returned container to hold 3, got {len(bars2)}"
+
+
 class TestFigParameterRemovedFromRenderers:
     """`fig` is no longer a per-call parameter on the box/stripe renderers.
 

--- a/tests/test_vector_glyph.py
+++ b/tests/test_vector_glyph.py
@@ -450,3 +450,30 @@ class TestSharedAxesArtistCleanup:
         assert (
             len(fig2.axes) == 2
         ), f"Expected 2 axes (plot + colorbar), got {len(fig2.axes)}"
+
+    def test_plot_validation_failure_preserves_prior_render(self):
+        """A failed `plot()` call must not tear down the previous valid render.
+
+        Test scenario:
+            Regression: `_clear_prior_render_artists` used to run before
+            `_prepare_scalar_mapping` validated the new call's magnitude,
+            so an all-NaN magnitude (no finite values to resolve
+            `vmin`/`vmax` from) destroyed the last-good chart along with
+            propagating the `ValueError`.
+        """
+        gx, gy, u, v = self._field()
+        glyph = VectorGlyph(gx, gy, u, v)
+        fig, ax, im = glyph.plot(kind="quiver")
+        axes_count = len(fig.axes)
+        glyph.u = np.full_like(gx, np.nan, dtype=float)
+        glyph.v = np.full_like(gy, np.nan, dtype=float)
+        glyph.default_options["vmin"] = None
+        glyph.default_options["vmax"] = None
+        with pytest.raises(ValueError):
+            glyph.plot(kind="quiver")
+        assert (
+            len(ax.collections) == 1
+        ), f"Expected the prior mappable, got {len(ax.collections)}"
+        assert (
+            len(fig.axes) == axes_count
+        ), f"Expected {axes_count} axes preserved, got {len(fig.axes)}"

--- a/tests/test_vector_glyph.py
+++ b/tests/test_vector_glyph.py
@@ -329,3 +329,99 @@ class TestAddColorbarToggle:
     def test_add_colorbar_in_option_keys(self):
         """`add_colorbar` is an accepted option key."""
         assert "add_colorbar" in VectorGlyph.option_keys(), "add_colorbar missing"
+
+
+class TestSharedAxesArtistCleanup:
+    """`plot()` must not stack mappable/colorbar artists on a shared `Axes`.
+
+    Regression coverage for issue #210, generalised beyond `ArrayGlyph`:
+    the same orphaned-artist defect existed in `VectorGlyph`, reachable
+    through the documented `VectorGlyph(ax=..., fig=...)` construction-time
+    binding that pyramids' `Analysis.plot_vector_field` `ax=` passthrough
+    exposes.
+    """
+
+    @staticmethod
+    def _field():
+        gx, gy = np.meshgrid(np.arange(5), np.arange(5))
+        return gx, gy, np.ones_like(gx, float), np.ones_like(gx, float)
+
+    def test_quiver_repeated_on_same_instance_does_not_stack(self):
+        """A second `plot(kind="quiver")` call on the same instance replaces the mappable."""
+        gx, gy, u, v = self._field()
+        glyph = VectorGlyph(gx, gy, u, v)
+        glyph.plot(kind="quiver")
+        old_im = glyph.im
+        glyph.plot(kind="quiver")
+        assert (
+            len(glyph.ax.collections) == 1
+        ), f"Expected exactly one mappable, got {len(glyph.ax.collections)}"
+        assert (
+            old_im not in glyph.ax.collections
+        ), "The first call's mappable must be removed"
+
+    def test_barbs_two_glyphs_sharing_axes_does_not_stack(self):
+        """A second, different glyph's `plot(kind="barbs")` onto a shared axes replaces it."""
+        gx, gy, u, v = self._field()
+        glyph1 = VectorGlyph(gx, gy, u, v)
+        glyph1.plot(kind="barbs")
+        old_im = glyph1.im
+        axes_count_after_first = len(glyph1.fig.axes)
+
+        glyph2 = VectorGlyph(gx, gy, u, v, ax=glyph1.ax, fig=glyph1.fig)
+        glyph2.plot(kind="barbs")
+
+        assert (
+            len(glyph1.ax.collections) == 1
+        ), f"Expected exactly one mappable, got {len(glyph1.ax.collections)}"
+        assert (
+            old_im not in glyph1.ax.collections
+        ), "The first glyph's mappable must be removed"
+        assert len(glyph1.fig.axes) == axes_count_after_first, (
+            f"Expected {axes_count_after_first} axes after the second glyph's call, "
+            f"got {len(glyph1.fig.axes)}"
+        )
+
+    def test_streamplot_repeated_does_not_leak_arrow_patches(self):
+        """Repeated `plot(kind="streamplot")` calls don't leak arrowhead patches.
+
+        Test scenario:
+            Regression for a matplotlib quirk: `streamplot`'s returned
+            `StreamplotSet.arrows` (a `PatchCollection`) is never actually
+            attached to the axes -- each `FancyArrowPatch` is added via
+            `ax.add_patch()` directly (matplotlib's own source comment:
+            "Adding the collection itself is broken; see #2341") -- so
+            `stream.arrows.remove()` alone raises `NotImplementedError`
+            and leaves every arrowhead behind. `plot()` must diff
+            `ax.patches` before/after `streamplot` to find and track the
+            actual arrow artists.
+        """
+        gx, gy, u, v = self._field()
+        glyph = VectorGlyph(gx, gy, u, v)
+        glyph.plot(kind="streamplot")
+        patches_after_first = len(glyph.ax.patches)
+        glyph.plot(kind="streamplot")
+        assert len(glyph.ax.patches) == patches_after_first, (
+            f"Expected {patches_after_first} arrow patches after the second call, "
+            f"got {len(glyph.ax.patches)} (arrowheads leaked)"
+        )
+        assert (
+            len(glyph.ax.collections) == 1
+        ), f"Expected exactly one line collection, got {len(glyph.ax.collections)}"
+
+    def test_two_glyphs_quiver_then_streamplot_on_shared_axes(self):
+        """A second glyph's `plot(kind="streamplot")` cleans up a first glyph's quiver."""
+        gx, gy, u, v = self._field()
+        glyph1 = VectorGlyph(gx, gy, u, v)
+        glyph1.plot(kind="quiver")
+        old_im = glyph1.im
+
+        glyph2 = VectorGlyph(gx, gy, u, v, ax=glyph1.ax, fig=glyph1.fig)
+        glyph2.plot(kind="streamplot")
+
+        assert (
+            old_im not in glyph1.ax.collections
+        ), "The first glyph's quiver mappable must be removed"
+        assert (
+            len(glyph1.ax.collections) == 1
+        ), f"Expected exactly one mappable, got {len(glyph1.ax.collections)}"

--- a/tests/test_vector_glyph.py
+++ b/tests/test_vector_glyph.py
@@ -425,3 +425,28 @@ class TestSharedAxesArtistCleanup:
         assert (
             len(glyph1.ax.collections) == 1
         ), f"Expected exactly one mappable, got {len(glyph1.ax.collections)}"
+
+    def test_ax_clear_before_replot_does_not_raise(self):
+        """A caller's own `ax.clear()` before the next `plot()` call doesn't crash.
+
+        Test scenario:
+            Regression: `ax.clear()` detaches the mappable but leaves the
+            colorbar's own (sibling) axes untouched, since a colorbar
+            lives on a separate `Axes`. The next `plot()` call's cleanup
+            then tried to remove that colorbar via a mappable whose
+            `.axes` was already `None` -- `Colorbar.remove()` raises
+            `AttributeError` instead of the `KeyError`/`NotImplementedError`
+            the cleanup already tolerated. `ax.clear()` is an ordinary
+            matplotlib idiom, so it must not crash the next render.
+        """
+        gx, gy, u, v = self._field()
+        glyph = VectorGlyph(gx, gy, u, v)
+        fig, ax, im = glyph.plot(kind="quiver")
+        ax.clear()
+        fig2, ax2, im2 = glyph.plot(kind="quiver")
+        assert (
+            len(ax2.collections) == 1
+        ), f"Expected exactly one mappable, got {len(ax2.collections)}"
+        assert (
+            len(fig2.axes) == 2
+        ), f"Expected 2 axes (plot + colorbar), got {len(fig2.axes)}"


### PR DESCRIPTION
# Description

Every glyph's `plot()`/`animate()`-style method unconditionally creates a new image/mappable
artist, colorbar, and (where applicable) frame-label `Text` on every call, without removing the
previous call's. Matplotlib has no "replace the previous artist" primitive for `ax.imshow()`,
`fig.colorbar()`, `ax.add_collection()`, `ax.bar()`, etc. — each call always adds a new artist.
Calling the method again on the same `Axes` — the same glyph instance re-rendering, or a
*different*, independently constructed glyph sharing the first's axes via `SomeGlyph(ax=...,
fig=...)` — leaves the earlier call's artists orphaned: still attached to the `Axes`/`Figure`, and
driven by nothing once the owning glyph's own attributes move on to the new call's objects. For
`animate()`, the orphaned image is additionally marked `animated=True` by the `init_func`
(matplotlib's blit contract), so normal (non-blit) canvas redraws silently skip it too.

**Verified reachable through `pyramids`' real, documented API**, not just theoretically: with the
currently-released cleopatra installed in `pyramids`' own environment,
`ds2.plot(band=0, ax=glyph1.ax, fig=glyph1.fig)` after `ds1.plot(band=0)` (the `ax=`/`fig=`
passthrough `Dataset.plot`/`NetCDF.plot`/`Analysis.plot`/`UgridDataset.plot` all expose) reproduces
the identical symptom — `ax.images` grows 1 → 2, the first dataset's image stays stuck. A follow-up
sweep across `pyramids`' other plotting entry points found two more confirmed-reachable gaps
(`Analysis.plot_histogram` → `StatisticalGlyph`, `Analysis.plot_vector_field` → `VectorGlyph`) and
extended the fix to `MeshGlyph` too (its own `ax=`/`fig=` passthrough via `UgridDataset.plot`/
`.plot_outline`), since it shares the identical defect shape.

## Fix

Two shared helpers in `glyph.py`, `_clear_prior_render_artists`/`_mark_render_artists`, track the
previous render's artists on the **Axes itself** (a private `_cleo_render_artists` marker), not on
any glyph instance — a per-instance check would miss the "different glyph sharing this Axes" case,
since a fresh instance's own attributes start at `None` regardless of what a *different* glyph
already left on the shared Axes. `_mark_render_artists` takes a variadic list of artists in removal
order (not a fixed `im`/`cbar` pair), since different glyphs' artifacts don't share one shape (a
mesh triangulation image, a quiver/streamplot mappable with separately-added arrowheads, one or
more histogram `BarContainer`s, a flattened `Axes.boxplot()` result dict, or no image at all).

Wired into every affected glyph:

- **`ArrayGlyph`**: `plot()` (including the `_plot_with_style` data-style-preset path) and
  `animate()`. Every combination of the two sharing an Axes now cleans up correctly, in either
  order: `plot()`→`plot()`, `plot()`→`animate()`, `animate()`→`plot()`, `animate()`→`animate()`,
  same glyph or different glyphs.
- **`MeshGlyph`**: `plot()` (previously only its colorbar had — per-instance-only — cleanup; the
  `tripcolor`/`tricontour(f)` mappable itself was never removed), `animate()` (previously **zero**
  cleanup, and didn't even track its own mappable/colorbar/frame-label on the instance —
  `create_color_bar(...)`'s return value and the frame-label `Text` were silently discarded), and
  `plot_outline()` (reset `self.im` to `None` without ever removing the actual wireframe artist).
  `animate()` also now re-marks its artists every frame inside its `_update()` closure, since each
  frame swaps in a brand-new mappable (tripcolor/tricontour can't update in place the way `imshow`
  can) rather than mutating one in place.
- **`StatisticalGlyph`**: `histogram()`, `boxplot()`, `multiboxplot()`, `stripes()` — this class had
  no prior cleanup of any kind. `histogram()`/`stripes()` mark their `BarContainer`(s) directly
  (each supports `.remove()` natively); `boxplot()`/`multiboxplot()` flatten `Axes.boxplot()`'s
  return dict (`boxes`/`medians`/`whiskers`/`caps`/`fliers`) into individual artists first, since
  there is no single "remove the whole boxplot" call.
- **`VectorGlyph`**: `plot()` — `self.im` wasn't even tracked on the instance before this. Its
  `streamplot` kind needed special handling: the returned `StreamplotSet.arrows` (a
  `PatchCollection`) is never actually attached to the axes — matplotlib adds each constituent
  `FancyArrowPatch` directly via `ax.add_patch()` instead (its own source comment: *"Adding the
  collection itself is broken; see #2341"*), so `arrows.remove()` alone raises
  `NotImplementedError` and leaves every arrowhead behind. Fixed by diffing `ax.patches`
  before/after `streamplot` to find and track the actual arrow artists that were added.

Two ordering/robustness details found while implementing this:

- A colorbar must be removed **before** the image it's attached to — `Colorbar.remove()` reads
  `self.mappable.axes` to restore the image axes' gridspec position, which is only valid while the
  image artist is still attached (removing image-then-colorbar raises `AttributeError:
  'NoneType' object has no attribute 'set_subplotspec'`).
- Artist removal is **best-effort**: `Glyph._reset_axes_for_restyle()` (used by both `ArrayGlyph`'s
  and `MeshGlyph`'s `apply_style()`) already removes the previous colorbar/artists itself before
  `plot()` runs, so the marker's references can already be stale by the time this cleanup consults
  them. Matplotlib raises `KeyError` (colorbar axes no longer on the figure's axes stack) or
  `NotImplementedError` (any other artist already detached, e.g. via `ax.clear()`) in that case —
  both are caught, since neither should crash this call's own render.

`ArrayGlyph._day_text` (previously only ever set inside `animate()`, never pre-declared) and
`MeshGlyph._day_text`/`VectorGlyph.im` (previously not tracked on the instance at all) are now
initialised in `__init__`, matching the existing `self.im`/`self.cbar` convention.

## Follow-up fixes from a second, independent review pass

A `/review-rounds`-style two-round review of this branch surfaced five findings on the first pass
(all fixed, see below) and two more on a second, independent pass — both in the same
clear-before-validate defect class the fix above targets, both confirmed by direct reproduction
before fixing:

- **`ax.clear()` before a subsequent `plot()`/`animate()` call crashed** with an uncaught
  `AttributeError`: a caller's own `ax.clear()` detaches the image but leaves the colorbar's own
  (sibling) axes untouched, so the next call's cleanup tried to remove that colorbar via a mappable
  whose `.axes` was already `None` — `Colorbar.remove()` reads `self.mappable.axes` and calls
  `.set_subplotspec()` on it, raising `AttributeError` instead of the `KeyError`/`NotImplementedError`
  the cleanup already tolerated. Broadened the tolerated exception set in
  `_clear_prior_render_artists` to include `AttributeError`.
- **`points=`/`display_cell_value=True` overlay artists weren't covered** by the cleanup: only the
  colorbar/image were tracked, so the scatter/label overlay (`points=`) and per-cell value `Text`
  artists (`display_cell_value=True`) doubled on a second `ArrayGlyph.plot()`/`.animate()` call.
  Both are now included in the tracked artist set.
- **Clearing prior artists before validating the new call's inputs destroyed a valid prior render
  on error** — across `ArrayGlyph.plot()`/`animate()`, `MeshGlyph.plot()`/`animate()`, and
  `VectorGlyph.plot()`, `_clear_prior_render_artists` ran before the new call's inputs were fully
  validated (e.g. an invalid `color_scale`), so a validation failure tore down the previous *valid*
  render — colorbar and image both removed — leaving a blank axes plus a propagated exception,
  rather than the last-good chart. Moved the clear to run only after every check that can raise has
  succeeded, immediately before the new artist is actually created.
- **`StatisticalGlyph.histogram()` still cleared before validating** (found on the second review
  pass): the `color` list length vs. `num_samples` check ran *after* `_clear_prior_render_artists`,
  reproducing the identical "valid prior render destroyed by a later validation failure" bug the
  previous fix was meant to close everywhere. Moved the clear to run after that check, matching the
  ordering already used by `boxplot()`/`multiboxplot()`/`stripes()`.
- **`ArrayGlyph.animate()` left `self.im`/`self.cbar`/`self._day_text` stale `None` after a caught
  validation error** (found on the second review pass): an unconditional
  `self.cbar = None; self.im = None; self._day_text = None` ran before the `color_scale`/norm
  validation that can raise, so a caught exception left these documented public attributes `None`
  even though the previous image was still visibly attached to the axes — inconsistent with
  `plot()`, whose equivalent early reset was already removed. Both branches of `animate()`
  unconditionally reassign all three regardless of outcome, so the early reset was dead weight;
  dropped it.
- No direct/isolated unit tests existed for the shared cleanup helpers themselves — coverage was
  entirely indirect, through each glyph's `plot()`/`animate()` integration tests. Added a focused
  `TestClearAndMarkRenderArtists` class in `tests/test_glyph.py` against a bare `Axes` with
  hand-built dummy artists, including a parametrized case locking in the `KeyError`/
  `NotImplementedError`/`AttributeError` tolerance above and one confirming any other exception type
  still propagates (the tolerance is intentionally narrow, not a blanket `except Exception`).

## Investigation context (issue #210) — confirmed fixed

While digging into #210's reported "`animate()` image freezes at frame 0 in saved video when
`add_reference_map()` is called first", the actual repro turned out to need `pyramids`
(`DatasetCollection.plot()` already calls `animate()` internally, then a caller's own `animate()`
call is a redundant second call on the same glyph) and confirmed this exact orphaned-artist symptom
via `ax.images` instrumentation. Earlier drafts of this PR description said this didn't close #210,
because neither I nor the issue's own investigation could reproduce the actual frozen-frame symptom
in a *pure-cleopatra* repro (several variants tried: a plain double `animate()` call, one with an
intervening full canvas draw, and one matching the real array's reported float64/`[0,1]`/
non-contiguous characteristics — none froze) — only the underlying orphaned-artist mechanism was
confirmed, not the freeze itself.

That gap is now closed: re-ran the actual reproducing script posted on #210 (real `pyramids` —
`DatasetCollection.read_multiple_files()` → `.plot()` → `.add_reference_map()` →
`.animate()` → `.save_animation()`, not a synthetic approximation) against this branch's fixed
code, installed live into `pyramids`' own `pixi` `dev` environment. Before the fix (per #210's own
comments), that script leaves `ax.images` at 2 with the first image orphaned, and the saved video's
frame 0 and frame 4 decode to identical content — the reported freeze. Running the identical script
against the fix: `ax.images` stays at 1 (the old image is correctly removed, not orphaned), and
decoded frame 0 vs. frame 4 differ substantially (non-zero pixel diff across the frame, not
identical). The freeze is gone.

## Out of scope (not touched here)

- The point-overlay (`points_scatter`/`points_id`) and cell-value-text (`cell_text_value`) artists
  created inside `ArrayGlyph.plot()`/`.animate()`'s bodies are not tracked as instance attributes,
  so they aren't cleaned up by this fix either.
- `ScatterGlyph`/`PolygonGlyph` share the same underlying defect (confirmed in an earlier sweep) but
  aren't reachable through any current `pyramids` `ax=`/`fig=` passthrough (`FeatureCollection.plot`
  doesn't expose one), so they're left for a follow-up rather than bundled into this PR.
- `VectorGlyph.add_key()` (the quiver-key legend) is a separate, opt-in call the caller makes after
  `plot()`, not touched here.
- A pre-existing, unrelated bug found (not fixed) while verifying the clear-before-validate fix:
  `plot(**kwargs)`'s kwargs-validation loop writes `self.default_options[key] = val` *before* the
  value is validated for actual use, so a failed call (e.g. a bad `color_scale`) permanently
  poisons the glyph's `default_options` for every subsequent call, even ones that don't repeat the
  bad kwarg. Confirmed via `git stash` to predate this PR; out of scope here since this PR is about
  artist destruction, not option-state poisoning.

**Dependencies:** none.

# Issues

- Closes #210 — the orphaned-artist defect this PR fixes was found while investigating that issue;
  re-running #210's own reproducing script against the fix (see "Investigation context" above)
  confirms the reported freeze is resolved, not just the underlying artist-leak mechanism.

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Run against the external uv env (`VIRTUAL_ENV=C:/python-environments/uv/cleopatra`, `PYTHONPATH=src`
pinned to this checkout, `uv run --active`):

- [x] Full suite green: `pytest tests/` -> **1632 passed**.
- [x] Doctests green across the whole package: `pytest --doctest-modules src/cleopatra/` ->
      **169 passed, 1 skipped**.
- [x] New regression tests, one `TestSharedAxesArtistCleanup`-style class per glyph, plus direct
      unit coverage for the shared helpers and the clear-before-validate ordering:
  - `ArrayGlyph` (`TestAnimateEdgeCases` + `TestSharedAxesArtistCleanup`): same-glyph repeats and
    cross-glyph shared-axes for both `plot()` and `animate()`, both call orders, the RGB path, the
    colorbar, the frame-label text, `apply_style()` after `plot()`, `ax.clear()` before a repeat
    call, the `points=`/`display_cell_value=True` overlays not stacking, a failed `plot()`/
    `animate()` call preserving the prior render on `ax`, and a failed `animate()` call preserving
    `self.im`/`self.cbar`/`self._day_text` rather than resetting them to `None`.
  - `MeshGlyph`: image-artist and outline non-accumulation, cross-glyph shared-axes for `plot()`
    and `animate()` (both orders), `animate()` populating `self.im`/`self._cbar`/`self._day_text`,
    `apply_style()` after `plot()`, `ax.clear()` before a repeat call, and a failed `plot()`/
    `animate()` call preserving the prior render.
  - `StatisticalGlyph`: cross-glyph shared-axes for `histogram()`/`multiboxplot()`/`stripes()`,
    same-instance repeats for `boxplot()`, and a failed `histogram()` call (mismatched `color`
    length) preserving the prior bars.
  - `VectorGlyph`: same-instance repeats for `quiver`, cross-glyph shared-axes for `barbs` and a
    `quiver`→`streamplot` combination, dedicated coverage for the `streamplot` arrowhead leak,
    `ax.clear()` before a repeat call, and a failed `plot()` call (all-NaN magnitude) preserving
    the prior render.
  - `Glyph` (`TestClearAndMarkRenderArtists`): direct unit tests for
    `_clear_prior_render_artists`/`_mark_render_artists` against a bare `Axes` with hand-built
    dummy artists, including the `KeyError`/`NotImplementedError`/`AttributeError` tolerance and a
    case confirming any other exception type still propagates.
- [x] Verified against `pyramids`' real API in its own `pixi` `dev` environment (cleopatra 0.26.0,
      pre-fix): `ds1.plot(band=0)` then `ds2.plot(band=0, ax=glyph1.ax, fig=glyph1.fig)` reproduced
      the identical `ax.images` 1 → 2 / orphaned-image symptom, confirming this is reachable through
      pyramids' own documented API, not just hand-constructed glyph objects.
- [x] **#210's own reproducing script re-verified against the fix, closing the loop**: installed
      this branch live into `pyramids`' `pixi` `dev` environment and re-ran the exact
      `DatasetCollection.read_multiple_files()` → `.plot()` → `.add_reference_map()` →
      `.animate()` → `.save_animation()` script posted on the issue. `ax.images` stays at 1
      (previously grew to 2, orphaned), and the saved video's frame 0 vs. frame 4 now decode to
      substantially different content (previously identical — the reported freeze). Confirms the
      fix resolves the actual reported symptom, not just the underlying mechanism.
- [x] Every fix in this PR verified by direct reproduction, before and after: reproduced each bug
      with a minimal script first, applied the fix, then re-ran the same script to confirm the
      symptom was gone and that an unrelated successful call still replaces (not stacks) artifacts.
- [x] mypy compared before/after via `git stash`, per touched file: zero new error *categories* on
      any file — every new error introduced is the same pre-existing, unsuppressed
      "`self.im`/`self.cbar` inferred as `None`" pattern this codebase already carries elsewhere
      (e.g. `ArrayGlyph.plot()`'s own `self.cbar` assignment has an identical, long-standing error).
      Two new `[attr-defined]` errors from stamping a private marker onto `Axes` in `glyph.py` are
      suppressed with `# type: ignore[attr-defined]`, matching this codebase's existing convention
      for similar mypy limitations.
- [x] black / isort / flake8 clean on every line this PR touches (pre-existing formatting/lint
      drift elsewhere in the touched files, unrelated to this change, confirmed via `git stash` to
      predate it on each file).

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

