### PR TITLE
feat(reference): make add_relief honor the axis CRS

### DIFF
--- a/src/cleopatra/geo.py
+++ b/src/cleopatra/geo.py
@@ -326,12 +326,12 @@ class GeoMixin:
     plotting, or pass `ax=` explicitly.
 
     Set `self.crs` to the CRS of the data plotted on the axes (an EPSG code
-    or CRS string) and `add_features` / `add_tiles` default their `crs=`
-    argument to it, so the reference layer is placed in matching
-    coordinates without restating it on every call. An explicit `crs=`
-    still wins; leaving `self.crs` as `None` preserves each helper's own
-    default. `add_relief` ignores `crs` -- relief is a fixed EPSG:4326
-    raster placed by `extent`.
+    or CRS string) and `add_features` / `add_tiles` / `add_relief` default
+    their `crs=` argument to it, so the reference layer is placed in matching
+    coordinates without restating it on every call. An explicit `crs=` still
+    wins; leaving `self.crs` as `None` preserves each helper's own default.
+    For `add_relief`, a non-EPSG:4326 `crs` warps the relief raster into the
+    axis CRS (a 4326 axis places it in lon/lat, unchanged).
     """
 
     #: Set by `cleopatra.glyph.Glyph`; the axes the basemap is drawn on.
@@ -387,8 +387,9 @@ class GeoMixin:
 
         Only injects when `self.crs` is set and `crs` is absent (or `None`)
         in `kwargs`, so the default `self.crs is None` is a pure pass-through
-        and an explicit `crs=` always wins. `crs` is keyword-only in both
-        `add_features` and `add_tiles`, so it always arrives via `kwargs`.
+        and an explicit `crs=` always wins. `crs` is keyword-only in
+        `add_features`, `add_tiles`, and `add_relief`, so it always arrives
+        via `kwargs`.
 
         Args:
             kwargs: The keyword arguments destined for the basemap helper.
@@ -465,8 +466,11 @@ class GeoMixin:
         """Draw a hypsometric relief backdrop under the glyph's data.
 
         Thin wrapper over `cleopatra.reference.add_relief`; arguments are
-        forwarded unchanged (e.g. `resolution`, `extent`, `alpha`).
-        Requires the `cleopatra[tiles]` extra (Pillow).
+        forwarded unchanged (e.g. `resolution`, `extent`, `alpha`). When
+        `crs` is omitted it defaults to `self.crs`, so on a non-EPSG:4326
+        axis the relief is warped to match the data (an explicit `crs=` still
+        wins). Requires the `cleopatra[tiles]` extra (Pillow, and pyproj for a
+        non-4326 `crs`).
 
         Args:
             *args: Positional arguments for
@@ -474,7 +478,9 @@ class GeoMixin:
                 `resolution`.
             ax: Axes to draw on. Defaults to the glyph's `self.ax`.
             **kwargs: Keyword arguments for
-                `cleopatra.reference.add_relief`.
+                `cleopatra.reference.add_relief`. A `crs` keyword is
+                defaulted to `self.crs` when omitted; an explicit `crs=`
+                overrides it.
 
         Returns:
             matplotlib.axes.Axes: The axes, for chaining.
@@ -486,7 +492,9 @@ class GeoMixin:
             cleopatra.reference.add_relief: The underlying implementation and
                 its full parameter list.
         """
-        return reference.add_relief(self._basemap_axes(ax), *args, **kwargs)
+        return reference.add_relief(
+            self._basemap_axes(ax), *args, **self._basemap_kwargs(kwargs)
+        )
 
     def add_labels(
         self, points: dict[str, tuple[float, float]], *, ax: Any = None, **kwargs: Any

--- a/src/cleopatra/geo.py
+++ b/src/cleopatra/geo.py
@@ -344,8 +344,8 @@ class GeoMixin:
     def crs(self) -> int | str | None:
         """CRS of the data plotted on `self.ax` (EPSG code or CRS string).
 
-        When set, `add_features` / `add_tiles` default `crs=` to it; `None`
-        keeps each helper's own default. The value is **validated on
+        When set, `add_features` / `add_tiles` / `add_relief` default `crs=`
+        to it; `None` keeps each helper's own default. The value is **validated on
         assignment** (see `cleopatra.geo._validate_crs`) so mistakes surface
         at `glyph.crs = ...` rather than later, when a basemap is drawn.
 

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -282,11 +282,15 @@ def add_relief(
     backdrop never changes the view.
 
     Note:
-        The relief image is equirectangular (EPSG:4326). When placed with
-        a non-EPSG:4326 `extent` it is simply stretched by `imshow` to fit
-        those bounds -- visually acceptable for small extents but not a
-        true reprojection. For a pixel-accurate backdrop in another
-        projection, reproject the source before drawing.
+        The relief image is equirectangular (EPSG:4326). A lon/lat `extent`
+        within the global bounds is **cropped** out of the global image and
+        placed over that box, so a regional call shows only that region's
+        terrain at true scale -- not the whole world squashed into it.
+        `extent=None` places the whole globe (the axis limits crop the
+        view). An `extent` outside the lon/lat bounds -- e.g. axes in a
+        projected CRS's units (metres) -- is stretched to fit, which is not
+        a true reprojection; reproject the source for a pixel-accurate
+        backdrop in another projection.
 
     Args:
         ax: A matplotlib `Axes` with data already plotted (so its limits
@@ -294,8 +298,10 @@ def add_relief(
         resolution: `"low"` or `"medium"` (see
             `available_relief_resolutions`).
         extent: `(west, south, east, north)` placement in axis units.
-            Defaults to the global EPSG:4326 extent
-            `(-180, -90, 180, 90)`.
+            `None` (default) places the whole global EPSG:4326 relief
+            `(-180, -90, 180, 90)`. A lon/lat box within those bounds crops
+            the relief to that region; a box outside them (e.g. projected
+            metres) stretches the whole image onto it.
         alpha: Backdrop opacity in `[0, 1]`.
         zorder: Matplotlib draw order (`-1` puts it behind all data).
         interpolation: Interpolation passed to `ax.imshow`.
@@ -341,7 +347,23 @@ def add_relief(
     """
     _validate_axes(ax)
     rgb = relief(resolution)
-    west, south, east, north = extent if extent is not None else _RELIEF_EXTENT_4326
+    if extent is None:
+        west, south, east, north = _RELIEF_EXTENT_4326
+    else:
+        west, south, east, north = extent
+        gw, gs, ge, gn = _RELIEF_EXTENT_4326
+        if gw <= west < east <= ge and gs <= south < north <= gn:
+            # A lon/lat sub-region: crop the global relief array to it and
+            # place the crop over that box, instead of stretching the whole
+            # global image onto the box (the issue #177 footgun). `extent`
+            # is None (whole globe) and non-lon/lat extents -- e.g. axes in
+            # projected metres -- keep the previous whole-image placement.
+            rows, cols = rgb.shape[:2]
+            c0 = max(0, int(np.floor((west - gw) / (ge - gw) * cols)))
+            c1 = min(cols, max(c0 + 1, int(np.ceil((east - gw) / (ge - gw) * cols))))
+            r0 = max(0, int(np.floor((gn - north) / (gn - gs) * rows)))
+            r1 = min(rows, max(r0 + 1, int(np.ceil((gn - south) / (gn - gs) * rows))))
+            rgb = rgb[r0:r1, c0:c1]
 
     xlim, ylim = ax.get_xlim(), ax.get_ylim()
     ax.imshow(

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -284,8 +284,11 @@ def add_relief(
     Note:
         The relief image is equirectangular (EPSG:4326). A lon/lat `extent`
         within the global bounds is **cropped** out of the global image and
-        placed over that box, so a regional call shows only that region's
-        terrain at true scale -- not the whole world squashed into it.
+        placed over that box, so a regional call shows that region's terrain
+        rather than the whole world squashed into it. The crop is sliced on
+        the relief's pixel grid and drawn at the requested box, so an off-grid
+        `extent` can shift the backdrop by up to one pixel (0.5 deg at `"low"`,
+        0.25 deg at `"medium"`); grid-aligned extents register exactly.
         `extent=None` places the whole globe (the axis limits crop the
         view). An `extent` outside the lon/lat bounds -- e.g. axes in a
         projected CRS's units (metres) -- is stretched to fit, which is not
@@ -298,10 +301,9 @@ def add_relief(
         resolution: `"low"` or `"medium"` (see
             `available_relief_resolutions`).
         extent: `(west, south, east, north)` placement in axis units.
-            `None` (default) places the whole global EPSG:4326 relief
-            `(-180, -90, 180, 90)`. A lon/lat box within those bounds crops
-            the relief to that region; a box outside them (e.g. projected
-            metres) stretches the whole image onto it.
+            `None` (default) uses the whole global EPSG:4326 relief
+            `(-180, -90, 180, 90)`. See `Note` for how an in-bounds lon/lat
+            box (cropped) differs from an out-of-bounds one (stretched).
         alpha: Backdrop opacity in `[0, 1]`.
         zorder: Matplotlib draw order (`-1` puts it behind all data).
         interpolation: Interpolation passed to `ax.imshow`.

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -297,8 +297,9 @@ def add_relief(
         CRS (per-pixel inverse reprojection via pyproj) so it lines up under
         data plotted in that CRS, exactly like `add_features` / `add_tiles`.
         The placement box defaults to the current axis view; parts of the box
-        that fall outside the CRS's domain are left transparent. This path
-        needs pyproj (the `[tiles]` extra).
+        that fall outside the CRS's domain are left transparent. The box (and
+        the axis view it defaults from) is assumed non-inverted -- `west <
+        east`, `south < north`. This path needs pyproj (the `[tiles]` extra).
 
     Args:
         ax: A matplotlib `Axes` with data already plotted (so its limits
@@ -806,7 +807,7 @@ def _make_transformer(crs: int | str) -> Any:
     """
     if importlib.util.find_spec("pyproj") is None:
         raise ImportError(
-            "Reprojecting reference features to a non-EPSG:4326 CRS requires "
+            "Reprojecting reference layers to a non-EPSG:4326 CRS requires "
             "pyproj, provided by the [tiles] extra. Install with "
             "`pip install cleopatra[tiles]`, or plot your data in EPSG:4326."
         )

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -273,48 +273,58 @@ def add_relief(
     alpha: float = 1.0,
     zorder: int = -1,
     interpolation: str = "bilinear",
+    crs: int | str | None = None,
 ) -> Any:
     """Draw a global hypsometric relief backdrop under existing data.
 
-    The `cartopy` `GeoAxes.stock_img()` analogue. Assumes the axes are
-    in EPSG:4326 (lon/lat); for data in another CRS pass `extent` in the
-    axes' own units. The current axis limits are preserved so adding the
-    backdrop never changes the view.
+    The `cartopy` `GeoAxes.stock_img()` analogue. Assumes the axes are in
+    EPSG:4326 (lon/lat) unless `crs` says otherwise, in which case the relief
+    is warped into that CRS. The current axis limits are preserved so adding
+    the backdrop never changes the view.
 
     Note:
-        The relief image is equirectangular (EPSG:4326). A lon/lat `extent`
-        within the global bounds is **cropped** out of the global image and
-        placed over that box, so a regional call shows that region's terrain
-        rather than the whole world squashed into it. The crop is sliced on
-        the relief's pixel grid and drawn at the requested box, so an off-grid
-        `extent` can shift the backdrop by up to one pixel (0.5 deg at `"low"`,
-        0.25 deg at `"medium"`); grid-aligned extents register exactly.
-        `extent=None` places the whole globe (the axis limits crop the
-        view). An `extent` outside the lon/lat bounds -- e.g. axes in a
-        projected CRS's units (metres) -- is stretched to fit, which is not
-        a true reprojection; reproject the source for a pixel-accurate
-        backdrop in another projection.
+        The relief image is equirectangular (EPSG:4326). On an EPSG:4326 axis
+        (the default, `crs=None`) a lon/lat `extent` within the global bounds
+        is **cropped** out of the global image and placed over that box, so a
+        regional call shows that region's terrain rather than the whole world
+        squashed into it. The crop is sliced on the relief's pixel grid and
+        drawn at the requested box, so an off-grid `extent` can shift the
+        backdrop by up to one pixel (0.5 deg at `"low"`, 0.25 deg at
+        `"medium"`); grid-aligned extents register exactly. `extent=None`
+        places the whole globe (the axis limits crop the view).
+
+        For a **non-EPSG:4326 `crs`** the relief is **warped** into the axis
+        CRS (per-pixel inverse reprojection via pyproj) so it lines up under
+        data plotted in that CRS, exactly like `add_features` / `add_tiles`.
+        The placement box defaults to the current axis view; parts of the box
+        that fall outside the CRS's domain are left transparent. This path
+        needs pyproj (the `[tiles]` extra).
 
     Args:
         ax: A matplotlib `Axes` with data already plotted (so its limits
             define the view).
         resolution: `"low"` or `"medium"` (see
             `available_relief_resolutions`).
-        extent: `(west, south, east, north)` placement in axis units.
-            `None` (default) uses the whole global EPSG:4326 relief
-            `(-180, -90, 180, 90)`. See `Note` for how an in-bounds lon/lat
-            box (cropped) differs from an out-of-bounds one (stretched).
+        extent: `(west, south, east, north)` placement in axis units. On an
+            EPSG:4326 axis, `None` (default) uses the whole global relief
+            `(-180, -90, 180, 90)`; see `Note` for crop-vs-stretch. For a
+            non-4326 `crs`, `None` fills the current axis view and any box is
+            interpreted in the axis CRS's units.
         alpha: Backdrop opacity in `[0, 1]`.
         zorder: Matplotlib draw order (`-1` puts it behind all data).
         interpolation: Interpolation passed to `ax.imshow`.
+        crs: CRS of the data on the axis. `None` or EPSG:4326 places the
+            relief in lon/lat with no reprojection; any other CRS (int EPSG
+            code or CRS string) warps the relief into it.
 
     Returns:
         matplotlib.axes.Axes: The same axes, for chaining.
 
     Raises:
-        ImportError: If Pillow (the `[tiles]` extra) is not installed.
+        ImportError: If Pillow (the `[tiles]` extra) is not installed, or if
+            a non-EPSG:4326 `crs` is requested without pyproj (also `[tiles]`).
         TypeError: If `ax` is not a matplotlib Axes.
-        ValueError: If `resolution` is unknown.
+        ValueError: If `resolution` or `crs` is unknown.
         ConnectionError: If the asset must be downloaded and the fetch
             fails.
 
@@ -349,37 +359,122 @@ def add_relief(
     """
     _validate_axes(ax)
     rgb = relief(resolution)
-    if extent is None:
-        west, south, east, north = _RELIEF_EXTENT_4326
-    else:
-        west, south, east, north = extent
-        gw, gs, ge, gn = _RELIEF_EXTENT_4326
-        if gw <= west < east <= ge and gs <= south < north <= gn:
-            # A lon/lat sub-region: crop the global relief array to it and
-            # place the crop over that box, instead of stretching the whole
-            # global image onto the box (the issue #177 footgun). `extent`
-            # is None (whole globe) and non-lon/lat extents -- e.g. axes in
-            # projected metres -- keep the previous whole-image placement.
-            rows, cols = rgb.shape[:2]
-            c0 = max(0, int(np.floor((west - gw) / (ge - gw) * cols)))
-            c1 = min(cols, max(c0 + 1, int(np.ceil((east - gw) / (ge - gw) * cols))))
-            r0 = max(0, int(np.floor((gn - north) / (gn - gs) * rows)))
-            r1 = min(rows, max(r0 + 1, int(np.ceil((gn - south) / (gn - gs) * rows))))
-            rgb = rgb[r0:r1, c0:c1]
-
     xlim, ylim = ax.get_xlim(), ax.get_ylim()
-    ax.imshow(
-        rgb,
-        extent=[west, east, south, north],
-        origin="upper",
-        alpha=alpha,
-        zorder=zorder,
-        interpolation=interpolation,
-        aspect=ax.get_aspect(),
-    )
+    if _is_4326(crs):
+        if extent is None:
+            west, south, east, north = _RELIEF_EXTENT_4326
+        else:
+            west, south, east, north = extent
+            gw, gs, ge, gn = _RELIEF_EXTENT_4326
+            if gw <= west < east <= ge and gs <= south < north <= gn:
+                # A lon/lat sub-region: crop the global relief array to it and
+                # place the crop over that box, instead of stretching the whole
+                # global image onto the box (the issue #177 footgun). `extent`
+                # is None (whole globe) and non-lon/lat extents -- e.g. axes in
+                # projected metres -- keep the previous whole-image placement.
+                rows, cols = rgb.shape[:2]
+                c0 = max(0, int(np.floor((west - gw) / (ge - gw) * cols)))
+                c1 = min(
+                    cols, max(c0 + 1, int(np.ceil((east - gw) / (ge - gw) * cols)))
+                )
+                r0 = max(0, int(np.floor((gn - north) / (gn - gs) * rows)))
+                r1 = min(
+                    rows, max(r0 + 1, int(np.ceil((gn - south) / (gn - gs) * rows)))
+                )
+                rgb = rgb[r0:r1, c0:c1]
+        ax.imshow(
+            rgb,
+            extent=[west, east, south, north],
+            origin="upper",
+            alpha=alpha,
+            zorder=zorder,
+            interpolation=interpolation,
+            aspect=ax.get_aspect(),
+        )
+    else:
+        # Non-EPSG:4326 axis: warp the global relief into the axis CRS so the
+        # terrain lines up under the data, exactly like add_features/add_tiles.
+        # The placement box defaults to the current axis view. Needs pyproj.
+        if extent is None:
+            west, east = xlim
+            south, north = ylim
+        else:
+            west, south, east, north = extent
+        warped = _warp_relief(rgb, (west, south, east, north), crs, alpha)  # type: ignore[arg-type]
+        ax.imshow(
+            warped,
+            extent=[west, east, south, north],
+            origin="upper",
+            zorder=zorder,
+            interpolation=interpolation,
+            aspect=ax.get_aspect(),
+        )
     ax.set_xlim(xlim)
     ax.set_ylim(ylim)
     return ax
+
+
+def _warp_relief(
+    rgb: np.ndarray,
+    box: tuple[float, float, float, float],
+    crs: int | str,
+    alpha: float,
+    *,
+    max_side: int = 1024,
+) -> np.ndarray:
+    """Warp the global EPSG:4326 relief into a non-4326 CRS placement box.
+
+    Builds an output grid over `box` in the target CRS's units, inverse-
+    transforms each cell centre to lon/lat with pyproj, and samples the
+    global relief (nearest neighbour). Cells whose inverse transform falls
+    outside the CRS's domain (non-finite) are left transparent, so partial
+    coverage -- an orthographic disc, a UTM band -- degrades gracefully.
+
+    Args:
+        rgb: The global EPSG:4326 relief, an `(H, W, 3)` uint8 array
+            (north-up, west-to-east).
+        box: `(west, south, east, north)` placement in the target CRS units.
+        crs: The target (axis) CRS -- an int EPSG code or CRS string.
+        alpha: Backdrop opacity in `[0, 1]`, baked into the alpha channel.
+        max_side: Longest side of the output grid, in pixels.
+
+    Returns:
+        numpy.ndarray: An `(out_h, out_w, 4)` uint8 RGBA array to `imshow`
+        at `box` with `origin="upper"`.
+    """
+    west, south, east, north = box
+    rows, cols = rgb.shape[:2]
+    gw, gs, ge, gn = _RELIEF_EXTENT_4326
+
+    span_x = abs(east - west)
+    span_y = abs(north - south)
+    aspect = span_x / span_y if span_y else 1.0
+    if aspect >= 1.0:
+        out_w, out_h = max_side, max(1, round(max_side / aspect))
+    else:
+        out_w, out_h = max(1, round(max_side * aspect)), max_side
+
+    transformer = _make_transformer(crs)
+    xs = west + (np.arange(out_w) + 0.5) / out_w * (east - west)
+    ys = north - (np.arange(out_h) + 0.5) / out_h * (north - south)
+    grid_x, grid_y = np.meshgrid(xs, ys)
+    lon, lat = transformer.transform(
+        grid_x.ravel(), grid_y.ravel(), direction="INVERSE"
+    )
+    lon = np.asarray(lon, dtype=float).reshape(out_h, out_w)
+    lat = np.asarray(lat, dtype=float).reshape(out_h, out_w)
+
+    valid = np.isfinite(lon) & np.isfinite(lat)
+    lon_wrapped = ((np.where(valid, lon, 0.0) - gw) % (ge - gw)) + gw
+    lat_safe = np.where(valid, lat, gn)
+    col = np.clip(((lon_wrapped - gw) / (ge - gw) * cols).astype(int), 0, cols - 1)
+    row = np.clip(((gn - lat_safe) / (gn - gs) * rows).astype(int), 0, rows - 1)
+
+    out = np.zeros((out_h, out_w, 4), dtype=np.uint8)
+    out[..., :3] = rgb[row, col]
+    fill = np.uint8(round(float(np.clip(alpha, 0.0, 1.0)) * 255))
+    out[..., 3] = np.where(valid, fill, np.uint8(0))
+    return out
 
 
 # --------------------------------------------------------------------------

--- a/src/cleopatra/reference.py
+++ b/src/cleopatra/reference.py
@@ -472,7 +472,10 @@ def _warp_relief(
     row = np.clip(((gn - lat_safe) / (gn - gs) * rows).astype(int), 0, rows - 1)
 
     out = np.zeros((out_h, out_w, 4), dtype=np.uint8)
-    out[..., :3] = rgb[row, col]
+    # Zero the RGB of masked cells too (not just their alpha), so a bilinear
+    # imshow blends the domain edge toward transparent-black rather than an
+    # arbitrary sampled terrain colour.
+    out[..., :3] = np.where(valid[..., None], rgb[row, col], np.uint8(0))
     fill = np.uint8(round(float(np.clip(alpha, 0.0, 1.0)) * 255))
     out[..., 3] = np.where(valid, fill, np.uint8(0))
     return out

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -451,6 +451,14 @@ def test_glyph_crs_drives_relief_warp(tmp_path: Path, monkeypatch):
     glyph.add_relief("low")
     placed = np.asarray(ax.images[0].get_array())
     assert placed.shape[2] == 4, f"relief should warp to RGBA, got {placed.shape}"
+    w = placed.shape[1]
+    west = placed[:, : w // 4].reshape(-1, 4)
+    east = placed[:, -(w // 4) :].reshape(-1, 4)
+    west = west[west[:, 3] > 0]
+    east = east[east[:, 3] > 0]
+    assert west.size and east.size, "expected opaque cells on both strips"
+    assert (west[:, 2] > west[:, 0]).all(), "west should stay blue after the warp"
+    assert (east[:, 0] > east[:, 2]).all(), "east should stay red after the warp"
     plt.close(fig)
 
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -254,19 +254,19 @@ def test_unset_crs_is_passthrough(monkeypatch):
     plt.close(fig)
 
 
-def test_add_relief_ignores_self_crs(monkeypatch):
-    """add_relief never receives crs, even when self.crs is set."""
+def test_add_relief_defaults_to_self_crs(monkeypatch):
+    """add_relief defaults crs to self.crs, like add_features/add_tiles."""
     seen = {}
     monkeypatch.setattr(
         refmod, "add_relief", lambda ax, *a, **k: seen.update(kwargs=k) or ax
     )
     fig, ax = plt.subplots()
     glyph = _Dummy(ax)
-    glyph.crs = 4326
+    glyph.crs = 3857
     glyph.add_relief("low")
     assert (
-        "crs" not in seen["kwargs"]
-    ), f"add_relief must not get crs, got {seen['kwargs']}"
+        seen["kwargs"].get("crs") == 3857
+    ), f"add_relief should default crs to self.crs, got {seen['kwargs']}"
     plt.close(fig)
 
 
@@ -281,9 +281,11 @@ def test_basemap_kwargs_helper():
     assert d._basemap_kwargs({"crs": None}) == {"crs": 4326}  # None treated as unset
 
 
-@pytest.mark.parametrize("fn", [tilesmod.add_tiles, refmod.add_features])
+@pytest.mark.parametrize(
+    "fn", [tilesmod.add_tiles, refmod.add_features, refmod.add_relief]
+)
 def test_crs_is_keyword_only_in_helpers(fn):
-    """crs is keyword-only in add_tiles/add_features, so it cannot be positional."""
+    """crs is keyword-only in add_tiles/add_features/add_relief, not positional."""
     kind = inspect.signature(fn).parameters["crs"].kind
     assert kind is inspect.Parameter.KEYWORD_ONLY, f"{fn.__name__}.crs is {kind}"
 
@@ -426,6 +428,29 @@ def test_glyph_crs_drives_reprojected_placement(tmp_path: Path, monkeypatch):
     # In EPSG:3857, lon=0 -> x~=0 m and lon=10 -> x~=1.11e6 m (not lon/lat degrees).
     assert abs(verts[0][0]) < 1.0, f"first vertex not at x~=0: {verts[0]}"
     assert verts[1][0] > 1.0e6, f"second vertex not reprojected to metres: {verts[1]}"
+    plt.close(fig)
+
+
+def test_glyph_crs_drives_relief_warp(tmp_path: Path, monkeypatch):
+    """End-to-end: glyph.crs alone warps the relief backdrop to that CRS."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    Image = pytest.importorskip(
+        "PIL.Image", reason="Pillow not installed (tiles extra)"
+    )
+    monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+    arr = np.zeros((4, 8, 3), dtype="uint8")
+    arr[:, :4] = (0, 0, 255)
+    arr[:, 4:] = (255, 0, 0)
+    Image.fromarray(arr).save(tmp_path / "ne_hypso_rgb_720x360.png")
+
+    fig, ax = plt.subplots()
+    glyph = PolygonGlyph([np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]])], ax=ax)
+    glyph.crs = 3857  # axis CRS recorded once; no crs= on the draw call
+    ax.set_xlim(-2e7, 2e7)
+    ax.set_ylim(-1e7, 1e7)
+    glyph.add_relief("low")
+    placed = np.asarray(ax.images[0].get_array())
+    assert placed.shape[2] == 4, f"relief should warp to RGBA, got {placed.shape}"
     plt.close(fig)
 
 

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -542,6 +542,22 @@ def test_add_relief_non_4326_crs_warps_and_aligns(cache: Path):
     plt.close(fig)
 
 
+def test_add_relief_non_4326_explicit_extent_tall_box(cache: Path):
+    """A non-4326 crs with an explicit, taller-than-wide extent warps to that
+    box (exercises the explicit-extent and aspect<1 grid-sizing branches)."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    _blue_west_red_east_relief(cache)
+    fig, ax = plt.subplots()
+    ax.set_xlim(-1e6, 1e6)
+    ax.set_ylim(-2e7, 2e7)
+    add_relief(ax, "low", extent=(-1e6, -2e7, 1e6, 2e7), crs=3857)
+    placed = np.asarray(ax.images[0].get_array())
+    assert placed.shape[2] == 4, f"warp path should be RGBA, got {placed.shape}"
+    assert placed.shape[0] > placed.shape[1], "a tall box should be taller than wide"
+    assert tuple(ax.images[0].get_extent()) == (-1e6, 1e6, -2e7, 2e7)
+    plt.close(fig)
+
+
 def test_add_relief_non_4326_masks_out_of_domain(cache: Path):
     """Cells outside the target CRS's domain (an orthographic disc) are left
     transparent instead of crashing."""

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -9,6 +9,7 @@ and the real read/parse/draw path is exercised offline.
 from __future__ import annotations
 
 import gzip
+import importlib.util
 import io
 import json
 import urllib.error
@@ -504,6 +505,73 @@ def test_add_relief_non_lonlat_extent_still_stretches(cache: Path):
         8,
     ), f"non-lon/lat extent should keep full image, got {placed.shape}"
     assert tuple(ax.images[0].get_extent()) == (1e6, 2e6, 6e6, 7e6)
+    plt.close(fig)
+
+
+def test_add_relief_crs_4326_places_without_warp(cache: Path):
+    """An explicit crs=4326 keeps the lon/lat path (RGB, no reprojection)."""
+    _blue_west_red_east_relief(cache)
+    fig, ax = plt.subplots()
+    ax.set_xlim(-180, 180)
+    ax.set_ylim(-90, 90)
+    add_relief(ax, "low", crs=4326)
+    placed = np.asarray(ax.images[0].get_array())
+    assert placed.shape[2] == 3, f"4326 path should stay RGB, got {placed.shape}"
+    plt.close(fig)
+
+
+def test_add_relief_non_4326_crs_warps_and_aligns(cache: Path):
+    """A non-4326 crs warps the relief into that CRS, keeping the west/east
+    (longitude) order of the source."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    _blue_west_red_east_relief(cache)
+    fig, ax = plt.subplots()
+    ax.set_xlim(-2e7, 2e7)  # ~full-world EPSG:3857 metres
+    ax.set_ylim(-1e7, 1e7)
+    add_relief(ax, "low", crs=3857)
+    placed = np.asarray(ax.images[0].get_array())
+    assert placed.shape[2] == 4, f"warp path should be RGBA, got {placed.shape}"
+    w = placed.shape[1]
+    west = placed[:, : w // 4].reshape(-1, 4)
+    east = placed[:, -(w // 4) :].reshape(-1, 4)
+    west = west[west[:, 3] > 0]
+    east = east[east[:, 3] > 0]
+    assert (west[:, 2] > west[:, 0]).all(), "western strip should stay blue"
+    assert (east[:, 0] > east[:, 2]).all(), "eastern strip should stay red"
+    plt.close(fig)
+
+
+def test_add_relief_non_4326_masks_out_of_domain(cache: Path):
+    """Cells outside the target CRS's domain (an orthographic disc) are left
+    transparent instead of crashing."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    _blue_west_red_east_relief(cache)
+    fig, ax = plt.subplots()
+    ax.set_xlim(-1e7, 1e7)
+    ax.set_ylim(-1e7, 1e7)
+    add_relief(ax, "low", crs="+proj=ortho +lat_0=0 +lon_0=0 +datum=WGS84")
+    alpha = np.asarray(ax.images[0].get_array())[..., 3]
+    assert (alpha == 0).any(), "corners outside the ortho disc should be transparent"
+    assert (alpha > 0).any(), "the disc centre should be opaque"
+    plt.close(fig)
+
+
+def test_add_relief_non_4326_requires_pyproj(
+    cache: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Without pyproj, a non-4326 crs raises an actionable ImportError."""
+    _blue_west_red_east_relief(cache)
+    real_find_spec = importlib.util.find_spec
+    monkeypatch.setattr(
+        importlib.util,
+        "find_spec",
+        lambda name: None if name == "pyproj" else real_find_spec(name),
+    )
+    fig, ax = plt.subplots()
+    ax.set_xlim(-2e7, 2e7)
+    ax.set_ylim(-1e7, 1e7)
+    with pytest.raises(ImportError, match="pyproj"):
+        add_relief(ax, "low", crs=3857)
     plt.close(fig)
 
 

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -446,12 +446,12 @@ def test_add_relief_lonlat_extent_crops_not_stretches(cache: Path):
     add_relief(ax, "low", extent=(0, -90, 180, 90))  # eastern hemisphere
     placed = np.asarray(ax.images[0].get_array())
     assert placed.shape[1] < 8, f"extent should crop, got full width {placed.shape}"
-    assert placed.shape[0] == 4, (
-        f"full-latitude extent must not crop rows, got {placed.shape}"
-    )
-    assert (placed[..., 0] == 255).all() and (placed[..., 2] == 0).all(), (
-        "the cropped region should be the red eastern half only"
-    )
+    assert (
+        placed.shape[0] == 4
+    ), f"full-latitude extent must not crop rows, got {placed.shape}"
+    assert (placed[..., 0] == 255).all() and (
+        placed[..., 2] == 0
+    ).all(), "the cropped region should be the red eastern half only"
     plt.close(fig)
 
 
@@ -477,12 +477,12 @@ def test_add_relief_lonlat_extent_crops_northern_rows(cache: Path):
     ax.set_ylim(0, 90)
     add_relief(ax, "low", extent=(-180, 0, 180, 90))  # northern hemisphere
     placed = np.asarray(ax.images[0].get_array())
-    assert placed.shape[0] < 4, (
-        f"extent should crop rows, got full height {placed.shape}"
-    )
-    assert (placed[..., 0] == 255).all() and (placed[..., 2] == 0).all(), (
-        "the cropped region should be the red northern rows only"
-    )
+    assert (
+        placed.shape[0] < 4
+    ), f"extent should crop rows, got full height {placed.shape}"
+    assert (placed[..., 0] == 255).all() and (
+        placed[..., 2] == 0
+    ).all(), "the cropped region should be the red northern rows only"
     plt.close(fig)
 
 
@@ -495,7 +495,10 @@ def test_add_relief_non_lonlat_extent_still_stretches(cache: Path):
     ax.set_ylim(6e6, 7e6)
     add_relief(ax, "low", extent=(1e6, 6e6, 2e6, 7e6))  # metres, out of bounds
     placed = np.asarray(ax.images[0].get_array())
-    assert placed.shape[:2] == (4, 8), f"non-lon/lat extent should keep full image, got {placed.shape}"
+    assert placed.shape[:2] == (
+        4,
+        8,
+    ), f"non-lon/lat extent should keep full image, got {placed.shape}"
     assert tuple(ax.images[0].get_extent()) == (1e6, 2e6, 6e6, 7e6)
     plt.close(fig)
 

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -536,6 +536,7 @@ def test_add_relief_non_4326_crs_warps_and_aligns(cache: Path):
     east = placed[:, -(w // 4) :].reshape(-1, 4)
     west = west[west[:, 3] > 0]
     east = east[east[:, 3] > 0]
+    assert west.size and east.size, "expected opaque cells on both strips"
     assert (west[:, 2] > west[:, 0]).all(), "western strip should stay blue"
     assert (east[:, 0] > east[:, 2]).all(), "eastern strip should stay red"
     plt.close(fig)

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -583,10 +583,9 @@ def test_add_relief_non_4326_bakes_alpha(cache: Path):
     ax.set_ylim(-1e7, 1e7)
     add_relief(ax, "low", crs=3857, alpha=0.5)
     alpha = np.asarray(ax.images[0].get_array())[..., 3]
-    assert set(np.unique(alpha)).issubset(
-        {0, 128}
-    ), f"alpha not baked: {np.unique(alpha)}"
-    assert (alpha == 128).any(), "opaque cells should carry the baked alpha byte"
+    # This full-world 3857 box is entirely in-domain, so every cell is opaque
+    # at the baked byte round(0.5 * 255) == 128 -- assert that exactly.
+    assert set(np.unique(alpha)) == {128}, f"alpha not baked to 128: {np.unique(alpha)}"
     assert ax.images[0].get_alpha() is None, "warp path must not set a scalar alpha"
     plt.close(fig)
 

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -423,6 +423,47 @@ def test_add_relief_custom_extent(cache: Path):
     plt.close(fig)
 
 
+def _blue_west_red_east_relief(cache: Path) -> None:
+    """Write a synthetic relief PNG: blue western half, red eastern half."""
+    Image = pytest.importorskip(
+        "PIL.Image", reason="Pillow not installed (tiles extra)"
+    )
+    arr = np.zeros((4, 8, 3), dtype="uint8")
+    arr[:, :4] = (0, 0, 255)  # western half blue
+    arr[:, 4:] = (255, 0, 0)  # eastern half red
+    Image.fromarray(arr).save(cache / "ne_hypso_rgb_720x360.png")
+
+
+def test_add_relief_lonlat_extent_crops_not_stretches(cache: Path):
+    """A lon/lat sub-region extent crops the relief (issue #177) rather than
+    stretching the whole global image onto the box."""
+    _blue_west_red_east_relief(cache)
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 180)
+    ax.set_ylim(-90, 90)
+    add_relief(ax, "low", extent=(0, -90, 180, 90))  # eastern hemisphere
+    placed = np.asarray(ax.images[0].get_array())
+    assert placed.shape[1] < 8, f"extent should crop, got full width {placed.shape}"
+    assert (placed[..., 0] == 255).all() and (placed[..., 2] == 0).all(), (
+        "the cropped region should be the red eastern half only"
+    )
+    plt.close(fig)
+
+
+def test_add_relief_non_lonlat_extent_still_stretches(cache: Path):
+    """An extent outside the lon/lat bounds (e.g. projected metres) keeps the
+    whole-image stretch placement."""
+    _blue_west_red_east_relief(cache)
+    fig, ax = plt.subplots()
+    ax.set_xlim(1e6, 2e6)
+    ax.set_ylim(6e6, 7e6)
+    add_relief(ax, "low", extent=(1e6, 6e6, 2e6, 7e6))  # metres, out of bounds
+    placed = np.asarray(ax.images[0].get_array())
+    assert placed.shape[:2] == (4, 8), f"non-lon/lat extent should keep full image, got {placed.shape}"
+    assert tuple(ax.images[0].get_extent()) == (1e6, 2e6, 6e6, 7e6)
+    plt.close(fig)
+
+
 def test_add_relief_bad_axes():
     with pytest.raises(TypeError, match="matplotlib.axes.Axes"):
         add_relief(object())

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -419,6 +419,9 @@ def test_add_relief_custom_extent(cache: Path):
     ax.set_xlim(0, 10)
     ax.set_ylim(0, 10)
     add_relief(ax, "low", extent=(0, 0, 10, 10))
+    # (0, 0, 10, 10) is in-bounds, so it exercises the crop branch: this
+    # degree-scale box crops the 4x8 fixture down to a single pixel.
+    assert np.asarray(ax.images[0].get_array()).shape[:2] == (1, 1)
     assert tuple(ax.images[0].get_extent()) == (0.0, 10.0, 0.0, 10.0)
     plt.close(fig)
 
@@ -480,6 +483,7 @@ def test_add_relief_lonlat_extent_crops_northern_rows(cache: Path):
     assert (
         placed.shape[0] < 4
     ), f"extent should crop rows, got full height {placed.shape}"
+    assert placed.shape[1] == 8, "full-longitude extent keeps all columns"
     assert (placed[..., 0] == 255).all() and (
         placed[..., 2] == 0
     ).all(), "the cropped region should be the red northern rows only"

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -573,6 +573,24 @@ def test_add_relief_non_4326_masks_out_of_domain(cache: Path):
     plt.close(fig)
 
 
+def test_add_relief_non_4326_bakes_alpha(cache: Path):
+    """On the warp path, alpha is baked into the RGBA alpha channel (imshow
+    gets no scalar alpha=)."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    _blue_west_red_east_relief(cache)
+    fig, ax = plt.subplots()
+    ax.set_xlim(-2e7, 2e7)
+    ax.set_ylim(-1e7, 1e7)
+    add_relief(ax, "low", crs=3857, alpha=0.5)
+    alpha = np.asarray(ax.images[0].get_array())[..., 3]
+    assert set(np.unique(alpha)).issubset(
+        {0, 128}
+    ), f"alpha not baked: {np.unique(alpha)}"
+    assert (alpha == 128).any(), "opaque cells should carry the baked alpha byte"
+    assert ax.images[0].get_alpha() is None, "warp path must not set a scalar alpha"
+    plt.close(fig)
+
+
 def test_add_relief_non_4326_requires_pyproj(
     cache: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -428,6 +428,8 @@ def _blue_west_red_east_relief(cache: Path) -> None:
     Image = pytest.importorskip(
         "PIL.Image", reason="Pillow not installed (tiles extra)"
     )
+    # The filename is the fixed relief cache key; the tiny 8x4 array stands in
+    # for the real 720x360 asset (dimensions are read from content, not name).
     arr = np.zeros((4, 8, 3), dtype="uint8")
     arr[:, :4] = (0, 0, 255)  # western half blue
     arr[:, 4:] = (255, 0, 0)  # eastern half red
@@ -444,8 +446,42 @@ def test_add_relief_lonlat_extent_crops_not_stretches(cache: Path):
     add_relief(ax, "low", extent=(0, -90, 180, 90))  # eastern hemisphere
     placed = np.asarray(ax.images[0].get_array())
     assert placed.shape[1] < 8, f"extent should crop, got full width {placed.shape}"
+    assert placed.shape[0] == 4, (
+        f"full-latitude extent must not crop rows, got {placed.shape}"
+    )
     assert (placed[..., 0] == 255).all() and (placed[..., 2] == 0).all(), (
         "the cropped region should be the red eastern half only"
+    )
+    plt.close(fig)
+
+
+def _red_north_blue_south_relief(cache: Path) -> None:
+    """Write a synthetic relief PNG: red northern (top) rows, blue southern."""
+    Image = pytest.importorskip(
+        "PIL.Image", reason="Pillow not installed (tiles extra)"
+    )
+    # The filename is the fixed relief cache key; the tiny 8x4 array stands in
+    # for the real 720x360 asset (dimensions are read from content, not name).
+    arr = np.zeros((4, 8, 3), dtype="uint8")
+    arr[:2] = (255, 0, 0)  # northern (top) rows red
+    arr[2:] = (0, 0, 255)  # southern (bottom) rows blue
+    Image.fromarray(arr).save(cache / "ne_hypso_rgb_720x360.png")
+
+
+def test_add_relief_lonlat_extent_crops_northern_rows(cache: Path):
+    """A northern-hemisphere extent crops the top rows (north-up +
+    `origin="upper"`) rather than flipping or stretching latitude."""
+    _red_north_blue_south_relief(cache)
+    fig, ax = plt.subplots()
+    ax.set_xlim(-180, 180)
+    ax.set_ylim(0, 90)
+    add_relief(ax, "low", extent=(-180, 0, 180, 90))  # northern hemisphere
+    placed = np.asarray(ax.images[0].get_array())
+    assert placed.shape[0] < 4, (
+        f"extent should crop rows, got full height {placed.shape}"
+    )
+    assert (placed[..., 0] == 255).all() and (placed[..., 2] == 0).all(), (
+        "the cropped region should be the red northern rows only"
     )
     plt.close(fig)
 


### PR DESCRIPTION
# Description

Two related fixes to `add_relief`, both from the reopened #177.

## 1. Crop a lon/lat `extent` instead of stretching (the footgun)

`add_relief` placed the whole global relief image at the given `extent`, so passing a lon/lat sub-region squashed
the entire world into that box — misaligned with the data and the `add_features` coastlines.

- A **lon/lat box within the global bounds** now crops the global relief array to that region and places the crop
  there, instead of stretching the whole image onto the box.
- **`extent=None`** is unchanged: the whole relief is placed and the axis limits crop the view.
- An **`extent` outside the lon/lat bounds** on a 4326 axis still uses the whole-image stretch.

The crop is sliced on the relief's pixel grid and drawn at the requested box, so an off-grid `extent` can shift the
backdrop by up to one pixel (0.5° at `"low"`, 0.25° at `"medium"`); grid-aligned extents register exactly.

## 2. Honor the axis CRS (thread `glyph.crs` into `add_relief`)

`add_relief` was the odd one out — it ignored `crs`, so on a non-EPSG:4326 axis the relief did not line up under
the data the way `add_features` / `add_tiles` do. It now takes a keyword-only `crs=`:

- **`crs` is `None` / EPSG:4326** (the default) → the lon/lat path above runs unchanged, with **no pyproj import**.
- **any other CRS** → the global relief is **warped** into the axis CRS: an output grid over the axis view is
  inverse-transformed to lon/lat with pyproj, the relief is sampled per pixel, and cells outside the CRS's domain
  are left **transparent**, so partial coverage (a UTM band, an orthographic disc) degrades gracefully.
- `GeoMixin.add_relief` now defaults `crs` to `self.crs` (via `_basemap_kwargs`), exactly like the other two
  helpers; an explicit `crs=` still wins and an unset `self.crs` preserves today's behaviour.

Only numpy + (for the non-4326 path) pyproj — no new dependencies beyond the existing `cleopatra[tiles]` extra, and
no GDAL.

Out of scope (now tracked separately): bundling a cropped relief into the `ecmwf-dark` reference-map style, split
out to #216 as a preset-styling feature. With that split, the `crs`-defaulting work #177 asked for (all three of
`add_features` / `add_tiles` / `add_relief`) is complete in this PR.

# Issues
- Closes #177 — `add_relief` axis-CRS defaulting + the stretch-onto-bounds footgun

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Crop path:
- `test_add_relief_lonlat_extent_crops_not_stretches` / `..._crops_northern_rows` — eastern- and
  northern-hemisphere extents crop the correct columns / rows (the latter guards the north-up / `origin="upper"`
  latitude axis); the custom-extent test asserts the fixture crops to a single pixel.
- `test_add_relief_non_lonlat_extent_still_stretches` — a metres extent keeps the whole-image stretch.

CRS warp path:
- `test_add_relief_crs_4326_places_without_warp` — an explicit `crs=4326` stays on the RGB lon/lat path.
- `test_add_relief_non_4326_crs_warps_and_aligns` — a Web-Mercator (3857) axis warps to RGBA and preserves the
  source's west/east (longitude) order.
- `test_add_relief_non_4326_masks_out_of_domain` — an orthographic CRS leaves the off-disc corners transparent.
- `test_add_relief_non_4326_requires_pyproj` — without pyproj, a non-4326 `crs` raises the actionable `[tiles]`
  `ImportError`.
- `test_geo.py::test_add_relief_defaults_to_self_crs`, `test_glyph_crs_drives_relief_warp` — end-to-end, setting
  `glyph.crs` alone warps the backdrop; `crs` is keyword-only in all three helpers.
- Full suite: **1531 passed, 1 skipped**; `reference.py` / `geo.py` doctests pass; black / flake8 / isort clean on
  the changed files.

- [x] Crop tests (lon/lat crop; north-up latitude guard; metres stretch)
- [x] Warp tests (4326 no-warp; 3857 alignment; out-of-domain transparency; pyproj-missing ImportError)
- [x] End-to-end via `glyph.crs`

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
