### PR TITLE
ci: pin workflow actions to specific versions and commit SHAs

### DIFF
--- a/.github/workflows/github-pages-mkdocs.yml
+++ b/.github/workflows/github-pages-mkdocs.yml
@@ -31,11 +31,11 @@ jobs:
         group: mkdocs-deploy-pr-main
         cancel-in-progress: false
       steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1
+      - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1.3.1
         with:
           trigger: 'pull_request'
           package-manager: 'uv'
@@ -52,10 +52,10 @@ jobs:
       group: mkdocs-deploy-pr-main
       cancel-in-progress: false
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
-    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@main
+    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1.3.1
       with:
         trigger: 'main'
         package-manager: 'uv'
@@ -69,10 +69,10 @@ jobs:
     if: github.event_name == 'release' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
-    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@main
+    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1.3.1
       with:
         trigger: 'release'
         package-manager: 'uv'

--- a/.github/workflows/github-pages-mkdocs.yml
+++ b/.github/workflows/github-pages-mkdocs.yml
@@ -31,11 +31,11 @@ jobs:
         group: mkdocs-deploy-pr-main
         cancel-in-progress: false
       steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1.3.1
+      - uses: serapeum-org/github-actions/actions/mkdocs-deploy@38c111084f99d5ff5f4a1e63bedce48fe33a10c0 # mkdocs/v1.3.1
         with:
           trigger: 'pull_request'
           package-manager: 'uv'
@@ -52,10 +52,10 @@ jobs:
       group: mkdocs-deploy-pr-main
       cancel-in-progress: false
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
-    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1.3.1
+    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@38c111084f99d5ff5f4a1e63bedce48fe33a10c0 # mkdocs/v1.3.1
       with:
         trigger: 'main'
         package-manager: 'uv'
@@ -69,10 +69,10 @@ jobs:
     if: github.event_name == 'release' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
-    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@mkdocs/v1.3.1
+    - uses: serapeum-org/github-actions/actions/mkdocs-deploy@38c111084f99d5ff5f4a1e63bedce48fe33a10c0 # mkdocs/v1.3.1
       with:
         trigger: 'release'
         package-manager: 'uv'

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ inputs.release-branch }}
@@ -57,7 +57,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release with Commitizen
-        uses: serapeum-org/github-actions/actions/release/github@github-release/v1.5.0
+        uses: serapeum-org/github-actions/actions/release/github@38c111084f99d5ff5f4a1e63bedce48fe33a10c0 # github-release/v1.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           increment: ${{ github.event.inputs.increment }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -64,6 +64,7 @@ jobs:
           prerelease-type: ${{ github.event.inputs.prerelease_type }}
           draft: ${{ github.event.inputs.draft }}
           package-manager: uv
+          package-manager-version: '0.12.1'
           python-version: "3.12"
           install-groups: "groups: dev docs"
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.release-branch }}
@@ -57,7 +57,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create GitHub Release with Commitizen
-        uses: serapeum-org/github-actions/actions/release/github@github-release/v1
+        uses: serapeum-org/github-actions/actions/release/github@github-release/v1.5.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           increment: ${{ github.event.inputs.increment }}

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -17,13 +17,13 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Build and publish to PyPI
-        uses: serapeum-org/github-actions/actions/release/pypi@pypi-release/v1
+        uses: serapeum-org/github-actions/actions/release/pypi@pypi-release/v1.0.3
         with:
           pypi-username: __token__
           pypi-password: ${{ secrets.PYPI_PUBLISH }}

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -17,13 +17,13 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Build and publish to PyPI
-        uses: serapeum-org/github-actions/actions/release/pypi@pypi-release/v1.0.3
+        uses: serapeum-org/github-actions/actions/release/pypi@38c111084f99d5ff5f4a1e63bedce48fe33a10c0 # pypi-release/v1.0.3
         with:
           pypi-username: __token__
           pypi-password: ${{ secrets.PYPI_PUBLISH }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,12 @@ jobs:
       OS: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@38c111084f99d5ff5f4a1e63bedce48fe33a10c0 # uv/v1.2.1
         with:
           python-version: ${{ matrix.python-version }}
           install-groups: "groups: dev"
@@ -37,7 +37,7 @@ jobs:
           uv run pytest -vvv --cov=src/cleopatra --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
 
       - name: test Jupyter notebook
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   main-package:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,12 +21,12 @@ jobs:
       OS: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1
+        uses: serapeum-org/github-actions/actions/python-setup/uv@uv/v1.2.1
         with:
           python-version: ${{ matrix.python-version }}
           install-groups: "groups: dev"
@@ -37,7 +37,7 @@ jobs:
           uv run pytest -vvv --cov=src/cleopatra --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
       - name: Upload coverage reports to Codecov with GitHub Action
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
 
       - name: test Jupyter notebook
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Set up Python
         uses: serapeum-org/github-actions/actions/python-setup/uv@38c111084f99d5ff5f4a1e63bedce48fe33a10c0 # uv/v1.2.1
         with:
+          version: '0.12.1'
           python-version: ${{ matrix.python-version }}
           install-groups: "groups: dev"
           verify-lock: true


### PR DESCRIPTION
# Description

Hardens the four workflows under `.github/workflows/` by updating and pinning every action reference, pinning the
`uv` package manager version to match the local dev environment, and tightening CI concurrency behavior:

- Bumped `actions/checkout` (`v5` → `v7.0.1`) and `codecov/codecov-action` (`v5` → `v7.0.0`), both of which were two
  majors behind.
- Pinned every `serapeum-org/github-actions` composite action (`mkdocs-deploy`, `release/github`, `release/pypi`,
  `python-setup/uv`) to a specific released version instead of the moving `v1` major tag.
- Fixed an inconsistency in `github-pages-mkdocs.yml` where the `deploy-pr` job pinned `mkdocs-deploy` to a version
  tag but `deploy-main`/`deploy-release` used an unpinned `@main` ref for the same action.
- Replaced every tag reference (third-party and internal) with the full commit SHA it currently resolves to, with
  the version kept as a trailing comment for readability. Tags are mutable, so this prevents a compromised or
  force-moved tag from silently pulling in different code on a future run.
- Pinned the `uv` version installed in `tests.yml` and `github-release.yml` to `0.12.1` (matching local dev)
  instead of letting it float to whatever is latest at run time. `pypi-release.yml` is left unpinned for now —
  `release/pypi` has no input to forward a `uv` version to the underlying `python-setup/uv` action; that would
  need an upstream change in `serapeum-org/github-actions`.
- Added a `concurrency` group to `tests.yml`: a new push to a pull request now cancels its own still-running test
  run (grouped by PR number), while pushes/merges to `main` are grouped by commit SHA so they're never cancelled
  and always run to completion, even if another push lands while one is in progress.

# Issues
- N/A (no linked issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

- Verified each pinned SHA matches the intended tag via the GitHub API (`repos/.../tags` and
  `repos/.../git/refs/tags/...`) before writing it into the workflow.
- Grepped `.github/workflows/` to confirm no floating tags (`v5`, `v1`, `@main`) remain.
- Confirmed the local `uv` version (`uv --version`) matches the `0.12.1` pinned in CI.
- Verified via the `serapeum-org/github-actions` composite action sources that `release/pypi` genuinely has no
  version-pin input, rather than assuming it did.
- Exercised on this PR itself: `tests.yml`, `deploy-pr` (mkdocs), SonarCloud, and GitGuardian checks all run
  against these changes.

- [x] Verified pinned SHAs against upstream tags via `gh api`
- [x] Confirmed no stale/unpinned action refs remain via grep
- [x] Confirmed local uv version matches the pinned CI version

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes