### PR TITLE
ci(docs): resolve the release tag for workflow_run-triggered deploys

### DIFF
--- a/.github/workflows/github-pages-mkdocs.yml
+++ b/.github/workflows/github-pages-mkdocs.yml
@@ -66,12 +66,23 @@ jobs:
         deploy-token: ${{ secrets.ACTIONS_DEPLOY_TOKEN }}
 
   deploy-release:
-    if: github.event_name == 'release' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    if: >-
+      github.event_name == 'release' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
+        ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+
+    - name: Extract version from pyproject.toml
+      id: version
+      run: |
+        VERSION=$(grep -m1 '^version' pyproject.toml | sed 's/.*"\(.*\)"/\1/')
+        echo "tag=$VERSION" >> $GITHUB_OUTPUT
+
     - uses: serapeum-org/github-actions/actions/mkdocs-deploy@38c111084f99d5ff5f4a1e63bedce48fe33a10c0 # mkdocs/v1.3.1
       with:
         trigger: 'release'
@@ -81,4 +92,5 @@ jobs:
         notebooks-path: 'docs/notebooks'
         notebooks-exclude: '**/.ipynb_checkpoints/**'
         deploy-token: ${{ secrets.ACTIONS_DEPLOY_TOKEN }}
+        release-tag: ${{ github.event.release.tag_name || steps.version.outputs.tag }}
         mike-alias: 'latest'


### PR DESCRIPTION
# Description

`deploy-release` in `github-pages-mkdocs.yml` hardcodes `trigger: 'release'` for the `mkdocs-deploy` composite
action but never supplies a `release-tag`. The action can only auto-resolve the version from
`github.event.release.tag_name`, which is only populated on a genuine `release` webhook event — not on the
`workflow_run` event this job normally runs from (triggered when `github-release` finishes). As a result the job
fails outright whenever it's reached the normal way, which is exactly what happened for the `0.27.0` release:
https://github.com/serapeum-org/cleopatra/actions/runs/30720586680/job/91423586068 — the docs site was never
updated for that release.

This mirrors the fix already in place in `pyramids`' `github-pages-mkdocs.yml`:

- Check out `github.event.workflow_run.head_branch || github.ref` instead of the default ref, so the job builds
  docs from the branch the release actually ran on rather than whatever `workflow_run`'s default checkout ref
  would be.
- Add a step that greps the version directly out of the just-bumped `pyproject.toml` on that branch (commitizen
  already wrote it there before this job runs).
- Pass `release-tag: ${{ github.event.release.tag_name || steps.version.outputs.tag }}`, so real `release` events
  keep using the event payload and `workflow_run` falls back to the extracted version.
- Guard the `workflow_run` branch of the job's `if:` with
  `github.event.workflow_run.head_repository.full_name == github.repository`, matching pyramids' fork-safety
  check.

# Issues
- N/A (no linked issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

- Compared against `pyramids`' `github-pages-mkdocs.yml`, which already runs this same pattern successfully in
  production.
- Confirmed cleopatra's `pyproject.toml` uses the same `version = "x.y.z"` line format the extraction grep expects.
- Not yet exercised against a real `workflow_run` event — that only happens once a subsequent `github-release` run
  completes, so the true validation is the next real release. The failing run linked above documents the exact
  failure mode this fixes.

- [x] Verified against pyramids' known-working equivalent implementation
- [x] Confirmed pyproject.toml version line format matches what the extraction step expects

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes