### PR TITLE
refactor(tiles): replace the mercantile dependency with built-in tile math

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,7 @@ conda install -c conda-forge cleopatra-tiles
 
 The conda packages are built from the
 [cleopatra-feedstock](https://github.com/conda-forge/cleopatra-feedstock)
-(the `cleopatra-tiles` output bundles `mercantile`, `pillow`, `pyproj`, and
-`xyzservices`).
+(the `cleopatra-tiles` output bundles `pillow`, `pyproj`, and `xyzservices`).
 
 ### From source (latest development version)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@
 
 ### Optional dependencies — the `tiles` extra
 
-The geospatial basemap features need four extra packages: the web-tile basemap helper
+The geospatial basemap features need three extra packages: the web-tile basemap helper
 (`cleopatra.tiles.add_tiles`), the reference-data layers (`cleopatra.reference.add_relief`
 for relief PNG decoding, and `cleopatra.reference.add_features(..., crs=...)` for
 reprojection), the orthographic globe presets in `cleopatra.projection`, and CRS
@@ -27,7 +27,6 @@ reprojection on the geographic glyphs (`GeoMixin.add_tiles` / `add_features` / `
 / `add_reference_map`). They are bundled in the `cleopatra[tiles]` extra (pip) / the
 `cleopatra-tiles` package (conda) and are otherwise not installed:
 
-- [mercantile](https://github.com/mapbox/mercantile) (1.2.1 or later)
 - [pillow](https://python-pillow.org/) (12.1.1 or later)
 - [pyproj](https://pyproj4.github.io/pyproj/) (3.7.2 or later)
 - [xyzservices](https://xyzservices.readthedocs.io/) (2026.3.0 or later)

--- a/docs/reference/tiles.md
+++ b/docs/reference/tiles.md
@@ -4,8 +4,8 @@ The `cleopatra.tiles` module adds an optional, pure-Python web-tile basemap help
 `add_tiles` fetches XYZ map tiles covering an axes' current extent, stitches them with
 Pillow, and renders the composite underneath your data. No GDAL is required.
 
-It is gated behind the `cleopatra[tiles]` optional extra (`mercantile`, `pillow`,
-`pyproj`, `xyzservices`):
+It is gated behind the `cleopatra[tiles]` optional extra (`pillow`, `pyproj`,
+`xyzservices`):
 
 === "pip"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
 
 [project.optional-dependencies]
 tiles = [
-    "mercantile>=1.2.1",
     "pillow>=12.1.1",
     "pyproj>=3.7.2",
     "xyzservices>=2026.3.0",

--- a/src/cleopatra/geo.py
+++ b/src/cleopatra/geo.py
@@ -20,9 +20,9 @@ it.
 
 Importing this module (and the `cleopatra.tiles` / `cleopatra.reference`
 modules it calls) does not require the optional `cleopatra[tiles]` extra:
-those modules gate their `[tiles]` dependencies (`mercantile`, `pyproj`,
-`Pillow`, ...) behind their own internal lazy imports, so the extra is
-only needed when a basemap is actually drawn.
+those modules gate their `[tiles]` dependencies (`pyproj`, `Pillow`, ...)
+behind their own internal lazy imports, so the extra is only needed when
+a basemap is actually drawn.
 """
 
 from __future__ import annotations

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -145,6 +145,14 @@ _EDGE_EPSILON = 1e-14
 #: to that single tile instead of spilling into the next row/column.
 _BBOX_EDGE_EPSILON = 1e-11
 
+#: Keeps `sin(radians(lat))` strictly inside `(-1, 1)`. Within about 6e-7
+#: degrees of either pole it rounds to exactly +/-1.0 in float64, which
+#: divides by zero in the Mercator `y` formula below; nudging it back from
+#: the boundary keeps that a (very large but finite, correctly clamped)
+#: number instead of a crash, matching this function's own documented
+#: contract to clamp rather than raise.
+_POLE_EPSILON = 1e-15
+
 
 def _lonlat_to_tile_xy(lon: float, lat: float, zoom: int) -> tuple[int, int]:
     """The `(x, y)` grid indices of the tile containing `(lon, lat)` at `zoom`.
@@ -168,6 +176,7 @@ def _lonlat_to_tile_xy(lon: float, lat: float, zoom: int) -> tuple[int, int]:
     n = 2**zoom
     frac_x = lon / 360.0 + 0.5
     sin_lat = math.sin(math.radians(lat))
+    sin_lat = max(-1.0 + _POLE_EPSILON, min(1.0 - _POLE_EPSILON, sin_lat))
     frac_y = 0.5 - 0.25 * math.log((1.0 + sin_lat) / (1.0 - sin_lat)) / math.pi
 
     if frac_x <= 0:

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -212,9 +212,9 @@ def _tiles_for_bbox(
         order `stitch_tiles`/tests expect).
     """
     w = max(-180.0, west)
-    s = max(-_MAX_LATITUDE, south)
+    s = max(-_MAX_LATITUDE, min(_MAX_LATITUDE, south))
     e = min(180.0, east)
-    n = min(_MAX_LATITUDE, north)
+    n = max(-_MAX_LATITUDE, min(_MAX_LATITUDE, north))
 
     x0, y0 = _lonlat_to_tile_xy(w, n, zoom)
     x1, y1 = _lonlat_to_tile_xy(e - _BBOX_EDGE_EPSILON, s + _BBOX_EDGE_EPSILON, zoom)

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -220,18 +220,10 @@ def _lonlat_to_tile_xy(lon: float, lat: float, zoom: int) -> tuple[int, int]:
     return x, y
 
 
-def _tiles_for_bbox(
+def _tiles_for_one_bbox(
     west: float, south: float, east: float, north: float, zoom: int
 ) -> list[Tile]:
-    """The `Tile`s covering a WGS84 bounding box at `zoom`.
-
-    `west`/`south`/`east`/`north` are clipped to the valid longitude
-    (+/-180) and Web Mercator latitude (+/-`_MAX_LATITUDE`) ranges first.
-    Requires `west <= east`: `add_tiles` always normalises its bbox with
-    `min`/`max` before calling this, so an antimeridian-crossing box (where
-    the "west" edge is numerically east of the "east" edge) never occurs
-    there -- this is checked explicitly rather than silently mishandled, in
-    case a future caller of this private helper doesn't uphold it.
+    """The `Tile`s covering one non-antimeridian-crossing WGS84 bbox at `zoom`.
 
     Args:
         west: Western bound, decimal degrees. Must be `<= east`.
@@ -242,31 +234,56 @@ def _tiles_for_bbox(
 
     Returns:
         list[Tile]: Every tile whose area intersects the bbox, ordered by
-        column then row (in `(x, y)` grid order, matching the iteration
-        order `stitch_tiles`/tests expect).
-
-    Raises:
-        ValueError: If `west > east` (an antimeridian-crossing box, not
-            supported -- splitting it into two sub-boxes the way
-            `mercantile.tiles` does is not implemented since no current
-            caller produces one).
+        column then row.
     """
-    if west > east:
-        raise ValueError(
-            f"_tiles_for_bbox does not support an antimeridian-crossing "
-            f"bbox (west={west!r} > east={east!r})"
-        )
     w = max(-180.0, west)
     s = max(-_MAX_LATITUDE, min(_MAX_LATITUDE, south))
     e = min(180.0, east)
-    n = max(-_MAX_LATITUDE, min(_MAX_LATITUDE, north))
+    n_clamped = max(-_MAX_LATITUDE, min(_MAX_LATITUDE, north))
 
-    x0, y0 = _lonlat_to_tile_xy(w, n, zoom)
+    x0, y0 = _lonlat_to_tile_xy(w, n_clamped, zoom)
     x1, y1 = _lonlat_to_tile_xy(e - _BBOX_EDGE_EPSILON, s + _BBOX_EDGE_EPSILON, zoom)
 
-    return [
-        Tile(i, j, zoom) for i in range(x0, x1 + 1) for j in range(y0, y1 + 1)
-    ]
+    return [Tile(i, j, zoom) for i in range(x0, x1 + 1) for j in range(y0, y1 + 1)]
+
+
+def _tiles_for_bbox(
+    west: float, south: float, east: float, north: float, zoom: int
+) -> list[Tile]:
+    """The `Tile`s covering a WGS84 bounding box at `zoom`.
+
+    `west`/`south`/`east`/`north` are clipped to the valid longitude
+    (+/-180) and Web Mercator latitude (+/-`_MAX_LATITUDE`) ranges first. A
+    `west > east` bbox is antimeridian-crossing (its west edge is
+    numerically east of its east edge, e.g. 170 to -170): rather than an
+    edge case to special-case away, this is a real, reachable input --
+    `add_tiles` normalises its bbox with `min`/`max` in its own *native*
+    CRS, but a near-global Web Mercator extent can still reproject to a
+    `west > east` pair in EPSG:4326, since the inverse transform wraps
+    longitude at the +/-180 seam. Handled the same way
+    `mercantile.tiles()` handles it: split into the two sub-boxes either
+    side of the seam (`[-180, east]` and `[west, 180]`) and concatenate
+    their tiles.
+
+    Args:
+        west: Western bound, decimal degrees.
+        south: Southern bound, decimal degrees.
+        east: Eastern bound, decimal degrees.
+        north: Northern bound, decimal degrees.
+        zoom: Web Mercator zoom level.
+
+    Returns:
+        list[Tile]: Every tile whose area intersects the bbox, ordered by
+        column then row (in `(x, y)` grid order, matching the iteration
+        order `stitch_tiles`/tests expect). For an antimeridian-crossing
+        bbox, the western sub-box's tiles come first, then the eastern
+        sub-box's.
+    """
+    if west > east:
+        return _tiles_for_one_bbox(-180.0, south, east, north, zoom) + (
+            _tiles_for_one_bbox(west, south, 180.0, north, zoom)
+        )
+    return _tiles_for_one_bbox(west, south, east, north, zoom)
 
 
 def _tile_xy_bounds(tile: Tile) -> tuple[float, float, float, float]:

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -107,12 +107,36 @@ class Tile(NamedTuple):
     north to south. Hashable and immutable, so it doubles as a dict key
     (see `fetch_tiles`'s `tile -> PNG bytes` mapping).
 
+    Attributes:
+        x: Column index, `0` (west edge) to `2**z - 1` (east edge).
+        y: Row index, `0` (north edge) to `2**z - 1` (south edge).
+        z: Zoom level; the grid is `2**z` tiles wide and tall.
+
     Examples:
         - The single tile covering the whole world at zoom 0:
             ```python
             >>> from cleopatra.tiles import Tile
             >>> Tile(0, 0, 0)
             Tile(x=0, y=0, z=0)
+
+            ```
+        - Two tiles compare equal by value, so one can look the other up
+            in a `{tile: data}` mapping (as `fetch_tiles`'s return value does):
+            ```python
+            >>> from cleopatra.tiles import Tile
+            >>> tile_data = {Tile(548, 335, 10): b"...png bytes..."}
+            >>> tile_data[Tile(x=548, y=335, z=10)]
+            b'...png bytes...'
+
+            ```
+        - Fields are accessible by name or by position:
+            ```python
+            >>> from cleopatra.tiles import Tile
+            >>> tile = Tile(548, 335, 10)
+            >>> tile.z
+            10
+            >>> tile[:2]
+            (548, 335)
 
             ```
     """

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -194,13 +194,14 @@ def _tiles_for_bbox(
 
     `west`/`south`/`east`/`north` are clipped to the valid longitude
     (+/-180) and Web Mercator latitude (+/-`_MAX_LATITUDE`) ranges first.
-    Assumes `west <= east`: `add_tiles` always normalises its bbox with
+    Requires `west <= east`: `add_tiles` always normalises its bbox with
     `min`/`max` before calling this, so an antimeridian-crossing box (where
     the "west" edge is numerically east of the "east" edge) never occurs
-    here.
+    there -- this is checked explicitly rather than silently mishandled, in
+    case a future caller of this private helper doesn't uphold it.
 
     Args:
-        west: Western bound, decimal degrees.
+        west: Western bound, decimal degrees. Must be `<= east`.
         south: Southern bound, decimal degrees.
         east: Eastern bound, decimal degrees.
         north: Northern bound, decimal degrees.
@@ -208,9 +209,20 @@ def _tiles_for_bbox(
 
     Returns:
         list[Tile]: Every tile whose area intersects the bbox, ordered by
-        row then column (in `(x, y)` grid order, matching the iteration
+        column then row (in `(x, y)` grid order, matching the iteration
         order `stitch_tiles`/tests expect).
+
+    Raises:
+        ValueError: If `west > east` (an antimeridian-crossing box, not
+            supported -- splitting it into two sub-boxes the way
+            `mercantile.tiles` does is not implemented since no current
+            caller produces one).
     """
+    if west > east:
+        raise ValueError(
+            f"_tiles_for_bbox does not support an antimeridian-crossing "
+            f"bbox (west={west!r} > east={east!r})"
+        )
     w = max(-180.0, west)
     s = max(-_MAX_LATITUDE, min(_MAX_LATITUDE, south))
     e = min(180.0, east)

--- a/src/cleopatra/tiles.py
+++ b/src/cleopatra/tiles.py
@@ -45,7 +45,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any
+from typing import Any, NamedTuple
 
 import numpy as np
 
@@ -70,8 +70,10 @@ _TILES_EXTRA_HINT = (
 )
 
 #: Import names of the packages the `[tiles]` extra provides ("PIL" is
-#: Pillow's import name).
-_TILES_EXTRA_MODULES = ("mercantile", "xyzservices", "PIL", "pyproj")
+#: Pillow's import name). The XYZ tile-grid math itself (`Tile`,
+#: `_tiles_for_bbox`, `_tile_xy_bounds` below) is implemented directly in
+#: this module rather than via a `mercantile` dependency.
+_TILES_EXTRA_MODULES = ("xyzservices", "PIL", "pyproj")
 
 #: True when every `[tiles]`-extra dependency is importable. Probed with
 #: `importlib.util.find_spec` so importing this module does not pull
@@ -89,11 +91,155 @@ def _require_tiles_extra() -> None:
         None
 
     Raises:
-        ImportError: If any of mercantile, xyzservices, Pillow, or
-            pyproj is missing from the active environment.
+        ImportError: If any of xyzservices, Pillow, or pyproj is missing
+            from the active environment.
     """
     if not _TILES_AVAILABLE:
         raise ImportError(_TILES_EXTRA_HINT)
+
+
+class Tile(NamedTuple):
+    """An XYZ web-map tile: column `x`, row `y`, at zoom level `z`.
+
+    The standard "slippy map" tile-coordinate triple used by every XYZ tile
+    provider (OpenStreetMap, CartoDB, Esri, ...): at zoom `z` the world is
+    divided into a `2**z` by `2**z` grid, `x` counted west to east and `y`
+    north to south. Hashable and immutable, so it doubles as a dict key
+    (see `fetch_tiles`'s `tile -> PNG bytes` mapping).
+
+    Examples:
+        - The single tile covering the whole world at zoom 0:
+            ```python
+            >>> from cleopatra.tiles import Tile
+            >>> Tile(0, 0, 0)
+            Tile(x=0, y=0, z=0)
+
+            ```
+    """
+
+    x: int
+    y: int
+    z: int
+
+
+#: WGS84 semi-major axis (metres) -- the sphere radius spherical Web Mercator
+#: (EPSG:3857) projects onto.
+_EARTH_RADIUS = 6378137.0
+
+#: Circumference of the Web Mercator sphere (metres): the width and height,
+#: in projected metres, of the whole world at any zoom level.
+_CIRCUMFERENCE = 2 * math.pi * _EARTH_RADIUS
+
+#: The maximum (and, negated, minimum) latitude Web Mercator can represent --
+#: beyond this the projection's `y` coordinate diverges to infinity. XYZ tile
+#: grids clip to this band and simply do not cover the poles.
+_MAX_LATITUDE = 85.051129
+
+#: Nudges a coordinate sitting exactly on a tile edge into the tile that edge
+#: belongs to, rather than the next one over (floating-point rounding right
+#: at a boundary would otherwise go either way).
+_EDGE_EPSILON = 1e-14
+
+#: Nudges a bounding box's east/south edge inward before locating its
+#: lower-right tile, so a box that exactly matches one tile's bounds resolves
+#: to that single tile instead of spilling into the next row/column.
+_BBOX_EDGE_EPSILON = 1e-11
+
+
+def _lonlat_to_tile_xy(lon: float, lat: float, zoom: int) -> tuple[int, int]:
+    """The `(x, y)` grid indices of the tile containing `(lon, lat)` at `zoom`.
+
+    Standard Web Mercator "slippy map" tile math (see e.g.
+    https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames): projects the
+    point to fractional `(x, y)` in `[0, 1]` (0,0 at the northwest corner of
+    the world, 1,1 at the southeast), then scales by the `2**zoom` grid and
+    floors. A point outside Web Mercator's representable range (past
+    `_MAX_LATITUDE`, or a longitude outside +/-180) clamps to the nearest
+    edge tile rather than raising.
+
+    Args:
+        lon: Longitude in decimal degrees.
+        lat: Latitude in decimal degrees.
+        zoom: Web Mercator zoom level.
+
+    Returns:
+        tuple[int, int]: The `(x, y)` tile indices, each in `[0, 2**zoom - 1]`.
+    """
+    n = 2**zoom
+    frac_x = lon / 360.0 + 0.5
+    sin_lat = math.sin(math.radians(lat))
+    frac_y = 0.5 - 0.25 * math.log((1.0 + sin_lat) / (1.0 - sin_lat)) / math.pi
+
+    if frac_x <= 0:
+        x = 0
+    elif frac_x >= 1:
+        x = n - 1
+    else:
+        x = int(math.floor((frac_x + _EDGE_EPSILON) * n))
+
+    if frac_y <= 0:
+        y = 0
+    elif frac_y >= 1:
+        y = n - 1
+    else:
+        y = int(math.floor((frac_y + _EDGE_EPSILON) * n))
+
+    return x, y
+
+
+def _tiles_for_bbox(
+    west: float, south: float, east: float, north: float, zoom: int
+) -> list[Tile]:
+    """The `Tile`s covering a WGS84 bounding box at `zoom`.
+
+    `west`/`south`/`east`/`north` are clipped to the valid longitude
+    (+/-180) and Web Mercator latitude (+/-`_MAX_LATITUDE`) ranges first.
+    Assumes `west <= east`: `add_tiles` always normalises its bbox with
+    `min`/`max` before calling this, so an antimeridian-crossing box (where
+    the "west" edge is numerically east of the "east" edge) never occurs
+    here.
+
+    Args:
+        west: Western bound, decimal degrees.
+        south: Southern bound, decimal degrees.
+        east: Eastern bound, decimal degrees.
+        north: Northern bound, decimal degrees.
+        zoom: Web Mercator zoom level.
+
+    Returns:
+        list[Tile]: Every tile whose area intersects the bbox, ordered by
+        row then column (in `(x, y)` grid order, matching the iteration
+        order `stitch_tiles`/tests expect).
+    """
+    w = max(-180.0, west)
+    s = max(-_MAX_LATITUDE, south)
+    e = min(180.0, east)
+    n = min(_MAX_LATITUDE, north)
+
+    x0, y0 = _lonlat_to_tile_xy(w, n, zoom)
+    x1, y1 = _lonlat_to_tile_xy(e - _BBOX_EDGE_EPSILON, s + _BBOX_EDGE_EPSILON, zoom)
+
+    return [
+        Tile(i, j, zoom) for i in range(x0, x1 + 1) for j in range(y0, y1 + 1)
+    ]
+
+
+def _tile_xy_bounds(tile: Tile) -> tuple[float, float, float, float]:
+    """The Web Mercator (EPSG:3857) bounds of `tile`.
+
+    Args:
+        tile: The tile to bound.
+
+    Returns:
+        tuple[float, float, float, float]: `(left, bottom, right, top)` in
+        EPSG:3857 metres.
+    """
+    tile_size = _CIRCUMFERENCE / 2**tile.z
+    left = tile.x * tile_size - _CIRCUMFERENCE / 2
+    right = left + tile_size
+    top = _CIRCUMFERENCE / 2 - tile.y * tile_size
+    bottom = top - tile_size
+    return left, bottom, right, top
 
 
 def get_provider(name: str | None = None) -> Any:
@@ -423,9 +569,8 @@ def fetch_single_tile(
         - Fetch a single OpenStreetMap tile (network-dependent, hence
             skipped under doctest):
             ```python
-            >>> import mercantile
-            >>> from cleopatra.tiles import fetch_single_tile, get_provider
-            >>> tile = mercantile.Tile(0, 0, 0)
+            >>> from cleopatra.tiles import Tile, fetch_single_tile, get_provider
+            >>> tile = Tile(0, 0, 0)
             >>> provider = get_provider("OpenStreetMap.Mapnik")
             >>> tile_obj, data = fetch_single_tile(  # doctest: +SKIP
             ...     tile, provider, timeout=10, retries=2
@@ -438,8 +583,7 @@ def fetch_single_tile(
         - Tile failures raise `ConnectionError` after retries
             are exhausted:
             ```python
-            >>> import mercantile
-            >>> from cleopatra.tiles import fetch_single_tile
+            >>> from cleopatra.tiles import Tile, fetch_single_tile
             >>> from xyzservices import TileProvider
             >>> bad = TileProvider(
             ...     name="bad",
@@ -447,7 +591,7 @@ def fetch_single_tile(
             ...     attribution="",
             ... )
             >>> fetch_single_tile(  # doctest: +SKIP
-            ...     mercantile.Tile(0, 0, 0), bad, timeout=1, retries=0
+            ...     Tile(0, 0, 0), bad, timeout=1, retries=0
             ... )
             Traceback (most recent call last):
                 ...
@@ -530,9 +674,8 @@ def fetch_tiles(
         - Fetch a small tile grid in parallel (network-dependent, hence
             skipped under doctest):
             ```python
-            >>> import mercantile
-            >>> from cleopatra.tiles import fetch_tiles, get_provider
-            >>> tiles = list(mercantile.tiles(13.0, 52.4, 13.6, 52.6, zooms=10))
+            >>> from cleopatra.tiles import _tiles_for_bbox, fetch_tiles, get_provider
+            >>> tiles = _tiles_for_bbox(13.0, 52.4, 13.6, 52.6, 10)
             >>> provider = get_provider("OpenStreetMap.Mapnik")
             >>> data = fetch_tiles(tiles, provider, max_workers=4)  # doctest: +SKIP
             >>> len(data) == len(tiles)  # doctest: +SKIP
@@ -582,7 +725,7 @@ def stitch_tiles(
     Arranges tiles in a grid based on their `x`, `y` positions. The
     tile size is read from the first decoded image (typically 256 or
     512 px). Computes the geographic extent of the stitched image in
-    EPSG:3857 using `mercantile.xy_bounds` on the corner tiles.
+    EPSG:3857 using `_tile_xy_bounds` on the corner tiles.
 
     Args:
         tile_data: Mapping of Tile to PNG bytes (from
@@ -603,12 +746,11 @@ def stitch_tiles(
         - Stitch a single synthetic tile into a 256x256 RGBA image:
             ```python
             >>> import io
-            >>> import mercantile
             >>> from PIL import Image
-            >>> from cleopatra.tiles import stitch_tiles
+            >>> from cleopatra.tiles import Tile, stitch_tiles
             >>> buf = io.BytesIO()
             >>> Image.new("RGBA", (256, 256), (255, 0, 0, 255)).save(buf, "PNG")
-            >>> tile = mercantile.Tile(0, 0, 0)
+            >>> tile = Tile(0, 0, 0)
             >>> image, extent = stitch_tiles({tile: buf.getvalue()}, [tile], 0)
             >>> image.shape
             (256, 256, 4)
@@ -617,15 +759,14 @@ def stitch_tiles(
 
             ```
         - The returned EPSG:3857 extent comes from
-            `mercantile.xy_bounds` on the corner tiles:
+            `_tile_xy_bounds` on the corner tiles:
             ```python
             >>> import io
-            >>> import mercantile
             >>> from PIL import Image
-            >>> from cleopatra.tiles import stitch_tiles
+            >>> from cleopatra.tiles import Tile, stitch_tiles
             >>> buf = io.BytesIO()
             >>> Image.new("RGBA", (256, 256), (0, 255, 0, 255)).save(buf, "PNG")
-            >>> tile = mercantile.Tile(0, 0, 0)
+            >>> tile = Tile(0, 0, 0)
             >>> _, (w, s, e, n) = stitch_tiles({tile: buf.getvalue()}, [tile], 0)
             >>> w < e and s < n
             True
@@ -633,9 +774,8 @@ def stitch_tiles(
             ```
         - Invalid tile bytes raise `ValueError`:
             ```python
-            >>> import mercantile
-            >>> from cleopatra.tiles import stitch_tiles
-            >>> tile = mercantile.Tile(0, 0, 0)
+            >>> from cleopatra.tiles import Tile, stitch_tiles
+            >>> tile = Tile(0, 0, 0)
             >>> try:
             ...     stitch_tiles({tile: b"not an image"}, [tile], 0)
             ... except ValueError as exc:
@@ -645,7 +785,6 @@ def stitch_tiles(
             ```
     """
     _require_tiles_extra()
-    import mercantile
     from PIL import Image
 
     try:
@@ -676,9 +815,13 @@ def stitch_tiles(
 
     image = np.array(merged)
 
-    tl = mercantile.xy_bounds(mercantile.Tile(x_indices[0], y_indices[0], zoom))
-    br = mercantile.xy_bounds(mercantile.Tile(x_indices[-1], y_indices[-1], zoom))
-    extent_3857 = (tl.left, br.bottom, br.right, tl.top)
+    tl_left, _tl_bottom, _tl_right, tl_top = _tile_xy_bounds(
+        Tile(x_indices[0], y_indices[0], zoom)
+    )
+    _br_left, br_bottom, br_right, _br_top = _tile_xy_bounds(
+        Tile(x_indices[-1], y_indices[-1], zoom)
+    )
+    extent_3857 = (tl_left, br_bottom, br_right, tl_top)
 
     return image, extent_3857
 
@@ -768,7 +911,6 @@ def add_tiles(
         >>> _ = add_tiles(ax, crs=3857)  # doctest: +SKIP
     """
     _require_tiles_extra()
-    import mercantile
     from pyproj import Transformer
 
     if not hasattr(ax, "get_xlim") or not hasattr(ax, "get_ylim"):
@@ -854,11 +996,11 @@ def add_tiles(
             raise ValueError(f"zoom must be 0-19, got {tile_zoom}")
 
     original_zoom = tile_zoom
-    tiles = list(mercantile.tiles(w4326, s4326, e4326, n4326, zooms=tile_zoom))
+    tiles = _tiles_for_bbox(w4326, s4326, e4326, n4326, zoom=tile_zoom)
 
     while len(tiles) > max_tiles and tile_zoom > 0:
         tile_zoom -= 1
-        tiles = list(mercantile.tiles(w4326, s4326, e4326, n4326, zooms=tile_zoom))
+        tiles = _tiles_for_bbox(w4326, s4326, e4326, n4326, zoom=tile_zoom)
 
     if tile_zoom != original_zoom:
         logger.warning(

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -638,8 +638,8 @@ class TestTile:
         assert (tile[0], tile[1], tile[2]) == (1, 2, 3), f"unexpected indexing: {tile}"
 
     def test_equality_is_by_value(self):
-        """Two `Tile`s with the same `(x, y, z)` compare equal."""
-        assert Tile(1, 2, 3) == Tile(1, 2, 3)
+        """Two independently-constructed `Tile`s with the same fields compare equal."""
+        assert Tile(1, 2, 3) == Tile(x=1, y=2, z=3)
         assert Tile(1, 2, 3) != Tile(1, 2, 4)
 
     def test_hashable_as_dict_key(self):

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -9,7 +9,6 @@ that pyramids uses for its basemap tests.
 from __future__ import annotations
 
 import io
-from collections import namedtuple
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import numpy as np
@@ -18,7 +17,6 @@ import pytest
 pytestmark = pytest.mark.plot
 
 pytest.importorskip("PIL", reason="Pillow not installed (tiles extra)")
-pytest.importorskip("mercantile", reason="mercantile not installed (tiles extra)")
 pytest.importorskip("xyzservices", reason="xyzservices not installed (tiles extra)")
 pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
 
@@ -32,6 +30,7 @@ from PIL import Image  # noqa: E402
 from cleopatra import tiles as tiles_mod  # noqa: E402
 from cleopatra.tiles import (  # noqa: E402
     MAX_TILES,
+    Tile,
     _densify_and_reproject_bounds,
     _looks_like_image,
     _require_tiles_extra,
@@ -42,8 +41,6 @@ from cleopatra.tiles import (  # noqa: E402
     get_provider,
     stitch_tiles,
 )
-
-Tile = namedtuple("Tile", ["x", "y", "z"])
 
 
 def _make_tile_png(size: int = 256) -> bytes:
@@ -442,8 +439,6 @@ class TestAddTilesIntegration:
 
     def test_max_tiles_reduces_zoom(self, mock_ax):
         """Zoom is decreased when the requested level needs > MAX_TILES tiles."""
-        import mercantile as merc_mod
-
         fake_image = np.zeros((256, 256, 4), dtype=np.uint8)
         many_tiles = [Tile(x=i, y=j, z=10) for i in range(20) for j in range(20)]
         few_tiles = [Tile(x=i, y=j, z=9) for i in range(10) for j in range(10)]
@@ -464,8 +459,8 @@ class TestAddTilesIntegration:
                 ),
             ),
             patch.object(
-                merc_mod,
-                "tiles",
+                tiles_mod,
+                "_tiles_for_bbox",
                 side_effect=[many_tiles, few_tiles],
             ) as mock_tiles,
         ):
@@ -473,13 +468,11 @@ class TestAddTilesIntegration:
 
         calls = mock_tiles.call_args_list
         assert len(calls) == 2
-        assert calls[0][1]["zooms"] == 10
-        assert calls[1][1]["zooms"] == 9
+        assert calls[0][1]["zoom"] == 10
+        assert calls[1][1]["zoom"] == 9
 
     def test_custom_max_tiles_relaxes_reduction(self, mock_ax):
         """A higher `max_tiles=` avoids the zoom reduction (N2)."""
-        import mercantile as merc_mod
-
         fake_image = np.zeros((256, 256, 4), dtype=np.uint8)
         # 400 tiles at the requested zoom — over the default 256, under 500.
         many_tiles = [Tile(x=i, y=j, z=10) for i in range(20) for j in range(20)]
@@ -496,13 +489,15 @@ class TestAddTilesIntegration:
                 "stitch_tiles",
                 return_value=(fake_image, (1e6, 6e6, 1.2e6, 6.2e6)),
             ),
-            patch.object(merc_mod, "tiles", side_effect=[many_tiles]) as mock_tiles,
+            patch.object(
+                tiles_mod, "_tiles_for_bbox", side_effect=[many_tiles]
+            ) as mock_tiles,
         ):
             add_tiles(mock_ax, crs=3857, max_tiles=500)
 
         # Only one call: 400 <= max_tiles=500, so no reduction.
         assert len(mock_tiles.call_args_list) == 1
-        assert mock_tiles.call_args_list[0][1]["zooms"] == 10
+        assert mock_tiles.call_args_list[0][1]["zoom"] == 10
 
     @pytest.mark.parametrize("bad", [0, -1, 2.5, True, "8"])
     def test_invalid_max_tiles_raises(self, mock_ax, bad):
@@ -1086,15 +1081,13 @@ class TestAddTilesCRSReprojectionFailure:
 
 
 class TestAddTilesEmptyTiles:
-    """Cover the branch where mercantile returns no tiles."""
+    """Cover the branch where the bbox has no covering tiles."""
 
     def test_empty_tiles_raises_value_error(self, mock_ax):
         """An empty tile list at the resolved zoom raises `ValueError`."""
-        import mercantile as merc_mod
-
         with (
             patch.object(tiles_mod, "auto_zoom", return_value=10),
-            patch.object(merc_mod, "tiles", return_value=[]),
+            patch.object(tiles_mod, "_tiles_for_bbox", return_value=[]),
         ):
             with pytest.raises(ValueError, match="No tiles found"):
                 add_tiles(mock_ax, crs=3857)

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -628,6 +628,31 @@ class TestDensifyAndReprojectEdgeCases:
         )
 
 
+class TestTile:
+    """Tests for `cleopatra.tiles.Tile`."""
+
+    def test_fields_are_positional_and_named(self):
+        """`Tile(x, y, z)` stores each field, accessible both by name and by index."""
+        tile = Tile(1, 2, 3)
+        assert (tile.x, tile.y, tile.z) == (1, 2, 3), f"unexpected fields: {tile}"
+        assert (tile[0], tile[1], tile[2]) == (1, 2, 3), f"unexpected indexing: {tile}"
+
+    def test_equality_is_by_value(self):
+        """Two `Tile`s with the same `(x, y, z)` compare equal."""
+        assert Tile(1, 2, 3) == Tile(1, 2, 3)
+        assert Tile(1, 2, 3) != Tile(1, 2, 4)
+
+    def test_hashable_as_dict_key(self):
+        """`Tile` is hashable, so it can key a `{tile: data}` mapping (as `fetch_tiles` does)."""
+        mapping = {Tile(0, 0, 0): b"a", Tile(1, 0, 1): b"b"}
+        assert mapping[Tile(0, 0, 0)] == b"a"
+        assert mapping[Tile(1, 0, 1)] == b"b"
+
+    def test_repr_is_readable(self):
+        """`repr(Tile(...))` names the fields, matching the module's own doctest."""
+        assert repr(Tile(0, 0, 0)) == "Tile(x=0, y=0, z=0)"
+
+
 class TestLonLatToTileXY:
     """Tests for `cleopatra.tiles._lonlat_to_tile_xy`.
 
@@ -713,6 +738,18 @@ class TestTilesForBbox:
         """A zero-area (single-point) bbox still resolves to the one tile containing it."""
         tiles = _tiles_for_bbox(13.4, 52.5, 13.4, 52.5, zoom=10)
         assert tiles == [Tile(550, 335, 10)]
+
+    def test_zero_width_bbox_resolves_to_a_single_column(self):
+        """A `west == east` bbox (zero width, non-zero height) still resolves sanely.
+
+        Test scenario:
+            A degenerate box that collapses only one axis (unlike the
+            single-point case above, which collapses both) should still
+            return every tile row the non-degenerate `south`/`north` span
+            covers, all in the same column.
+        """
+        tiles = sorted(_tiles_for_bbox(13.4, 52.4, 13.4, 52.6, zoom=10))
+        assert tiles == [Tile(550, 335, 10), Tile(550, 336, 10)]
 
     def test_high_zoom_small_bbox(self):
         """A small bbox at zoom 18 resolves to the mercantile-verified 8x13 tile grid."""

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -785,6 +785,34 @@ class TestTilesForBbox:
         expected = sorted([Tile(0, 7, 4), Tile(0, 8, 4), Tile(15, 7, 4), Tile(15, 8, 4)])
         assert tiles == expected
 
+    def test_antimeridian_crossing_bbox_also_touching_a_pole(self):
+        """An antimeridian-crossing bbox that also clips the north pole splits and clamps.
+
+        Both the west>east split and the latitude clamp apply at once;
+        verified to match `mercantile.tiles()` exactly for this combination.
+        """
+        tiles = sorted(_tiles_for_bbox(170.0, 80.0, -170.0, 85.0, zoom=4))
+        expected = sorted([Tile(0, 0, 4), Tile(0, 1, 4), Tile(15, 0, 4), Tile(15, 1, 4)])
+        assert tiles == expected
+
+    def test_antimeridian_crossing_bbox_at_zoom_0(self):
+        """An antimeridian-crossing bbox at zoom 0 matches mercantile's own duplicate-tile quirk.
+
+        At zoom 0 there is only one tile in the whole world, so both
+        dateline-side sub-boxes resolve to it; `mercantile.tiles()` does
+        not deduplicate across the split and returns it twice, and this
+        implementation matches that exactly rather than silently
+        "improving" on it.
+        """
+        tiles = _tiles_for_bbox(170.0, -10.0, -170.0, 10.0, zoom=0)
+        assert tiles == [Tile(0, 0, 0), Tile(0, 0, 0)]
+
+    def test_antimeridian_crossing_bbox_with_east_exactly_on_seam(self):
+        """An antimeridian-crossing bbox whose `east` sits exactly on `-180` still splits correctly."""
+        tiles = sorted(_tiles_for_bbox(170.0, -10.0, -180.0, 10.0, zoom=4))
+        expected = sorted([Tile(0, 7, 4), Tile(0, 8, 4), Tile(15, 7, 4), Tile(15, 8, 4)])
+        assert tiles == expected
+
 
 class TestTileXYBounds:
     """Tests for `cleopatra.tiles._tile_xy_bounds`.

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -32,8 +32,11 @@ from cleopatra.tiles import (  # noqa: E402
     MAX_TILES,
     Tile,
     _densify_and_reproject_bounds,
+    _lonlat_to_tile_xy,
     _looks_like_image,
     _require_tiles_extra,
+    _tile_xy_bounds,
+    _tiles_for_bbox,
     add_tiles,
     auto_zoom,
     fetch_single_tile,
@@ -623,6 +626,150 @@ class TestDensifyAndReprojectEdgeCases:
         assert all(np.isfinite([west, south, east, north])), (
             f"Bounds should all be finite, got ({west}, {south}, {east}, {north})"
         )
+
+
+class TestLonLatToTileXY:
+    """Tests for `cleopatra.tiles._lonlat_to_tile_xy`.
+
+    Expected `(x, y)` pairs are cross-checked against the real `mercantile`
+    package's `mercantile.tile()` (see the removal PR's commit messages for
+    the full equivalence-fuzzing methodology); the literal values here just
+    lock those results in as a regression test that doesn't need
+    `mercantile` installed to run.
+    """
+
+    @pytest.mark.parametrize(
+        "lon, lat, zoom, expected",
+        [
+            (0.0, 0.0, 0, (0, 0)),
+            (13.4, 52.5, 10, (550, 335)),
+            (-179.9, 89.9, 3, (0, 0)),
+            (179.9, -89.9, 3, (7, 7)),
+            (0.0, 0.0, 1, (1, 1)),
+        ],
+        ids=["world-origin-z0", "berlin-z10", "nw-corner", "se-corner", "equator-z1"],
+    )
+    def test_known_points(self, lon, lat, zoom, expected):
+        """Known (lon, lat, zoom) triples resolve to their mercantile-verified tile index."""
+        assert _lonlat_to_tile_xy(lon, lat, zoom) == expected
+
+    @pytest.mark.parametrize(
+        "lon, expected_x",
+        [(200.0, 31), (-200.0, 0), (180.0, 31), (-180.0, 0)],
+        ids=["past-east-edge", "past-west-edge", "east-edge", "west-edge"],
+    )
+    def test_out_of_range_longitude_clamps_to_edge_column(self, lon, expected_x):
+        """A longitude outside +/-180 (or exactly on it) clamps to the edge column, not raise."""
+        x, _y = _lonlat_to_tile_xy(lon, 0.0, zoom=5)
+        assert x == expected_x
+
+    @pytest.mark.parametrize(
+        "lat, expected_y",
+        [(90.0, 0), (-90.0, 31), (89.99999999, 0), (-89.99999999, 31)],
+        ids=["exact-north-pole", "exact-south-pole", "near-north-pole", "near-south-pole"],
+    )
+    def test_pole_latitude_clamps_instead_of_crashing(self, lat, expected_y):
+        """A latitude at (or within float precision of) +/-90 clamps to the edge row.
+
+        Regression test for a `ZeroDivisionError`/`ValueError: math domain
+        error` that used to be raised here: `sin(radians(lat))` rounds to
+        exactly +/-1.0 within ~6e-7 degrees of either pole, dividing by zero
+        in the Mercator `y` formula.
+        """
+        _x, y = _lonlat_to_tile_xy(0.0, lat, zoom=5)
+        assert y == expected_y
+
+
+class TestTilesForBbox:
+    """Tests for `cleopatra.tiles._tiles_for_bbox`.
+
+    Expected tile lists are cross-checked against `mercantile.tiles()` (see
+    the removal PR's commit messages); the literal values here lock those
+    results in without needing `mercantile` installed to run.
+    """
+
+    def test_whole_world_at_zoom_0_is_one_tile(self):
+        """The whole world at zoom 0 is exactly the single root tile."""
+        assert _tiles_for_bbox(-180.0, -85.0, 180.0, 85.0, zoom=0) == [Tile(0, 0, 0)]
+
+    def test_known_city_bbox(self):
+        """A real-world (Berlin) bbox resolves to its mercantile-verified 2x3 tile grid."""
+        tiles = sorted(_tiles_for_bbox(13.0, 52.4, 13.6, 52.6, zoom=10))
+        expected = sorted(
+            Tile(x, y, 10)
+            for x in (548, 549, 550)
+            for y in (335, 336)
+        )
+        assert tiles == expected
+
+    def test_bbox_exactly_matching_one_tile_resolves_to_that_tile(self):
+        """A bbox exactly on one tile's own lon/lat bounds resolves to just that tile."""
+        tiles = _tiles_for_bbox(
+            13.359375, 52.48278022207821, 13.7109375, 52.69636107827448, zoom=10
+        )
+        assert tiles == [Tile(550, 335, 10)]
+
+    def test_degenerate_point_bbox_resolves_to_one_tile(self):
+        """A zero-area (single-point) bbox still resolves to the one tile containing it."""
+        tiles = _tiles_for_bbox(13.4, 52.5, 13.4, 52.5, zoom=10)
+        assert tiles == [Tile(550, 335, 10)]
+
+    def test_high_zoom_small_bbox(self):
+        """A small bbox at zoom 18 resolves to the mercantile-verified 8x13 tile grid."""
+        tiles = _tiles_for_bbox(13.4, 52.5, 13.41, 52.51, zoom=18)
+        xs = sorted({t.x for t in tiles})
+        ys = sorted({t.y for t in tiles})
+        assert len(tiles) == 104
+        assert (xs[0], xs[-1]) == (140829, 140836)
+        assert (ys[0], ys[-1]) == (85983, 85995)
+
+    def test_bbox_touching_north_pole_clamps_instead_of_crashing(self):
+        """A bbox whose `north` is exactly 90 clamps to the top row rather than crashing."""
+        tiles = sorted(_tiles_for_bbox(-1.0, 89.0, 1.0, 90.0, zoom=5))
+        assert tiles == [Tile(15, 0, 5), Tile(16, 0, 5)]
+
+    def test_bbox_touching_south_pole_clamps_instead_of_crashing(self):
+        """A bbox whose `south` is exactly -90 clamps to the bottom row rather than crashing."""
+        tiles = sorted(_tiles_for_bbox(-1.0, -90.0, 1.0, -89.0, zoom=5))
+        assert tiles == [Tile(15, 31, 5), Tile(16, 31, 5)]
+
+    def test_antimeridian_crossing_bbox_raises(self):
+        """A `west > east` bbox (antimeridian-crossing) raises instead of returning `[]`."""
+        with pytest.raises(ValueError, match="antimeridian"):
+            _tiles_for_bbox(170.0, -10.0, -170.0, 10.0, zoom=4)
+
+
+class TestTileXYBounds:
+    """Tests for `cleopatra.tiles._tile_xy_bounds`.
+
+    Expected bounds are cross-checked against `mercantile.xy_bounds()` (see
+    the removal PR's commit messages); the literal values here lock those
+    results in without needing `mercantile` installed to run.
+    """
+
+    def test_whole_world_tile(self):
+        """The root tile's bounds span the full EPSG:3857 world extent."""
+        left, bottom, right, top = _tile_xy_bounds(Tile(0, 0, 0))
+        assert left == pytest.approx(-20037508.342789244)
+        assert bottom == pytest.approx(-20037508.342789244)
+        assert right == pytest.approx(20037508.342789244)
+        assert top == pytest.approx(20037508.342789244)
+
+    def test_quadrant_tile(self):
+        """Tile (1, 1, 1) is the southeast quadrant of the world."""
+        left, bottom, right, top = _tile_xy_bounds(Tile(1, 1, 1))
+        assert left == pytest.approx(0.0)
+        assert bottom == pytest.approx(-20037508.342789244)
+        assert right == pytest.approx(20037508.342789244)
+        assert top == pytest.approx(0.0)
+
+    def test_known_tile(self):
+        """A real-world tile's bounds match mercantile's `xy_bounds` exactly."""
+        left, bottom, right, top = _tile_xy_bounds(Tile(550, 335, 10))
+        assert left == pytest.approx(1487158.8223163895)
+        assert bottom == pytest.approx(6887893.492833803)
+        assert right == pytest.approx(1526294.5807983999)
+        assert top == pytest.approx(6927029.2513158135)
 
 
 class TestFetchSingleTile:

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -770,10 +770,20 @@ class TestTilesForBbox:
         tiles = sorted(_tiles_for_bbox(-1.0, -90.0, 1.0, -89.0, zoom=5))
         assert tiles == [Tile(15, 31, 5), Tile(16, 31, 5)]
 
-    def test_antimeridian_crossing_bbox_raises(self):
-        """A `west > east` bbox (antimeridian-crossing) raises instead of returning `[]`."""
-        with pytest.raises(ValueError, match="antimeridian"):
-            _tiles_for_bbox(170.0, -10.0, -170.0, 10.0, zoom=4)
+    def test_antimeridian_crossing_bbox_splits_like_mercantile(self):
+        """A `west > east` bbox (antimeridian-crossing) splits into both dateline halves.
+
+        Regression test for a `ValueError` this used to raise instead: a
+        `west > east` bbox is not just a hand-crafted edge case, it is a
+        real, reachable input through `add_tiles` -- reprojecting a
+        near-global Web Mercator extent to EPSG:4326 wraps longitude at
+        the +/-180 seam, producing exactly this shape (see
+        `TestAddTilesNearGlobalExtent`). `mercantile.tiles()` handles it by
+        splitting into `[-180, east]` and `[west, 180]`; this must match.
+        """
+        tiles = sorted(_tiles_for_bbox(170.0, -10.0, -170.0, 10.0, zoom=4))
+        expected = sorted([Tile(0, 7, 4), Tile(0, 8, 4), Tile(15, 7, 4), Tile(15, 8, 4)])
+        assert tiles == expected
 
 
 class TestTileXYBounds:
@@ -1275,3 +1285,76 @@ class TestAddTilesEmptyTiles:
         ):
             with pytest.raises(ValueError, match="No tiles found"):
                 add_tiles(mock_ax, crs=3857)
+
+
+class TestAddTilesNearGlobalExtent:
+    """End-to-end regression test for a near-global Web Mercator extent.
+
+    Drives `add_tiles` through its real reprojection and `_tiles_for_bbox`
+    call (only `fetch_tiles`/`stitch_tiles` are mocked, unlike the other
+    `add_tiles` tests, which mock `_tiles_for_bbox` itself). This is
+    deliberate: reprojecting a near-global EPSG:3857 extent to EPSG:4326
+    wraps longitude at the +/-180 seam (`pyproj`'s inverse Web Mercator
+    transform), producing a `west > east` bbox -- exactly the
+    antimeridian-crossing shape `_tiles_for_bbox` must split rather than
+    crash or silently drop tiles on. A test that mocks `_tiles_for_bbox`
+    itself (as the other `add_tiles` tests do) cannot exercise this path.
+    """
+
+    @pytest.fixture
+    def near_global_ax(self):
+        """A mock axes whose Web Mercator x-limits extend past the world bounds by 5%."""
+        extended = 20037508.342789244 * 1.05
+        ax = MagicMock()
+        ax.get_xlim.return_value = (-extended, extended)
+        ax.get_ylim.return_value = (-8_000_000.0, 8_000_000.0)
+        ax.get_aspect.return_value = "auto"
+
+        mock_transform = MagicMock()
+        mock_transform.inverted.return_value = mock_transform
+        mock_fig = MagicMock()
+        mock_fig.dpi = 100.0
+        type(mock_fig).dpi_scale_trans = PropertyMock(return_value=mock_transform)
+
+        mock_bbox = MagicMock()
+        mock_bbox.width = 6.0
+        mock_bbox.height = 4.0
+        mock_bbox.transformed.return_value = mock_bbox
+
+        ax.get_figure.return_value = mock_fig
+        ax.get_window_extent.return_value = mock_bbox
+        return ax
+
+    def test_near_global_extent_does_not_raise(self, near_global_ax):
+        """`add_tiles` succeeds on a near-global extent instead of raising.
+
+        Test scenario:
+            A 5%-margin whole-world Web Mercator extent (matplotlib's own
+            default autoscale margin on full-world data would produce
+            exactly this) reprojects to a `west > east` EPSG:4326 bbox.
+            Before this fix, that raised `ValueError` from `_tiles_for_bbox`
+            (or, before the round-1 fix, silently produced no tiles); now it
+            must resolve successfully via the antimeridian split.
+        """
+        fake_image = np.zeros((256, 256, 4), dtype=np.uint8)
+        with (
+            patch.object(
+                tiles_mod,
+                "fetch_tiles",
+                return_value={Tile(0, 0, 3): _make_tile_png()},
+            ),
+            patch.object(
+                tiles_mod,
+                "stitch_tiles",
+                return_value=(fake_image, (-20037508.34, -8000000.0, 20037508.34, 8000000.0)),
+            ) as mock_stitch,
+        ):
+            add_tiles(near_global_ax, crs=3857, zoom=3)
+
+        tiles_passed = mock_stitch.call_args[0][1]
+        xs = {t.x for t in tiles_passed}
+        assert len(tiles_passed) > 0, "the antimeridian split should still produce tiles"
+        assert 0 in xs, "should include tiles from the western half of the split (x near 0)"
+        assert max(xs) >= 2**3 - 1, (
+            "should include tiles from the eastern half of the split (x near the grid edge)"
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -414,7 +414,6 @@ dependencies = [
 
 [package.optional-dependencies]
 tiles = [
-    { name = "mercantile" },
     { name = "pillow" },
     { name = "pyproj" },
     { name = "xyzservices" },
@@ -458,7 +457,6 @@ requires-dist = [
     { name = "hpc-utils", specifier = ">=0.1.4" },
     { name = "imageio-ffmpeg", specifier = ">=0.4.9" },
     { name = "matplotlib", specifier = ">=3.9" },
-    { name = "mercantile", marker = "extra == 'tiles'", specifier = ">=1.2.1" },
     { name = "numpy", specifier = ">=2.0.0" },
     { name = "pillow", marker = "extra == 'tiles'", specifier = ">=12.1.1" },
     { name = "pyproj", marker = "extra == 'tiles'", specifier = ">=3.7.2" },
@@ -2029,18 +2027,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "mercantile"
-version = "1.2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/c6/87409bcb26fb68c393fa8cf58ba09363aa7298cfb438a0109b5cb14bc98b/mercantile-1.2.1.tar.gz", hash = "sha256:fa3c6db15daffd58454ac198b31887519a19caccee3f9d63d17ae7ff61b3b56b", size = 26352, upload-time = "2021-04-21T14:42:41.096Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/d6/de0cc74f8d36976aeca0dd2e9cbf711882ff8e177495115fd82459afdc4d/mercantile-1.2.1-py3-none-any.whl", hash = "sha256:30f457a73ee88261aab787b7069d85961a5703bb09dc57a170190bc042cd023f", size = 14779, upload-time = "2021-04-21T14:42:39.841Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

`cleopatra.tiles` only ever used three things from `mercantile`: the `Tile` type,
`tiles()` to enumerate the XYZ tiles covering a bbox, and `xy_bounds()` to convert a
tile back to its Web Mercator bounds. That's about 130 lines of standard "slippy map
tilenames" math (a fixed, decades-old algorithm, not something that needs an external
dependency to stay correct) — not enough surface to justify carrying the dependency.

This replaces it with a small, built-in implementation: a public `Tile(NamedTuple)`
plus private helpers `_lonlat_to_tile_xy()`, `_tiles_for_bbox()`, and
`_tile_xy_bounds()`, in `cleopatra/tiles.py`. No behavior change — see the testing
section for how that was verified, and for two real bugs found and fixed along the way
during a two-round adversarial review.

No dependencies are added; `mercantile` is dropped from the `[tiles]` extra and
`uv.lock`.

# Issues
- Closes #238

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

The risk here is a subtly-wrong tile-math reimplementation, so verification focused on
proving equivalence against the actual `mercantile` source rather than just "tests
pass" — this went through two independent rounds of adversarial review, both of which
found real issues:

- Pulled `mercantile`'s real implementation (`tile()`, `tiles()`, `xy_bounds()`) via
  `inspect.getsource` against the installed package and matched the port to it
  formula-for-formula (same `EPSILON`/`LL_EPSILON` constants, same clamping behavior
  at the poles).
- Cross-checked `_lonlat_to_tile_xy`, `_tiles_for_bbox`, and `_tile_xy_bounds` against
  their real `mercantile` counterparts across hundreds of thousands of points/bboxes/
  tile coordinates (poles, antimeridian, degenerate/zero-area boxes, zoom 0–30) — 0
  mismatches in the reachable input space.
- **Round 1 review** found and fixed an asymmetric latitude clamp and a `sin(lat)`
  rounding-to-exactly-±1.0 case, both of which crashed with a raw `ZeroDivisionError`
  within ~1e-7° of either pole instead of clamping as documented.
- **Round 2 review** found a real regression the round-1 antimeridian fix introduced:
  `add_tiles` crashed on any near-global Web Mercator extent (e.g. matplotlib's own
  default 5% autoscale margin on full-world data), because reprojecting to EPSG:4326
  wraps longitude at the ±180° seam. Fixed by splitting the bbox into its two
  dateline-side halves and concatenating, matching `mercantile.tiles()`'s own
  behavior — verified against the reviewer's exact repro and end-to-end through
  `add_tiles` itself, not just the private helper.
- Added 30+ direct unit tests for the tile-math functions (known points/bboxes/tiles,
  poles, antimeridian, degenerate bboxes, high zoom) with expected values cross-checked
  against real `mercantile`, plus an end-to-end `add_tiles()` test exercising the
  reprojection-driven antimeridian wraparound.
- Updated `tests/test_tiles.py` to mock the new internal `_tiles_for_bbox` instead of
  patching the `mercantile` module, and to import `Tile` from `cleopatra.tiles`
  instead of a local duplicate namedtuple.

- [x] `pytest tests/test_tiles.py` — 142 passed
- [x] `pytest` (full suite) — 1917 passed
- [x] `pytest --doctest-modules src/cleopatra` — passing
- [x] `mypy src/cleopatra/tiles.py` — 0 errors
- [x] SonarCloud Quality Gate — passing, 0 open issues

# Checklist:

- [ ] updated version number in pyproject.toml — N/A, not a release
- [ ] added changes to History.rst — N/A, `docs/change-log.md` is auto-generated by commitizen from commit messages, never hand-edited
- [x] updated the latest version in README file — updated the conda-feedstock dependency list mention
- [x] I have added tests that prove my fix is effective or that my feature works — updated `tests/test_tiles.py` to match the new implementation, plus the equivalence checks described above
- [x] New and existing unit tests pass locally with my changes
