### PR TITLE
feat(array_glyph): complete the ColorBar spec with caption and sizing fields

### DIFF
--- a/docs/notebooks/array_glyph/array_glyph_examples.ipynb
+++ b/docs/notebooks/array_glyph/array_glyph_examples.ipynb
@@ -17,21 +17,7 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "from cleopatra.config import Config\n",
-    "\n",
-    "Config.set_matplotlib_backend()\n",
-    "from cleopatra.animation import embed_gif\n",
-    "from cleopatra.array_glyph import ArrayGlyph, PointOverlay\n",
-    "\n",
-    "# Set the random seed for reproducibility\n",
-    "np.random.seed(42)"
-   ]
+   "source": "import os\n\nimport matplotlib.pyplot as plt\nimport numpy as np\n\nfrom cleopatra.config import Config\n\nConfig.set_matplotlib_backend()\nfrom cleopatra.animation import embed_gif\nfrom cleopatra.array_glyph import ArrayGlyph, ColorBar, PointOverlay\n\n# Set the random seed for reproducibility\nnp.random.seed(42)"
   },
   {
    "cell_type": "markdown",
@@ -127,17 +113,7 @@
    "id": "10",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "array_glyph_custom = ArrayGlyph(complex_array)\n",
-    "\n",
-    "# Plot with custom settings\n",
-    "fig, ax = array_glyph_custom.plot(\n",
-    "    cmap=\"viridis\",  # Use the viridis colormap\n",
-    "    title=\"Custom Array Plot\",  # Add a title\n",
-    "    ticks_spacing=0.5,  # Set tick spacing\n",
-    "    figsize=(10, 8),  # Set figure size\n",
-    ")"
-   ]
+   "source": "array_glyph_custom = ArrayGlyph(complex_array)\n\n# Plot with custom settings\nfig, ax = array_glyph_custom.plot(\n    cmap=\"viridis\",  # Use the viridis colormap\n    title=\"Custom Array Plot\",  # Add a title\n    colorbar=ColorBar(ticks_spacing=0.5),  # Set tick spacing\n    figsize=(10, 8),  # Set figure size\n)"
   },
   {
    "cell_type": "markdown",
@@ -565,23 +541,7 @@
    "id": "44",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Create an array\n",
-    "colorbar_array = np.random.rand(15, 15)\n",
-    "\n",
-    "# Initialize the ArrayGlyph with the array\n",
-    "array_glyph_colorbar = ArrayGlyph(colorbar_array)\n",
-    "\n",
-    "# Plot with a custom colorbar\n",
-    "fig, ax = array_glyph_colorbar.plot(\n",
-    "    cbar_label=\"Values\",  # Set colorbar label\n",
-    "    cbar_orientation=\"horizontal\",  # Set colorbar orientation\n",
-    "    cbar_length=0.8,  # Shrink the colorbar\n",
-    "    cmap=\"plasma\",  # Use the plasma colormap\n",
-    "    title=\"Array with Custom Colorbar\",\n",
-    "    figsize=(10, 8),\n",
-    ")"
-   ]
+   "source": "# Create an array\ncolorbar_array = np.random.rand(15, 15)\n\n# Initialize the ArrayGlyph with the array\narray_glyph_colorbar = ArrayGlyph(colorbar_array)\n\n# Plot with a custom colorbar\nfig, ax = array_glyph_colorbar.plot(\n    colorbar=ColorBar(label=\"Values\", length=0.8),  # Caption + shrink the colorbar\n    cbar_orientation=\"horizontal\",  # Set colorbar orientation\n    cmap=\"plasma\",  # Use the plasma colormap\n    title=\"Array with Custom Colorbar\",\n    figsize=(10, 8),\n)"
   },
   {
    "cell_type": "markdown",

--- a/docs/notebooks/array_glyph/array_glyph_examples.ipynb
+++ b/docs/notebooks/array_glyph/array_glyph_examples.ipynb
@@ -541,7 +541,7 @@
    "id": "44",
    "metadata": {},
    "outputs": [],
-   "source": "# Create an array\ncolorbar_array = np.random.rand(15, 15)\n\n# Initialize the ArrayGlyph with the array\narray_glyph_colorbar = ArrayGlyph(colorbar_array)\n\n# Plot with a custom colorbar\nfig, ax = array_glyph_colorbar.plot(\n    colorbar=ColorBar(label=\"Values\", length=0.8),  # Caption + shrink the colorbar\n    cbar_orientation=\"horizontal\",  # Set colorbar orientation\n    cmap=\"plasma\",  # Use the plasma colormap\n    title=\"Array with Custom Colorbar\",\n    figsize=(10, 8),\n)"
+   "source": "# Create an array\ncolorbar_array = np.random.default_rng(42).random((15, 15))\n\n# Initialize the ArrayGlyph with the array\narray_glyph_colorbar = ArrayGlyph(colorbar_array)\n\n# Plot with a custom colorbar\nfig, ax = array_glyph_colorbar.plot(\n    colorbar=ColorBar(label=\"Values\", length=0.8),  # Caption + shrink the colorbar\n    cbar_orientation=\"horizontal\",  # Set colorbar orientation\n    cmap=\"plasma\",  # Use the plasma colormap\n    title=\"Array with Custom Colorbar\",\n    figsize=(10, 8),\n)"
   },
   {
    "cell_type": "markdown",

--- a/docs/notebooks/array_glyph/reference_map.ipynb
+++ b/docs/notebooks/array_glyph/reference_map.ipynb
@@ -1,198 +1,164 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "id": "0",
-            "metadata": {},
-            "source": [
-                "# Weather-centre reference maps with `add_reference_map`\n",
-                "\n",
-                "Dressing a georeferenced `ArrayGlyph` in the clean look of an operational weather-centre chart (ECMWF /\n",
-                "Magics style: grey coastlines, a dashed lon/lat graticule, degree labels, a subtle frame) used to take a\n",
-                "dozen-plus lines of matplotlib after `plot()`. `add_reference_map` collapses that recipe into one call.\n",
-                "\n",
-                "It is a thin **preset** over the existing `add_features` Natural Earth layers, so it needs no `cartopy` \u2014 just\n",
-                "the `cleopatra[tiles]` extra for the reference data. Because it draws in the axes' geographic coordinates, the\n",
-                "glyph must be **georeferenced**: pass `extent=[west, south, east, north]` (or construct the glyph with\n",
-                "`extent=`). Deriving that extent from a source dataset is the caller's job \u2014 cleopatra renders the\n",
-                "coordinates it is given."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "1",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "%matplotlib inline\n",
-                "import warnings\n",
-                "\n",
-                "import matplotlib.pyplot as plt\n",
-                "import numpy as np\n",
-                "\n",
-                "from cleopatra.array_glyph import ArrayGlyph\n",
-                "from cleopatra.geo import available_map_styles\n",
-                "\n",
-                "warnings.filterwarnings(\"ignore\")  # keep the embedded outputs lean\n",
-                "available_map_styles()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "2",
-            "metadata": {},
-            "source": [
-                "## A georeferenced field\n",
-                "\n",
-                "We build a smooth synthetic field over the US East Coast / western Atlantic and give the glyph its geographic\n",
-                "`extent` as `[west, south, east, north]`. On its own it is just a coloured grid \u2014 no geography yet."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "3",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "west, south, east, north = -100.0, 15.0, -40.0, 55.0\n",
-                "lat = np.linspace(south, north, 80)\n",
-                "lon = np.linspace(west, east, 120)\n",
-                "lon2d, lat2d = np.meshgrid(lon, lat)\n",
-                "\n",
-                "# a smooth anomaly, just so there is something to look at\n",
-                "field = np.exp(-(((lon2d + 72) ** 2) / 120.0 + ((lat2d - 34) ** 2) / 60.0))\n",
-                "\n",
-                "glyph = ArrayGlyph(field, extent=[west, south, east, north], figsize=(7, 5))\n",
-                "glyph.plot(cmap=\"turbo\", cbar_label=\"anomaly\")\n",
-                "plt.show()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "4",
-            "metadata": {},
-            "source": [
-                "## One call for the ECMWF look\n",
-                "\n",
-                "`add_reference_map(\"ecmwf\")` overlays grey coastlines + borders, a dashed graticule, `\u00b0W`/`\u00b0N` labels and a\n",
-                "subtle frame. It returns the axes for chaining."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "5",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "glyph = ArrayGlyph(field, extent=[west, south, east, north], figsize=(7, 5))\n",
-                "glyph.plot(cmap=\"turbo\", cbar_label=\"anomaly\")\n",
-                "glyph.add_reference_map(\"ecmwf\")\n",
-                "plt.show()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "6",
-            "metadata": {},
-            "source": [
-                "### What it replaces\n",
-                "\n",
-                "Without the preset, every notebook re-derived the same recipe by hand:\n",
-                "\n",
-                "```python\n",
-                "ax = glyph.ax\n",
-                "glyph.add_features(\"coastline\", \"50m\", colors=\"0.45\", linewidths=0.8, zorder=5)\n",
-                "glyph.add_features(\"borders\",   \"50m\", colors=\"0.55\", linewidths=0.5, zorder=5)\n",
-                "from matplotlib.ticker import MultipleLocator, FuncFormatter\n",
-                "ax.xaxis.set_major_locator(MultipleLocator(10)); ax.yaxis.set_major_locator(MultipleLocator(10))\n",
-                "ax.xaxis.set_major_formatter(FuncFormatter(lambda v, _: f\"{abs(v):.0f}\u00b0W\"))\n",
-                "ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _: f\"{v:.0f}\u00b0N\"))\n",
-                "ax.grid(True, color=\"0.7\", linestyle=(0, (4, 4)), linewidth=0.5, zorder=4)\n",
-                "ax.tick_params(colors=\"0.35\", labelsize=8, length=0)\n",
-                "for sp in ax.spines.values(): sp.set_edgecolor(\"0.6\"); sp.set_linewidth(0.8)\n",
-                "```"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "7",
-            "metadata": {},
-            "source": [
-                "## Dark backgrounds\n",
-                "\n",
-                "ECMWF's mid-grey is tuned for light backgrounds; over a dark field (e.g. a satellite true-colour RGB) it\n",
-                "vanishes. The `\"ecmwf-dark\"` preset uses lighter greys, and `style=\"auto\"` picks between the two from the\n",
-                "background luminance. Here is a mostly-dark RGB scene:"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "8",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "h, w = 80, 120\n",
-                "yy, xx = np.mgrid[0:h, 0:w]\n",
-                "blob = np.exp(-(((xx - 70) ** 2) / 300.0 + ((yy - 30) ** 2) / 200.0))\n",
-                "rgb = np.zeros((h, w, 3))\n",
-                "rgb[..., 0] = 0.95 * blob  # a warm bright feature on a near-black scene\n",
-                "rgb[..., 1] = 0.45 * blob\n",
-                "\n",
-                "glyph = ArrayGlyph(rgb, extent=[west, south, east, north], figsize=(7, 5))\n",
-                "glyph.plot()\n",
-                "glyph.add_reference_map(\"auto\")  # -> ecmwf-dark, light-grey coastlines\n",
-                "plt.show()"
-            ]
-        },
-        {
-            "cell_type": "markdown",
-            "id": "9",
-            "metadata": {},
-            "source": [
-                "## Tuning\n",
-                "\n",
-                "Override the graticule spacing with `graticule_step`, the coastline detail with `resolution`, or start from\n",
-                "the `cleopatra.geo.REFERENCE_MAP_STYLES` table for a fully custom preset. Pass `ax=` to decorate a specific\n",
-                "axes."
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "10",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "glyph = ArrayGlyph(field, extent=[west, south, east, north], figsize=(7, 5))\n",
-                "glyph.plot(cmap=\"turbo\", cbar_label=\"anomaly\")\n",
-                "glyph.add_reference_map(\"ecmwf\", graticule_step=20, resolution=\"110m\")\n",
-                "plt.show()"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.12.11"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 5
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Weather-centre reference maps with `add_reference_map`\n",
+    "\n",
+    "Dressing a georeferenced `ArrayGlyph` in the clean look of an operational weather-centre chart (ECMWF /\n",
+    "Magics style: grey coastlines, a dashed lon/lat graticule, degree labels, a subtle frame) used to take a\n",
+    "dozen-plus lines of matplotlib after `plot()`. `add_reference_map` collapses that recipe into one call.\n",
+    "\n",
+    "It is a thin **preset** over the existing `add_features` Natural Earth layers, so it needs no `cartopy` — just\n",
+    "the `cleopatra[tiles]` extra for the reference data. Because it draws in the axes' geographic coordinates, the\n",
+    "glyph must be **georeferenced**: pass `extent=[west, south, east, north]` (or construct the glyph with\n",
+    "`extent=`). Deriving that extent from a source dataset is the caller's job — cleopatra renders the\n",
+    "coordinates it is given."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": "%matplotlib inline\nimport warnings\n\nimport matplotlib.pyplot as plt\nimport numpy as np\n\nfrom cleopatra.array_glyph import ArrayGlyph, ColorBar\nfrom cleopatra.geo import available_map_styles\n\nwarnings.filterwarnings(\"ignore\")  # keep the embedded outputs lean\navailable_map_styles()"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "## A georeferenced field\n",
+    "\n",
+    "We build a smooth synthetic field over the US East Coast / western Atlantic and give the glyph its geographic\n",
+    "`extent` as `[west, south, east, north]`. On its own it is just a coloured grid — no geography yet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3",
+   "metadata": {},
+   "outputs": [],
+   "source": "west, south, east, north = -100.0, 15.0, -40.0, 55.0\nlat = np.linspace(south, north, 80)\nlon = np.linspace(west, east, 120)\nlon2d, lat2d = np.meshgrid(lon, lat)\n\n# a smooth anomaly, just so there is something to look at\nfield = np.exp(-(((lon2d + 72) ** 2) / 120.0 + ((lat2d - 34) ** 2) / 60.0))\n\nglyph = ArrayGlyph(field, extent=[west, south, east, north], figsize=(7, 5))\nglyph.plot(cmap=\"turbo\", colorbar=ColorBar(label=\"anomaly\"))\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## One call for the ECMWF look\n",
+    "\n",
+    "`add_reference_map(\"ecmwf\")` overlays grey coastlines + borders, a dashed graticule, `°W`/`°N` labels and a\n",
+    "subtle frame. It returns the axes for chaining."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": "glyph = ArrayGlyph(field, extent=[west, south, east, north], figsize=(7, 5))\nglyph.plot(cmap=\"turbo\", colorbar=ColorBar(label=\"anomaly\"))\nglyph.add_reference_map(\"ecmwf\")\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "### What it replaces\n",
+    "\n",
+    "Without the preset, every notebook re-derived the same recipe by hand:\n",
+    "\n",
+    "```python\n",
+    "ax = glyph.ax\n",
+    "glyph.add_features(\"coastline\", \"50m\", colors=\"0.45\", linewidths=0.8, zorder=5)\n",
+    "glyph.add_features(\"borders\",   \"50m\", colors=\"0.55\", linewidths=0.5, zorder=5)\n",
+    "from matplotlib.ticker import MultipleLocator, FuncFormatter\n",
+    "ax.xaxis.set_major_locator(MultipleLocator(10)); ax.yaxis.set_major_locator(MultipleLocator(10))\n",
+    "ax.xaxis.set_major_formatter(FuncFormatter(lambda v, _: f\"{abs(v):.0f}°W\"))\n",
+    "ax.yaxis.set_major_formatter(FuncFormatter(lambda v, _: f\"{v:.0f}°N\"))\n",
+    "ax.grid(True, color=\"0.7\", linestyle=(0, (4, 4)), linewidth=0.5, zorder=4)\n",
+    "ax.tick_params(colors=\"0.35\", labelsize=8, length=0)\n",
+    "for sp in ax.spines.values(): sp.set_edgecolor(\"0.6\"); sp.set_linewidth(0.8)\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7",
+   "metadata": {},
+   "source": [
+    "## Dark backgrounds\n",
+    "\n",
+    "ECMWF's mid-grey is tuned for light backgrounds; over a dark field (e.g. a satellite true-colour RGB) it\n",
+    "vanishes. The `\"ecmwf-dark\"` preset uses lighter greys, and `style=\"auto\"` picks between the two from the\n",
+    "background luminance. Here is a mostly-dark RGB scene:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h, w = 80, 120\n",
+    "yy, xx = np.mgrid[0:h, 0:w]\n",
+    "blob = np.exp(-(((xx - 70) ** 2) / 300.0 + ((yy - 30) ** 2) / 200.0))\n",
+    "rgb = np.zeros((h, w, 3))\n",
+    "rgb[..., 0] = 0.95 * blob  # a warm bright feature on a near-black scene\n",
+    "rgb[..., 1] = 0.45 * blob\n",
+    "\n",
+    "glyph = ArrayGlyph(rgb, extent=[west, south, east, north], figsize=(7, 5))\n",
+    "glyph.plot()\n",
+    "glyph.add_reference_map(\"auto\")  # -> ecmwf-dark, light-grey coastlines\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "## Tuning\n",
+    "\n",
+    "Override the graticule spacing with `graticule_step`, the coastline detail with `resolution`, or start from\n",
+    "the `cleopatra.geo.REFERENCE_MAP_STYLES` table for a fully custom preset. Pass `ax=` to decorate a specific\n",
+    "axes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": "glyph = ArrayGlyph(field, extent=[west, south, east, north], figsize=(7, 5))\nglyph.plot(cmap=\"turbo\", colorbar=ColorBar(label=\"anomaly\"))\nglyph.add_reference_map(\"ecmwf\", graticule_step=20, resolution=\"110m\")\nplt.show()"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -288,8 +288,8 @@ class ColorbarOptions(TypedDict, total=False):
         add_colorbar: Whether to draw the glyph's own colorbar, by
             default `True`.
         cbar_orientation: Colorbar orientation, by default `'vertical'`.
-        cbar_label_rotation: Rotation angle of the colorbar label, by
-            default `-90`.
+        cbar_label_rotation: Rotation angle (degrees) of the colorbar label.
+            `None` (the default) leaves matplotlib's own default orientation.
         cbar_label_location: Location of the colorbar label, by default
             `'bottom'`.
         cbar_length: Ratio controlling the colorbar's height/width, by
@@ -306,7 +306,7 @@ class ColorbarOptions(TypedDict, total=False):
 
     add_colorbar: bool
     cbar_orientation: Literal["vertical", "horizontal"]
-    cbar_label_rotation: float
+    cbar_label_rotation: float | None
     cbar_label_location: Literal[
         "top", "bottom", "center", "baseline", "center_baseline"
     ]

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -3597,7 +3597,8 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         # `colorbar=` (a ColorBar / bool) resolves last, so it wins over
         # the default `add_colorbar` and any internal cbar_* key.
-        self.default_options.update(_resolve_colorbar(colorbar))
+        resolved_colorbar = _resolve_colorbar(colorbar)
+        self.default_options.update(resolved_colorbar)
 
         # Record colour limits supplied to THIS plot() call so a preset render
         # honours them (see `_style_color_overrides`). Sticky, and only for
@@ -3691,11 +3692,16 @@ class ArrayGlyph(GeoMixin, Glyph):
             self.im = ax.imshow(arr, extent=extent)
             self.cbar = None
         else:
-            # if user did not input ticks spacing use the calculated one.
-            if "ticks_spacing" in kwargs.keys():
-                self.default_options["ticks_spacing"] = kwargs["ticks_spacing"]
-            else:
-                self.default_options["ticks_spacing"] = self.ticks_spacing
+            # Tick-spacing precedence: a `colorbar=ColorBar(ticks_spacing=...)`
+            # spec wins (already merged above), then a loose `ticks_spacing=`
+            # kwarg, then the auto-computed value. Guarding on the resolved
+            # spec keeps the merged value from being clobbered here, since a
+            # ColorBar value arrives via `colorbar=`, never through `kwargs`.
+            if "ticks_spacing" not in resolved_colorbar:
+                if "ticks_spacing" in kwargs.keys():
+                    self.default_options["ticks_spacing"] = kwargs["ticks_spacing"]
+                else:
+                    self.default_options["ticks_spacing"] = self.ticks_spacing
 
             # Recompute (vmin, vmax) for this plot call if any of the
             # xarray-aligned colour kwargs (`robust`, `center`) or the
@@ -3715,10 +3721,11 @@ class ArrayGlyph(GeoMixin, Glyph):
                 )
                 self._vmin = vmin_final
                 self._vmax = vmax_final
-                # Keep ticks_spacing in sync with the new colour range
-                # unless the caller pinned it explicitly (fall back to 1.0
-                # for a degenerate range so the tick math stays safe).
-                if "ticks_spacing" not in kwargs:
+                # Keep ticks_spacing in sync with the new colour range unless
+                # the caller pinned it explicitly -- via a loose `ticks_spacing=`
+                # kwarg or a `colorbar=ColorBar(ticks_spacing=...)` spec (fall
+                # back to 1.0 for a degenerate range so the tick math stays safe).
+                if "ticks_spacing" not in kwargs and "ticks_spacing" not in resolved_colorbar:
                     self.ticks_spacing = (vmax_final - vmin_final) / 10 or 1.0
                     self.default_options["ticks_spacing"] = self.ticks_spacing
 
@@ -4569,7 +4576,8 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         # `colorbar=` (a ColorBar / bool) resolves last, so it wins over
         # the default `add_colorbar` and any internal cbar_* key.
-        self.default_options.update(_resolve_colorbar(colorbar))
+        resolved_colorbar = _resolve_colorbar(colorbar)
+        self.default_options.update(resolved_colorbar)
 
         # Record colour limits supplied to THIS animate() call so a styled
         # animation honours an explicit caller override of the preset's fixed
@@ -4590,11 +4598,16 @@ class ArrayGlyph(GeoMixin, Glyph):
             and (colorbar.location is not None or colorbar.inside)
         )
 
-        # if user did not input ticks spacing use the calculated one.
-        if "ticks_spacing" in kwargs.keys():
-            self.default_options["ticks_spacing"] = kwargs["ticks_spacing"]
-        else:
-            self.default_options["ticks_spacing"] = self.ticks_spacing
+        # Tick-spacing precedence: a `colorbar=ColorBar(ticks_spacing=...)` spec
+        # wins (already merged above), then a loose `ticks_spacing=` kwarg, then
+        # the auto-computed value. Guarding on the resolved spec keeps the merged
+        # value from being clobbered here, since a ColorBar value arrives via
+        # `colorbar=`, never through `kwargs`.
+        if "ticks_spacing" not in resolved_colorbar:
+            if "ticks_spacing" in kwargs.keys():
+                self.default_options["ticks_spacing"] = kwargs["ticks_spacing"]
+            else:
+                self.default_options["ticks_spacing"] = self.ticks_spacing
 
         if "vmin" in kwargs.keys():
             self.default_options["vmin"] = kwargs["vmin"]

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -3297,12 +3297,13 @@ class ArrayGlyph(GeoMixin, Glyph):
                 >>> array = ArrayGlyph(arr, figsize=(6, 6), title="Customized color bar", title_size=18)
                 >>> fig, ax = array.plot(
                 ...     cbar_orientation="horizontal",
-                ...     cbar_label_rotation=-90,
-                ...     cbar_label_location="center",
-                ...     cbar_length=0.7,
-                ...     cbar_label_size=12,
-                ...     cbar_label="Discharge m3/s",
-                ...     ticks_spacing=5,
+                ...     colorbar=ColorBar(
+                ...         label="Discharge m3/s",
+                ...         label_location="center",
+                ...         length=0.7,
+                ...         label_size=12,
+                ...         ticks_spacing=5,
+                ...     ),
                 ...     color_scale="linear",
                 ...     cmap="coolwarm_r",
                 ... )
@@ -3358,10 +3359,9 @@ class ArrayGlyph(GeoMixin, Glyph):
                     ```python
                     >>> array = ArrayGlyph(arr, figsize=(6, 6), title="Power scale", title_size=18)
                     >>> fig, ax = array.plot(
-                    ...     cbar_label="Discharge m3/s",
+                    ...     colorbar=ColorBar(label="Discharge m3/s"),
                     ...     color_scale="power",
                     ...     cmap="coolwarm_r",
-                    ...     cbar_label_rotation=-90,
                     ... )
 
                     ```
@@ -3375,8 +3375,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                     ...     color_scale="power",
                     ...     gamma=0.8,
                     ...     cmap="coolwarm_r",
-                    ...     cbar_label_rotation=-90,
-                    ...     cbar_label="Discharge m3/s",
+                    ...     colorbar=ColorBar(label="Discharge m3/s"),
                     ... )
 
                     ```
@@ -3390,8 +3389,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                     ...     color_scale="power",
                     ...     gamma=0.1,
                     ...     cmap="coolwarm_r",
-                    ...     cbar_label_rotation=-90,
-                    ...     cbar_label="Discharge m3/s",
+                    ...     colorbar=ColorBar(label="Discharge m3/s"),
                     ... )
 
                     ```
@@ -3404,10 +3402,9 @@ class ArrayGlyph(GeoMixin, Glyph):
                     ```python
                     >>> array = ArrayGlyph(arr, figsize=(6, 6), title="Logarithmic scale", title_size=18)
                     >>> fig, ax = array.plot(
-                    ...     cbar_label="Discharge m3/s",
+                    ...     colorbar=ColorBar(label="Discharge m3/s"),
                     ...     color_scale="sym-lognorm",
                     ...     cmap="coolwarm_r",
-                    ...     cbar_label_rotation=-90,
                     ... )
 
                     ```
@@ -3419,8 +3416,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                     ...     arr, figsize=(6, 6), title="Logarithmic scale: Customized Parameter", title_size=12
                     ... )
                     >>> fig, ax = array.plot(
-                    ...     cbar_label_rotation=-90,
-                    ...     cbar_label="Discharge m3/s",
+                    ...     colorbar=ColorBar(label="Discharge m3/s"),
                     ...     color_scale="sym-lognorm",
                     ...     cmap="coolwarm_r",
                     ...     line_threshold=0.015,
@@ -3434,8 +3430,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                 ```python
                 >>> array = ArrayGlyph(arr, figsize=(6, 6), title="Defined boundary scale", title_size=18)
                 >>> fig, ax = array.plot(
-                ...     cbar_label_rotation=-90,
-                ...     cbar_label="Discharge m3/s",
+                ...     colorbar=ColorBar(label="Discharge m3/s"),
                 ...     color_scale="boundary-norm",
                 ...     cmap="coolwarm_r",
                 ... )
@@ -3450,8 +3445,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                     ... )
                     >>> bounds = [0, 5, 10]
                     >>> fig, ax = array.plot(
-                    ...     cbar_label_rotation=-90,
-                    ...     cbar_label="Discharge m3/s",
+                    ...     colorbar=ColorBar(label="Discharge m3/s"),
                     ...     color_scale="boundary-norm",
                     ...     bounds=bounds,
                     ...     cmap="coolwarm_r",
@@ -3466,8 +3460,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                 ```python
                 >>> array = ArrayGlyph(arr, figsize=(6, 6), title="Midpoint scale", title_size=18)
                 >>> fig, ax = array.plot(
-                ...     cbar_label_rotation=-90,
-                ...     cbar_label="Discharge m3/s",
+                ...     colorbar=ColorBar(label="Discharge m3/s"),
                 ...     color_scale="midpoint",
                 ...     cmap="coolwarm_r",
                 ...     midpoint=2,

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -945,6 +945,40 @@ def _resolve_colorbar(colorbar: bool | ColorBar | None) -> dict:
     )
 
 
+#: Loose colorbar kwargs now superseded by `ColorBar` fields (issue #234).
+#: Passing any of these to `plot` / `animate` is deprecated -- use the mapped
+#: `ColorBar` field instead. They still take effect (folded into
+#: `default_options`) so nothing breaks during the deprecation window.
+_DEPRECATED_CBAR_KWARGS = {
+    "cbar_label": "label",
+    "cbar_length": "length",
+    "cbar_label_size": "label_size",
+    "cbar_label_rotation": "label_rotation",
+    "cbar_label_location": "label_location",
+    "ticks_spacing": "ticks_spacing",
+}
+
+
+def _warn_deprecated_cbar_kwargs(kwargs: dict) -> None:
+    """Warn for any loose `cbar_*` kwarg that a `ColorBar` field now replaces.
+
+    The kwargs still take effect (the caller folds them into `default_options`);
+    this only steers callers toward the typed `colorbar=ColorBar(...)` spec.
+
+    Args:
+        kwargs: The `plot` / `animate` keyword arguments to inspect for the
+            deprecated loose colorbar keys.
+    """
+    for key, field in _DEPRECATED_CBAR_KWARGS.items():
+        if key in kwargs:
+            warnings.warn(
+                f"The '{key}' keyword is deprecated; pass "
+                f"colorbar=ColorBar({field}=...) instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
+
 #: Deprecated `animate` kwargs that `_resolve_frame_label` folds into a
 #: `FrameLabel` instead of the (now-removed) individual keywords.
 #: `text_loc` is the oldest generation (pre-dating `label_location`) and is
@@ -3550,6 +3584,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         # model just does not have a variance-safe way to type "a dict this
         # helper is allowed to pop deprecated keys from".
         points = _resolve_point_overlay(points, kwargs)  # type: ignore[arg-type]
+        _warn_deprecated_cbar_kwargs(kwargs)
 
         for key, val in kwargs.items():
             if key not in self.default_options.keys():
@@ -4506,6 +4541,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         )
         frame_label = _resolve_frame_label(frame_label, kwargs)  # type: ignore[arg-type]
         points = _resolve_point_overlay(points, kwargs)  # type: ignore[arg-type]
+        _warn_deprecated_cbar_kwargs(kwargs)
 
         # Resolved into a local rather than written back onto `frame_label`,
         # so a `FrameLabel` instance the caller passed in (and might reuse

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -892,6 +892,16 @@ def _resolve_colorbar(colorbar: bool | ColorBar | None) -> dict:
             'left'
 
             ```
+        - Caption / sizing fields map onto their `cbar_*` keys only when set,
+            so an unset field is omitted (leaving the existing default):
+            ```python
+            >>> from cleopatra.array_glyph import _resolve_colorbar, ColorBar
+            >>> _resolve_colorbar(ColorBar(label="Depth [m]", length=0.8))["cbar_label"]
+            'Depth [m]'
+            >>> "cbar_label" in _resolve_colorbar(ColorBar(location="right"))
+            False
+
+            ```
     """
     if colorbar is None:
         return {}

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -952,7 +952,9 @@ def _resolve_colorbar(colorbar: bool | ColorBar | None) -> dict:
 
 #: Loose colorbar kwargs now superseded by `ColorBar` fields (issue #234).
 #: Passing any of these to `plot` / `animate` is deprecated -- use the mapped
-#: `ColorBar` field instead. They still take effect (folded into
+#: `ColorBar` field instead. This set includes the non-`cbar_`-prefixed
+#: `ticks_spacing`, deprecated in favour of `ColorBar(ticks_spacing=...)`, not
+#: only the `cbar_*` keys. They still take effect (folded into
 #: `default_options`) so nothing breaks during the deprecation window.
 _DEPRECATED_CBAR_KWARGS = {
     "cbar_label": "label",

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -738,6 +738,19 @@ class ColorBar:
             and, for a `style` preset, the swatch legend's endpoint values.
             `None` (default) keeps matplotlib's default for a colorbar; for the
             swatch it defaults to a colour that contrasts with `box`, else white.
+        label: Caption text for the scale (the colorbar's title). `None`
+            (default) keeps the current default caption.
+        length: Bar length as a fraction of the axis (e.g. `0.8`). `None`
+            (default) keeps the default length.
+        label_size: Font size of the caption. `None` (default) keeps the
+            default.
+        label_rotation: Rotation of the caption in degrees. `None` (default)
+            keeps the default.
+        label_location: Where the caption sits along the bar (e.g. `"center"`).
+            Distinct from `location`, which is the bar's *edge*. `None`
+            (default) keeps the default.
+        ticks_spacing: Spacing between the colorbar's ticks. `None` (default)
+            keeps the default.
 
     Examples:
         - An inside colorbar on the right -- its box defaults on:
@@ -756,6 +769,14 @@ class ColorBar:
             (None, 'black', 'black')
 
             ```
+        - A captioned bar, fully specified through the spec (no loose kwargs):
+            ```python
+            >>> from cleopatra.array_glyph import ColorBar
+            >>> spec = ColorBar(location="bottom", label="Rainfall mm/day", length=0.8)
+            >>> (spec.label, spec.length)
+            ('Rainfall mm/day', 0.8)
+
+            ```
     """
 
     def __init__(
@@ -766,6 +787,12 @@ class ColorBar:
         box: bool | str | dict | None = None,
         label_color: str | None = None,
         tick_color: str | None = None,
+        label: str | None = None,
+        length: float | None = None,
+        label_size: float | None = None,
+        label_rotation: float | None = None,
+        label_location: str | None = None,
+        ticks_spacing: float | None = None,
     ) -> None:
         """Initialise a `ColorBar`.
 
@@ -779,6 +806,16 @@ class ColorBar:
                 swatch title for a `style` preset); `None` keeps the default.
             tick_color: Colour of the colorbar's tick numbers; `None` keeps
                 matplotlib's default.
+            label: Caption text (scale title); `None` keeps the default.
+            length: Bar length as a fraction of the axis; `None` keeps the
+                default.
+            label_size: Caption font size; `None` keeps the default.
+            label_rotation: Caption rotation in degrees; `None` keeps the
+                default.
+            label_location: Caption placement along the bar (distinct from
+                `location`, the bar's edge); `None` keeps the default.
+            ticks_spacing: Spacing between the colorbar's ticks; `None` keeps
+                the default.
         """
         self.location = location
         self.inside = inside
@@ -787,6 +824,12 @@ class ColorBar:
         self.box = True if (inside and box is None) else box
         self.label_color = label_color
         self.tick_color = tick_color
+        self.label = label
+        self.length = length
+        self.label_size = label_size
+        self.label_rotation = label_rotation
+        self.label_location = label_location
+        self.ticks_spacing = ticks_spacing
 
 
 def _swatch_text_default(box: bool | str | dict | None) -> str:
@@ -864,7 +907,7 @@ def _resolve_colorbar(colorbar: bool | ColorBar | None) -> dict:
             "cbar_tick_color": None,
         }
     if isinstance(colorbar, ColorBar):
-        return {
+        updates = {
             "add_colorbar": True,
             "cbar_location": colorbar.location,
             "cbar_inside": colorbar.inside,
@@ -872,6 +915,20 @@ def _resolve_colorbar(colorbar: bool | ColorBar | None) -> dict:
             "cbar_label_color": colorbar.label_color,
             "cbar_tick_color": colorbar.tick_color,
         }
+        # Caption / size / spacing fields override the loose cbar_* keys only
+        # when set, so an unset field leaves the existing default in place (and
+        # a caller still mixing in a loose cbar_label during the transition is
+        # not clobbered). Phase 2 deprecates those loose kwargs.
+        optional = {
+            "cbar_label": colorbar.label,
+            "cbar_length": colorbar.length,
+            "cbar_label_size": colorbar.label_size,
+            "cbar_label_rotation": colorbar.label_rotation,
+            "cbar_label_location": colorbar.label_location,
+            "ticks_spacing": colorbar.ticks_spacing,
+        }
+        updates.update({k: v for k, v in optional.items() if v is not None})
+        return updates
     raise TypeError(
         "colorbar must be a bool, ColorBar, or None, got "
         f"{type(colorbar).__name__}."

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -745,7 +745,8 @@ class ColorBar:
         label_size: Font size of the caption. `None` (default) keeps the
             default.
         label_rotation: Rotation of the caption in degrees. `None` (default)
-            keeps the default.
+            leaves matplotlib's own label orientation; pass a value to rotate
+            the caption (e.g. `0` for a horizontal caption).
         label_location: Where the caption sits along the bar (e.g. `"center"`).
             Distinct from `location`, which is the bar's *edge*. `None`
             (default) keeps the default.
@@ -810,8 +811,8 @@ class ColorBar:
             length: Bar length as a fraction of the axis; `None` keeps the
                 default.
             label_size: Caption font size; `None` keeps the default.
-            label_rotation: Caption rotation in degrees; `None` keeps the
-                default.
+            label_rotation: Caption rotation in degrees; `None` leaves
+                matplotlib's own label orientation.
             label_location: Caption placement along the bar (distinct from
                 `location`, the bar's edge); `None` keeps the default.
             ticks_spacing: Spacing between the colorbar's ticks; `None` keeps

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -748,8 +748,10 @@ class ColorBar:
             leaves matplotlib's own label orientation; pass a value to rotate
             the caption (e.g. `0` for a horizontal caption).
         label_location: Where the caption sits along the bar (e.g. `"center"`).
-            Distinct from `location`, which is the bar's *edge*. `None`
-            (default) keeps the default.
+            Distinct from `location`, which is the bar's *edge*. Valid values
+            depend on orientation (vertical bar: `"top"`/`"center"`/`"bottom"`;
+            horizontal bar: `"left"`/`"center"`/`"right"`). `None` (default)
+            keeps the default.
         ticks_spacing: Spacing between the colorbar's ticks. `None` (default)
             keeps the default.
 
@@ -814,7 +816,9 @@ class ColorBar:
             label_rotation: Caption rotation in degrees; `None` leaves
                 matplotlib's own label orientation.
             label_location: Caption placement along the bar (distinct from
-                `location`, the bar's edge); `None` keeps the default.
+                `location`, the bar's edge); valid values depend on orientation
+                (vertical: top/center/bottom, horizontal: left/center/right);
+                `None` keeps the default.
             ticks_spacing: Spacing between the colorbar's ticks; `None` keeps
                 the default.
         """
@@ -3097,18 +3101,27 @@ class ArrayGlyph(GeoMixin, Glyph):
                         Orientation of the color bar, by default 'vertical'.
                         Can be 'horizontal' or 'vertical'.
                     cbar_label_rotation : float, optional
-                        Rotation angle of the color bar label, by default -90.
+                        Deprecated; use `colorbar=ColorBar(label_rotation=...)`.
+                        Rotation angle (degrees) of the color bar label, by
+                        default None (matplotlib's own label orientation).
                     cbar_label_location : str, optional
-                        Location of the color bar label, by default 'bottom'.
-                        Options: 'top', 'bottom', 'center', 'baseline', 'center_baseline'.
+                        Deprecated; use `colorbar=ColorBar(label_location=...)`.
+                        Location of the color bar label, by default 'center'.
+                        Options: 'top', 'bottom', 'center', 'baseline',
+                        'center_baseline'; the valid set depends on the bar
+                        orientation (vertical: top/center/bottom).
                     cbar_length : float, optional
-                        Ratio to control the height/width of the color bar, by default 0.75.
+                        Deprecated; use `colorbar=ColorBar(length=...)`. Ratio to
+                        control the height/width of the color bar, by default 0.75.
                     ticks_spacing : int, optional
-                        Spacing between ticks on the color bar, by default 2.
+                        Deprecated; use `colorbar=ColorBar(ticks_spacing=...)`.
+                        Spacing between ticks on the color bar, by default 5.
                     cbar_label_size : int, optional
-                        Font size of the color bar label, by default 12.
+                        Deprecated; use `colorbar=ColorBar(label_size=...)`. Font
+                        size of the color bar label, by default 12.
                     cbar_label : str, optional
-                        Label text for the color bar, by default 'Value'.
+                        Deprecated; use `colorbar=ColorBar(label=...)`. Label text
+                        for the color bar, by default None.
 
                 Color scale options:
                     color_scale : ColorScale or str, optional
@@ -4291,18 +4304,27 @@ class ArrayGlyph(GeoMixin, Glyph):
                         Orientation of the color bar, by default 'vertical'.
                         Can be 'horizontal' or 'vertical'.
                     cbar_label_rotation : float, optional
-                        Rotation angle of the color bar label, by default -90.
+                        Deprecated; use `colorbar=ColorBar(label_rotation=...)`.
+                        Rotation angle (degrees) of the color bar label, by
+                        default None (matplotlib's own label orientation).
                     cbar_label_location : str, optional
-                        Location of the color bar label, by default 'bottom'.
-                        Options: 'top', 'bottom', 'center', 'baseline', 'center_baseline'.
+                        Deprecated; use `colorbar=ColorBar(label_location=...)`.
+                        Location of the color bar label, by default 'center'.
+                        Options: 'top', 'bottom', 'center', 'baseline',
+                        'center_baseline'; the valid set depends on the bar
+                        orientation (vertical: top/center/bottom).
                     cbar_length : float, optional
-                        Ratio to control the height/width of the color bar, by default 0.75.
+                        Deprecated; use `colorbar=ColorBar(length=...)`. Ratio to
+                        control the height/width of the color bar, by default 0.75.
                     ticks_spacing : int, optional
-                        Spacing between ticks on the color bar, by default 2.
+                        Deprecated; use `colorbar=ColorBar(ticks_spacing=...)`.
+                        Spacing between ticks on the color bar, by default 5.
                     cbar_label_size : int, optional
-                        Font size of the color bar label, by default 12.
+                        Deprecated; use `colorbar=ColorBar(label_size=...)`. Font
+                        size of the color bar label, by default 12.
                     cbar_label : str, optional
-                        Label text for the color bar, by default 'Value'.
+                        Deprecated; use `colorbar=ColorBar(label=...)`. Label text
+                        for the color bar, by default None.
 
                 Color scale options:
                     color_scale : ColorScale or str, optional

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1459,11 +1459,13 @@ class Glyph:
         label_text = (
             user_label if user_label is not None else self.default_options["cbar_label"]
         )
+        label_rotation = self.default_options.get("cbar_label_rotation")
         cbar.set_label(
             label_text,
             fontsize=self.default_options["cbar_label_size"],
             loc=self.default_options["cbar_label_location"],
             **({"color": label_color} if label_color else {}),
+            **({"rotation": label_rotation} if label_rotation is not None else {}),
         )
 
     def _inside_colorbar_axes(

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1497,11 +1497,19 @@ class Glyph:
                 `(cax, inset_bounds, label_side)` for `_draw_cbar_box`.
         """
         fig = ax.figure
+        # The inset's long axis scales with `cbar_length` relative to its
+        # default and re-centres, so `ColorBar(length=...)` shortens/lengthens
+        # an inset bar the way `shrink=` does an outside one. The default length
+        # reproduces the historical 0.72 span centred at 0.5 exactly.
+        default_length = STYLE_DEFAULTS["cbar_length"]
+        length = self.default_options.get("cbar_length") or default_length
+        long_frac = 0.72 * (length / default_length)
+        long_start = 0.5 - long_frac / 2
         bounds, label_side = {
-            "right": ((0.905, 0.14, 0.022, 0.72), "left"),
-            "left": ((0.073, 0.14, 0.022, 0.72), "right"),
-            "top": ((0.14, 0.905, 0.72, 0.022), "bottom"),
-            "bottom": ((0.14, 0.073, 0.72, 0.022), "top"),
+            "right": ((0.905, long_start, 0.022, long_frac), "left"),
+            "left": ((0.073, long_start, 0.022, long_frac), "right"),
+            "top": ((long_start, 0.905, long_frac, 0.022), "bottom"),
+            "bottom": ((long_start, 0.073, long_frac, 0.022), "top"),
         }[location]
         cax = ax.inset_axes(bounds)
         cax.set_zorder(6)

--- a/src/cleopatra/styles.py
+++ b/src/cleopatra/styles.py
@@ -103,7 +103,7 @@ DEFAULT_OPTIONS: dict[str, Any] = {
     "cmap": "coolwarm_r",
     "cbar_label_size": 12,
     "cbar_label": None,
-    "cbar_label_rotation": -90,
+    "cbar_label_rotation": None,
     "cbar_label_location": "center",
     "ticks_spacing": 5,
     "color_scale": "linear",

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -6229,9 +6229,45 @@ class TestColorbarPlacement:
             `ColorBar` that sets no caption must not overwrite a loose `cbar_label`.
         """
         g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
-        g.plot(cmap="viridis", colorbar=ColorBar(location="right"), cbar_label="Legacy caption")
+        with pytest.warns(DeprecationWarning, match="cbar_label"):
+            g.plot(cmap="viridis", colorbar=ColorBar(location="right"), cbar_label="Legacy caption")
         caption = g.cbar.ax.get_xlabel() or g.cbar.ax.get_ylabel()
         assert caption == "Legacy caption", f"loose cbar_label was clobbered, got {caption!r}"
+        plt.close("all")
+
+    def test_ticks_spacing_via_spec_takes_effect(self):
+        """`ColorBar(ticks_spacing=...)` drives the drawn tick spacing (#234).
+
+        Test scenario:
+            A spec-provided tick spacing must survive to the render rather than
+            being overwritten by the auto-computed `(vmax - vmin) / 10`.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", vmin=0.0, vmax=20.0, colorbar=ColorBar(location="right", ticks_spacing=5.0))
+        resolved = g.default_options["ticks_spacing"]
+        assert resolved == 5.0, f"spec ticks_spacing was clobbered, got {resolved}"
+        spacings = np.diff(g.cbar.get_ticks())
+        assert np.allclose(spacings, 5.0), f"drawn ticks not spaced by 5.0, got {g.cbar.get_ticks()}"
+        plt.close("all")
+
+    def test_ticks_spacing_spec_wins_over_loose_kwarg(self):
+        """A `ColorBar(ticks_spacing=...)` spec wins over a loose `ticks_spacing=`.
+
+        Test scenario:
+            When both are supplied, `colorbar=` resolves last and takes
+            precedence, consistent with every other mapped `cbar_*` field.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
+            g.plot(
+                cmap="viridis",
+                vmin=0.0,
+                vmax=20.0,
+                ticks_spacing=2.0,
+                colorbar=ColorBar(location="right", ticks_spacing=5.0),
+            )
+        resolved = g.default_options["ticks_spacing"]
+        assert resolved == 5.0, f"loose ticks_spacing should lose to the spec, got {resolved}"
         plt.close("all")
 
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2154,6 +2154,25 @@ class TestAnimateEdgeCases:
         assert anim is not None
         assert glyph.default_options["ticks_spacing"] == 50.0
 
+    def test_animate_ticks_spacing_via_spec(
+        self,
+        coello_data: np.ndarray,
+        animate_time_list: list,
+        no_data_value: float,
+    ):
+        """`animate(colorbar=ColorBar(ticks_spacing=...))` honors the spec spacing (#234).
+
+        Test scenario:
+            The typed spec must survive to the render in animate too, not be
+            overwritten by the auto-computed spacing (the plot-path bug's twin).
+        """
+        glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
+        anim = glyph.animate(animate_time_list, colorbar=ColorBar(ticks_spacing=50.0))
+        assert anim is not None
+        assert glyph.default_options["ticks_spacing"] == 50.0, (
+            f"spec ticks_spacing not honored in animate, got {glyph.default_options['ticks_spacing']}"
+        )
+
     def test_data_getter_is_keyword_only(
         self,
         coello_data: np.ndarray,
@@ -6298,6 +6317,35 @@ class TestColorbarPlacement:
         y_label = g.cbar.ax.yaxis.get_label()
         label_obj = y_label if y_label.get_text() == "Depth" else g.cbar.ax.xaxis.get_label()
         assert label_obj.get_rotation() != 0.0, "unset label_rotation should keep matplotlib's default"
+        plt.close("all")
+
+    def test_label_size_via_spec_takes_effect(self):
+        """`ColorBar(label_size=...)` sets the caption font size (#234).
+
+        Test scenario:
+            A spec-provided font size reaches the drawn colorbar label.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", colorbar=ColorBar(location="right", label="Depth", label_size=20))
+        y_label = g.cbar.ax.yaxis.get_label()
+        label_obj = y_label if y_label.get_text() == "Depth" else g.cbar.ax.xaxis.get_label()
+        assert label_obj.get_fontsize() == 20, f"label_size not applied, got {label_obj.get_fontsize()}"
+        plt.close("all")
+
+    def test_length_via_spec_changes_bar_extent(self):
+        """`ColorBar(length=...)` scales the drawn colorbar's long axis (#234).
+
+        Test scenario:
+            A larger `length` yields a taller vertical colorbar, so the field
+            reaches `fig.colorbar(shrink=...)` rather than being ignored.
+        """
+        short = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        short.plot(cmap="viridis", colorbar=ColorBar(location="right", length=0.3))
+        tall = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        tall.plot(cmap="viridis", colorbar=ColorBar(location="right", length=0.9))
+        short_h = short.cbar.ax.get_position().height
+        tall_h = tall.cbar.ax.get_position().height
+        assert tall_h > short_h, f"length=0.9 bar ({tall_h}) should exceed length=0.3 ({short_h})"
         plt.close("all")
 
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -6364,6 +6364,22 @@ class TestColorbarPlacement:
         assert tall_h > short_h, f"inside length=0.9 bar ({tall_h}) should exceed length=0.3 ({short_h})"
         plt.close("all")
 
+    def test_label_location_via_spec_reaches_render(self):
+        """`ColorBar(label_location=...)` positions the caption along the bar (#234).
+
+        Test scenario:
+            A "top" caption sits higher along a vertical bar than a "bottom" one,
+            confirming label_location reaches `set_label(loc=...)` at render.
+        """
+        top = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        top.plot(cmap="viridis", colorbar=ColorBar(location="right", label="Depth", label_location="top"))
+        bottom = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        bottom.plot(cmap="viridis", colorbar=ColorBar(location="right", label="Depth", label_location="bottom"))
+        top_y = top.cbar.ax.yaxis.get_label().get_position()[1]
+        bottom_y = bottom.cbar.ax.yaxis.get_label().get_position()[1]
+        assert top_y > bottom_y, f"label_location not applied: top_y={top_y}, bottom_y={bottom_y}"
+        plt.close("all")
+
 
 class TestColorBar:
     """Tests for the `ColorBar` placement/box config object."""

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -119,7 +119,7 @@ class TestPlotArray:
     ):
         array = ArrayGlyph(arr, exclude_value=[no_data_value])
         fig, ax = array.plot(
-            color_scale=color_scale[0], cmap=cmap, ticks_spacing=ticks_spacing
+            color_scale=color_scale[0], cmap=cmap, colorbar=ColorBar(ticks_spacing=ticks_spacing)
         )
         assert isinstance(fig, Figure)
 
@@ -137,7 +137,7 @@ class TestPlotArray:
             color_scale=color_scale[1],
             cmap=cmap,
             gamma=color_scale_2_gamma,
-            ticks_spacing=ticks_spacing,
+            colorbar=ColorBar(ticks_spacing=ticks_spacing),
         )
         assert isinstance(fig, Figure)
 
@@ -157,7 +157,7 @@ class TestPlotArray:
             line_scale=color_scale_3_linscale,
             line_threshold=color_scale_3_linthresh,
             cmap=cmap,
-            ticks_spacing=ticks_spacing,
+            colorbar=ColorBar(ticks_spacing=ticks_spacing),
         )
 
         assert isinstance(fig, Figure)
@@ -171,7 +171,7 @@ class TestPlotArray:
         ticks_spacing: int,
     ):
         array = ArrayGlyph(arr, exclude_value=[no_data_value])
-        fig, ax = array.plot(color_scale=color_scale[3], cmap=cmap, ticks_spacing=5)
+        fig, ax = array.plot(color_scale=color_scale[3], cmap=cmap, colorbar=ColorBar(ticks_spacing=5))
 
         assert isinstance(fig, Figure)
 
@@ -188,7 +188,7 @@ class TestPlotArray:
         fig, ax = array.plot(
             color_scale=color_scale[3],
             cmap=cmap,
-            ticks_spacing=ticks_spacing,
+            colorbar=ColorBar(ticks_spacing=ticks_spacing),
             bounds=bounds,
         )
 
@@ -208,7 +208,7 @@ class TestPlotArray:
             color_scale=color_scale[4],
             midpoint=midpoint,
             cmap=cmap,
-            ticks_spacing=ticks_spacing,
+            colorbar=ColorBar(ticks_spacing=ticks_spacing),
         )
 
         assert isinstance(fig, Figure)
@@ -227,7 +227,7 @@ class TestPlotArray:
             display_cell_value=display_cell_value,
             num_size=num_size,
             background_color_threshold=background_color_threshold,
-            ticks_spacing=ticks_spacing,
+            colorbar=ColorBar(ticks_spacing=ticks_spacing),
         )
 
         assert isinstance(fig, Figure)
@@ -254,7 +254,7 @@ class TestPlotArray:
             display_cell_value=display_cell_value,
             num_size=num_size,
             background_color_threshold=background_color_threshold,
-            ticks_spacing=ticks_spacing,
+            colorbar=ColorBar(ticks_spacing=ticks_spacing),
         )
 
         assert isinstance(fig, Figure)
@@ -1769,12 +1769,13 @@ class TestPlotRecomputeBranch:
             glyph.plot(banana_count=12)
 
     def test_recompute_with_explicit_ticks_spacing(self):
-        """`plot(robust=True, ticks_spacing=...)` keeps the user's spacing."""
+        """A loose `ticks_spacing=` (deprecated) still wins over the recompute path."""
         rng = np.random.default_rng(1337)
         body = rng.random(98)
         arr = np.concatenate([body, [-1000.0, 1000.0]]).reshape(10, 10)
         glyph = ArrayGlyph(arr)
-        glyph.plot(robust=True, ticks_spacing=0.1)
+        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
+            glyph.plot(robust=True, ticks_spacing=0.1)
         assert glyph.default_options["ticks_spacing"] == 0.1, (
             "Explicit ticks_spacing must win over the recompute path"
         )
@@ -2146,9 +2147,10 @@ class TestAnimateEdgeCases:
         animate_time_list: list,
         no_data_value: float,
     ):
-        """`animate(ticks_spacing=...)` overrides the auto-computed spacing."""
+        """A loose `animate(ticks_spacing=...)` (deprecated) overrides the auto spacing."""
         glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
-        anim = glyph.animate(animate_time_list, ticks_spacing=50.0)
+        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
+            anim = glyph.animate(animate_time_list, ticks_spacing=50.0)
         assert anim is not None
         assert glyph.default_options["ticks_spacing"] == 50.0
 
@@ -2273,11 +2275,11 @@ class TestAnimateEdgeCases:
         """`size=None` inherits `cbar_label_size` (the pre-`size` behaviour).
 
         Test scenario:
-            With ``FrameLabel()`` (size unset) and ``cbar_label_size=17``, the
-            label falls back to the colorbar label size, 17 pt.
+            With ``FrameLabel()`` (size unset) and ``ColorBar(label_size=17)``,
+            the label falls back to the colorbar label size, 17 pt.
         """
         glyph = ArrayGlyph(coello_data)
-        glyph.animate(animate_time_list, frame_label=FrameLabel(), cbar_label_size=17)
+        glyph.animate(animate_time_list, frame_label=FrameLabel(), colorbar=ColorBar(label_size=17))
         assert glyph._day_text.get_fontsize() == 17, (
             f"Expected inherited fontsize 17, got {glyph._day_text.get_fontsize()}"
         )
@@ -6268,6 +6270,34 @@ class TestColorbarPlacement:
             )
         resolved = g.default_options["ticks_spacing"]
         assert resolved == 5.0, f"loose ticks_spacing should lose to the spec, got {resolved}"
+        plt.close("all")
+
+    def test_label_rotation_via_spec_takes_effect(self):
+        """`ColorBar(label_rotation=...)` rotates the drawn caption (#234).
+
+        Test scenario:
+            A spec-provided rotation reaches the colorbar label instead of being
+            dropped (matplotlib's default vertical-label rotation is not 0).
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", colorbar=ColorBar(location="right", label="Depth", label_rotation=0.0))
+        y_label = g.cbar.ax.yaxis.get_label()
+        label_obj = y_label if y_label.get_text() == "Depth" else g.cbar.ax.xaxis.get_label()
+        assert label_obj.get_rotation() == 0.0, f"label_rotation not applied, got {label_obj.get_rotation()}"
+        plt.close("all")
+
+    def test_label_rotation_unset_leaves_matplotlib_default(self):
+        """An unset `label_rotation` leaves matplotlib's default orientation.
+
+        Test scenario:
+            Phase 1 is additive -- a caption with no `label_rotation` keeps the
+            pre-existing (non-zero) vertical rotation, so nothing regresses.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", colorbar=ColorBar(location="right", label="Depth"))
+        y_label = g.cbar.ax.yaxis.get_label()
+        label_obj = y_label if y_label.get_text() == "Depth" else g.cbar.ax.xaxis.get_label()
+        assert label_obj.get_rotation() != 0.0, "unset label_rotation should keep matplotlib's default"
         plt.close("all")
 
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -6207,6 +6207,32 @@ class TestColorbarPlacement:
         assert len(g_box.ax.patches) == len(g_no.ax.patches) + 1, "box=True should add one swatch backing panel"
         plt.close("all")
 
+    def test_caption_via_spec_alone(self):
+        """A caption/length set through `ColorBar` render with no loose kwargs.
+
+        Test scenario:
+            #234 -- `ColorBar(label=..., length=...)` fully configures the bar,
+            so the caption renders without falling back to a loose `cbar_label=`.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", colorbar=ColorBar(location="bottom", label="Rainfall mm/day", length=0.8))
+        caption = g.cbar.ax.get_xlabel() or g.cbar.ax.get_ylabel()
+        assert caption == "Rainfall mm/day", f"caption not set via ColorBar, got {caption!r}"
+        plt.close("all")
+
+    def test_spec_does_not_clobber_loose_caption(self):
+        """An unset ColorBar caption leaves a loose `cbar_label` intact.
+
+        Test scenario:
+            During the transition (before the loose kwargs are deprecated), a
+            `ColorBar` that sets no caption must not overwrite a loose `cbar_label`.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", colorbar=ColorBar(location="right"), cbar_label="Legacy caption")
+        caption = g.cbar.ax.get_xlabel() or g.cbar.ax.get_ylabel()
+        assert caption == "Legacy caption", f"loose cbar_label was clobbered, got {caption!r}"
+        plt.close("all")
+
 
 class TestColorBar:
     """Tests for the `ColorBar` placement/box config object."""
@@ -6280,6 +6306,28 @@ class TestColorBar:
         spec = ColorBar(label_color="black", tick_color="red")
         assert (spec.label_color, spec.tick_color) == ("black", "red"), "colour fields should store verbatim"
 
+    def test_caption_sizing_fields_default_none_and_store(self):
+        """The caption/sizing fields default to `None` and store verbatim.
+
+        Test scenario:
+            label / length / label_size / label_rotation / label_location /
+            ticks_spacing are optional holders, `None` when unset.
+        """
+        bare = ColorBar()
+        for f in ("label", "length", "label_size", "label_rotation",
+                  "label_location", "ticks_spacing"):
+            assert getattr(bare, f) is None, f"{f} should default to None"
+        spec = ColorBar(
+            label="Rainfall mm/day", length=0.8, label_size=9.0,
+            label_rotation=90.0, label_location="center", ticks_spacing=5.0,
+        )
+        assert spec.label == "Rainfall mm/day", f"label not stored: {spec.label}"
+        assert spec.length == 0.8, f"length not stored: {spec.length}"
+        assert spec.label_size == 9.0, f"label_size not stored: {spec.label_size}"
+        assert spec.label_rotation == 90.0, f"label_rotation not stored: {spec.label_rotation}"
+        assert spec.label_location == "center", f"label_location not stored: {spec.label_location}"
+        assert spec.ticks_spacing == 5.0, f"ticks_spacing not stored: {spec.ticks_spacing}"
+
 
 class TestResolveColorbar:
     """Tests for the `_resolve_colorbar` front-door parser."""
@@ -6335,6 +6383,39 @@ class TestResolveColorbar:
             "cbar_tick_color": "red",
         }
         assert out == expected, f"spec fields not mapped, got {out}"
+
+    def test_spec_maps_caption_and_sizing_fields(self):
+        """A `ColorBar` maps its caption/sizing fields onto the `cbar_*` keys.
+
+        Test scenario:
+            label -> cbar_label, length -> cbar_length, label_size ->
+            cbar_label_size, label_rotation -> cbar_label_rotation,
+            label_location -> cbar_label_location, ticks_spacing -> ticks_spacing.
+        """
+        out = _resolve_colorbar(
+            ColorBar(
+                label="Rainfall mm/day", length=0.8, label_size=9.0,
+                label_rotation=90.0, label_location="center", ticks_spacing=5.0,
+            )
+        )
+        assert out["cbar_label"] == "Rainfall mm/day", f"cbar_label not mapped: {out}"
+        assert out["cbar_length"] == 0.8, f"cbar_length not mapped: {out}"
+        assert out["cbar_label_size"] == 9.0, f"cbar_label_size not mapped: {out}"
+        assert out["cbar_label_rotation"] == 90.0, f"cbar_label_rotation not mapped: {out}"
+        assert out["cbar_label_location"] == "center", f"cbar_label_location not mapped: {out}"
+        assert out["ticks_spacing"] == 5.0, f"ticks_spacing not mapped: {out}"
+
+    def test_unset_caption_fields_are_not_emitted(self):
+        """Unset caption/sizing fields are omitted, so loose defaults survive.
+
+        Test scenario:
+            A `ColorBar` that sets no caption/sizing field must not emit those
+            `cbar_*` keys (otherwise it would clobber a loose `cbar_label`).
+        """
+        out = _resolve_colorbar(ColorBar(location="right"))
+        for key in ("cbar_label", "cbar_length", "cbar_label_size",
+                    "cbar_label_rotation", "cbar_label_location", "ticks_spacing"):
+            assert key not in out, f"{key} should not be emitted when unset, got {out}"
 
     @pytest.mark.parametrize("bad", ["right", 1, 1.5, ["right"], {"location": "right"}])
     def test_invalid_type_raises(self, bad):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -19,6 +19,7 @@ from cleopatra.array_glyph import (
     _UNSET,
     _resolve_colorbar,
     _swatch_text_default,
+    _warn_deprecated_cbar_kwargs,
     AnimateKwargs,
     ArrayGlyph,
     ColorBar,
@@ -6429,6 +6430,65 @@ class TestResolveColorbar:
         """
         with pytest.raises(TypeError, match="colorbar must be"):
             _resolve_colorbar(bad)
+
+
+class TestDeprecatedCbarKwargs:
+    """Deprecation of the loose `cbar_*` kwargs superseded by `ColorBar` (#234)."""
+
+    @staticmethod
+    def _field() -> np.ndarray:
+        """Return a small 2-D field for a single static plot."""
+        return np.arange(20 * 30, dtype=float).reshape(20, 30)
+
+    def test_helper_warns_for_a_deprecated_key(self):
+        """`_warn_deprecated_cbar_kwargs` warns and names the `ColorBar` field.
+
+        Test scenario:
+            A loose `cbar_label` triggers a DeprecationWarning pointing at
+            `colorbar=ColorBar(label=...)`.
+        """
+        with pytest.warns(DeprecationWarning, match=r"cbar_label.*ColorBar\(label="):
+            _warn_deprecated_cbar_kwargs({"cbar_label": "Depth"})
+
+    def test_helper_silent_without_deprecated_keys(self):
+        """No warning is emitted when no deprecated key is present.
+
+        Test scenario:
+            A kwargs dict free of loose cbar_* keys warns nothing.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _warn_deprecated_cbar_kwargs({"cmap": "viridis", "vmin": 0})
+
+    def test_plot_loose_cbar_label_warns_but_still_works(self):
+        """A loose `cbar_label` on `plot` warns yet still renders the caption.
+
+        Test scenario:
+            During the deprecation window the kwarg keeps working (caption
+            rendered) while steering the caller toward `ColorBar`.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 30.0, 20.0])
+        with pytest.warns(DeprecationWarning, match="cbar_label"):
+            g.plot(cmap="viridis", cbar_label="Rainfall mm/day")
+        caption = g.cbar.ax.get_xlabel() or g.cbar.ax.get_ylabel()
+        assert caption == "Rainfall mm/day", f"deprecated kwarg should still work, got {caption!r}"
+        plt.close("all")
+
+    def test_typed_colorbar_does_not_warn(self):
+        """Configuring the caption through `ColorBar` emits no cbar deprecation.
+
+        Test scenario:
+            The typed `colorbar=ColorBar(label=...)` path is the recommended
+            replacement and must not raise the loose-kwarg deprecation.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 30.0, 20.0])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            g.plot(cmap="viridis", colorbar=ColorBar(label="Rainfall mm/day"))
+        assert not any(
+            "deprecated" in str(x.message) and "cbar" in str(x.message) for x in caught
+        ), "typed ColorBar should not trigger the loose-kwarg deprecation"
+        plt.close("all")
 
 
 class TestStylePrecedence:

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -6348,6 +6348,22 @@ class TestColorbarPlacement:
         assert tall_h > short_h, f"length=0.9 bar ({tall_h}) should exceed length=0.3 ({short_h})"
         plt.close("all")
 
+    def test_length_inside_changes_bar_extent(self):
+        """`ColorBar(inside=True, length=...)` scales an inset bar too (#234).
+
+        Test scenario:
+            The inset path must honor `length` -- a shorter spec yields a shorter
+            inset bar rather than the field silently no-opping.
+        """
+        short = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        short.plot(cmap="viridis", colorbar=ColorBar(location="right", inside=True, length=0.3))
+        tall = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        tall.plot(cmap="viridis", colorbar=ColorBar(location="right", inside=True, length=0.9))
+        short_h = short.cbar.ax.get_position().height
+        tall_h = tall.cbar.ax.get_position().height
+        assert tall_h > short_h, f"inside length=0.9 bar ({tall_h}) should exceed length=0.3 ({short_h})"
+        plt.close("all")
+
 
 class TestColorBar:
     """Tests for the `ColorBar` placement/box config object."""


### PR DESCRIPTION
# Description

Completes the `ColorBar` spec for `ArrayGlyph` so the colorbar can be configured entirely through the typed
`colorbar=ColorBar(...)` object instead of loose `cbar_*` keyword arguments (issue #234).

- Adds six caption/sizing fields to `ColorBar`: `label`, `length`, `label_size`, `label_rotation`,
  `label_location`, and `ticks_spacing`. `_resolve_colorbar` maps them onto the internal `cbar_*` / `ticks_spacing`
  options **only when set**, so an unset field never clobbers a loose value passed during the transition.
- Makes fields that were previously silent no-ops actually work end-to-end: `cbar_label_rotation` is now applied to
  the colorbar label, `ColorBar.length` now sizes **inside (inset)** colorbars too (not just outside gutter bars), and
  a `ColorBar(ticks_spacing=...)` value is no longer overwritten by the auto-computed spacing in `plot`/`animate`.
- Deprecates the loose `cbar_*` and top-level `ticks_spacing` kwargs in favour of `colorbar=ColorBar(...)` via a
  `DeprecationWarning`. The kwargs still take effect during the deprecation window, so nothing breaks.
- Migrates the `plot`/`animate` docstrings, the `ArrayGlyph` tutorial notebooks, and the test suite to the typed
  spec, and adds render-level tests for every new field.

This change is **non-breaking**. The vendored `cbar_label_rotation` default of `-90` (which was dead code, read by
no renderer) is changed to `None`, which preserves matplotlib's existing default label orientation for callers who do
not set it.

Scope note: the typed spec + deprecation are `ArrayGlyph`-only for now; extending them to `MeshGlyph`/`FlowGlyph` is
intentionally left as separate follow-up work.

No new dependencies are required.

# Issues

- Closes #234 — complete the `ColorBar` spec (caption/length/sizing fields; deprecate the loose `cbar_*` kwargs)

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Run from the repository root against the project environment:

```
PYTHONPATH=src python -m pytest -m "not live" -q
PYTHONPATH=src python -m pytest --doctest-modules src/cleopatra/array_glyph.py src/cleopatra/glyph.py src/cleopatra/styles.py -q
```

- [x] Full offline unit-test suite (`pytest -m "not live"`) — 1902 passed
- [x] Doctests for `array_glyph`, `glyph`, and `styles` — 66 passed

New tests cover: field storage and defaults; the `_resolve_colorbar` mapping (including that unset fields are
omitted); per-key `DeprecationWarning`s and the still-working legacy path; and render-level assertions that each new
field reaches the drawn colorbar — `ticks_spacing` (outside and via `animate`, plus spec-wins-over-loose precedence),
`label_rotation` (applied when set, matplotlib default preserved when unset), `label_size`, `length` (outside and
inside), and `label_location`.

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
