### PR TITLE
feat(array_glyph): add ColorBar.orientation and deprecate the loose cbar_orientation kwarg

### DIFF
--- a/docs/notebooks/array_glyph/array_glyph_examples.ipynb
+++ b/docs/notebooks/array_glyph/array_glyph_examples.ipynb
@@ -541,7 +541,7 @@
    "id": "44",
    "metadata": {},
    "outputs": [],
-   "source": "# Create an array\ncolorbar_array = np.random.default_rng(42).random((15, 15))\n\n# Initialize the ArrayGlyph with the array\narray_glyph_colorbar = ArrayGlyph(colorbar_array)\n\n# Plot with a custom colorbar\nfig, ax = array_glyph_colorbar.plot(\n    colorbar=ColorBar(label=\"Values\", length=0.8),  # Caption + shrink the colorbar\n    cbar_orientation=\"horizontal\",  # Set colorbar orientation\n    cmap=\"plasma\",  # Use the plasma colormap\n    title=\"Array with Custom Colorbar\",\n    figsize=(10, 8),\n)"
+   "source": "# Create an array\ncolorbar_array = np.random.default_rng(42).random((15, 15))\n\n# Initialize the ArrayGlyph with the array\narray_glyph_colorbar = ArrayGlyph(colorbar_array)\n\n# Plot with a custom colorbar\nfig, ax = array_glyph_colorbar.plot(\n    colorbar=ColorBar(label=\"Values\", length=0.8, orientation=\"horizontal\"),\n    cmap=\"plasma\",  # Use the plasma colormap\n    title=\"Array with Custom Colorbar\",\n    figsize=(10, 8),\n)"
   },
   {
    "cell_type": "markdown",

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -713,6 +713,11 @@ class ColorBar:
             or `"bottom"`. `None` (default) keeps matplotlib's placement
             (right of a vertical bar). Left/right force a vertical bar,
             top/bottom a horizontal one.
+        orientation: Bar orientation -- `"vertical"` or `"horizontal"`. `None`
+            (default) lets `location` decide (or matplotlib's default when
+            `location` is `None`). Because a set `location` fixes the
+            orientation, an `orientation` that disagrees with it is ignored
+            (with a `UserWarning`) -- set only one.
         inside: When `True`, the colorbar is inset *inside* the frame at
             `location` (overlaying the data) rather than in an outside gutter,
             by default `False`. An inset is a child of the data axes, so it
@@ -786,6 +791,7 @@ class ColorBar:
         self,
         *,
         location: Literal["left", "right", "top", "bottom"] | None = None,
+        orientation: Literal["vertical", "horizontal"] | None = None,
         inside: bool = False,
         box: bool | str | dict | None = None,
         label_color: str | None = None,
@@ -802,6 +808,9 @@ class ColorBar:
         Args:
             location: Edge to sit on (`"left"`/`"right"`/`"top"`/`"bottom"`),
                 or `None` for matplotlib's default placement.
+            orientation: Bar orientation (`"vertical"`/`"horizontal"`), or
+                `None` to let `location` decide. Ignored (with a `UserWarning`)
+                when it disagrees with the orientation `location` implies.
             inside: Inset the colorbar inside the frame, by default `False`.
             box: Backing panel for an inside colorbar (`True` / colour / dict),
                 or `None` to default it on when `inside` is set.
@@ -823,6 +832,20 @@ class ColorBar:
                 the default.
         """
         self.location = location
+        self.orientation = orientation
+        # `location` fixes the orientation (left/right -> vertical, top/bottom
+        # -> horizontal). If an explicit `orientation` disagrees it is ignored
+        # downstream, so warn here rather than dropping it silently (issue #235).
+        if location is not None and orientation is not None:
+            implied = "vertical" if location in ("left", "right") else "horizontal"
+            if orientation != implied:
+                warnings.warn(
+                    f"ColorBar(orientation={orientation!r}) is ignored because "
+                    f"location={location!r} already fixes the orientation to "
+                    f"{implied!r}; set only one.",
+                    UserWarning,
+                    stacklevel=2,
+                )
         self.inside = inside
         # An inset over moving data almost always wants a panel: default the
         # box on when `inside` is set and the caller did not decide explicitly.
@@ -940,6 +963,7 @@ def _resolve_colorbar(colorbar: bool | ColorBar | None) -> dict:
             "cbar_label_size": colorbar.label_size,
             "cbar_label_rotation": colorbar.label_rotation,
             "cbar_label_location": colorbar.label_location,
+            "cbar_orientation": colorbar.orientation,
             "ticks_spacing": colorbar.ticks_spacing,
         }
         updates.update({k: v for k, v in optional.items() if v is not None})
@@ -962,6 +986,7 @@ _DEPRECATED_CBAR_KWARGS = {
     "cbar_label_size": "label_size",
     "cbar_label_rotation": "label_rotation",
     "cbar_label_location": "label_location",
+    "cbar_orientation": "orientation",
     "ticks_spacing": "ticks_spacing",
 }
 
@@ -3100,6 +3125,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                         color bar is skipped (with a warning) even when
                         `add_colorbar` is True, and `self.cbar` stays None.
                     cbar_orientation : str, optional
+                        Deprecated; use `colorbar=ColorBar(orientation=...)`.
                         Orientation of the color bar, by default 'vertical'.
                         Can be 'horizontal' or 'vertical'.
                     cbar_label_rotation : float, optional
@@ -3312,13 +3338,13 @@ class ArrayGlyph(GeoMixin, Glyph):
                 ```python
                 >>> array = ArrayGlyph(arr, figsize=(6, 6), title="Customized color bar", title_size=18)
                 >>> fig, ax = array.plot(
-                ...     cbar_orientation="horizontal",
                 ...     colorbar=ColorBar(
                 ...         label="Discharge m3/s",
                 ...         label_location="center",
                 ...         length=0.7,
                 ...         label_size=12,
                 ...         ticks_spacing=5,
+                ...         orientation="horizontal",
                 ...     ),
                 ...     color_scale="linear",
                 ...     cmap="coolwarm_r",
@@ -4303,6 +4329,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                         None and no axes space is taken by a color bar.
                         The mappable is still reachable via `self.im`.
                     cbar_orientation : str, optional
+                        Deprecated; use `colorbar=ColorBar(orientation=...)`.
                         Orientation of the color bar, by default 'vertical'.
                         Can be 'horizontal' or 'vertical'.
                     cbar_label_rotation : float, optional

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -714,10 +714,12 @@ class ColorBar:
             (right of a vertical bar). Left/right force a vertical bar,
             top/bottom a horizontal one.
         orientation: Bar orientation -- `"vertical"` or `"horizontal"`. `None`
-            (default) lets `location` decide (or matplotlib's default when
-            `location` is `None`). Because a set `location` fixes the
+            (default) lets `location` decide, and yields a vertical bar when
+            `location` is `None` too. Because a set `location` fixes the
             orientation, an `orientation` that disagrees with it is ignored
-            (with a `UserWarning`) -- set only one.
+            (with a `UserWarning`) -- set only one. The resolved orientation is
+            sticky on a reused glyph: a later `ColorBar()` with `orientation`
+            unset does not reset a previously applied one.
         inside: When `True`, the colorbar is inset *inside* the frame at
             `location` (overlaying the data) rather than in an outside gutter,
             by default `False`. An inset is a child of the data axes, so it
@@ -809,8 +811,9 @@ class ColorBar:
             location: Edge to sit on (`"left"`/`"right"`/`"top"`/`"bottom"`),
                 or `None` for matplotlib's default placement.
             orientation: Bar orientation (`"vertical"`/`"horizontal"`), or
-                `None` to let `location` decide. Ignored (with a `UserWarning`)
-                when it disagrees with the orientation `location` implies.
+                `None` to let `location` decide (a vertical bar when neither is
+                set). Ignored (with a `UserWarning`) when it disagrees with the
+                orientation `location` implies.
             inside: Inset the colorbar inside the frame, by default `False`.
             box: Backing panel for an inside colorbar (`True` / colour / dict),
                 or `None` to default it on when `inside` is set.

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -3014,6 +3014,54 @@ class ArrayGlyph(GeoMixin, Glyph):
         )
         return list(map(add_text, indices))
 
+    def _apply_kwargs_and_colorbar(
+        self, colorbar: bool | ColorBar | None, kwargs: dict
+    ) -> dict:
+        """Fold loose kwargs and `colorbar=` into `default_options`; set style flags.
+
+        Shared by `plot` and `animate`: validates and applies each loose keyword
+        into `default_options`, merges the resolved `colorbar=` spec last (so it
+        wins over a same-named loose key), records this call's colour-limit
+        overrides for a preset render, and sets `_style_wants_colorbar` -- a
+        placement-bearing `colorbar=` (`location`, `inside`, `orientation`, or
+        `True`) draws a real colorbar over a preset's swatch, while a spec
+        carrying only colours/box styles the swatch in place.
+
+        Args:
+            colorbar: The `colorbar=` argument (`bool`, `ColorBar`, or `None`).
+            kwargs: The remaining `plot` / `animate` keyword arguments.
+
+        Returns:
+            The resolved `colorbar` option dict, so the caller can honour a
+            spec-provided `ticks_spacing` before auto-computing it.
+        """
+        for key, val in kwargs.items():
+            if key not in self.default_options.keys():
+                raise ValueError(
+                    f"The given keyword argument:{key} is not correct, possible parameters are,"
+                    f" {DEFAULT_OPTIONS}"
+                )
+            else:
+                self.default_options[key] = val
+        # `colorbar=` (a ColorBar / bool) resolves last, so it wins over the
+        # default `add_colorbar` and any internal cbar_* key.
+        resolved_colorbar = _resolve_colorbar(colorbar)
+        self.default_options.update(resolved_colorbar)
+        # Record colour limits supplied to THIS call so a preset render honours
+        # them (see `_style_color_overrides`); sticky, only for keys passed.
+        for key in ("vmin", "vmax", "center", "cmap"):
+            if key in kwargs and kwargs[key] is not None:
+                self._style_color_overrides[key] = kwargs[key]
+        self._style_wants_colorbar = colorbar is True or (
+            isinstance(colorbar, ColorBar)
+            and (
+                colorbar.location is not None
+                or colorbar.inside
+                or colorbar.orientation is not None
+            )
+        )
+        return resolved_colorbar
+
     def plot(
         self,
         points: np.ndarray | PointOverlay | None = None,
@@ -3635,41 +3683,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         points = _resolve_point_overlay(points, kwargs)  # type: ignore[arg-type]
         _warn_deprecated_cbar_kwargs(kwargs)
 
-        for key, val in kwargs.items():
-            if key not in self.default_options.keys():
-                raise ValueError(
-                    f"The given keyword argument:{key} is not correct, possible parameters are,"
-                    f" {DEFAULT_OPTIONS}"
-                )
-            else:
-                self.default_options[key] = val
-
-        # `colorbar=` (a ColorBar / bool) resolves last, so it wins over
-        # the default `add_colorbar` and any internal cbar_* key.
-        resolved_colorbar = _resolve_colorbar(colorbar)
-        self.default_options.update(resolved_colorbar)
-
-        # Record colour limits supplied to THIS plot() call so a preset render
-        # honours them (see `_style_color_overrides`). Sticky, and only for
-        # keys actually passed -- an auto-ranged plain plot adds nothing.
-        # `kwargs` is a real, mutable dict at runtime -- mypy's TypedDict model
-        # just does not support indexing it with a non-literal (loop) key.
-        kwargs_dict = cast(dict, kwargs)
-        for key in ("vmin", "vmax", "center", "cmap"):
-            if key in kwargs_dict and kwargs_dict[key] is not None:
-                self._style_color_overrides[key] = kwargs_dict[key]
-        # A `colorbar=` that requests PLACEMENT (a `ColorBar` with `location`/
-        # `inside`, or `colorbar=True`) overrides a preset's swatch with a real
-        # colorbar. A `ColorBar` carrying only colours/box styles the swatch in
-        # place instead, so the ECMWF swatch is kept.
-        self._style_wants_colorbar = colorbar is True or (
-            isinstance(colorbar, ColorBar)
-            and (
-                colorbar.location is not None
-                or colorbar.inside
-                or colorbar.orientation is not None
-            )
-        )
+        resolved_colorbar = self._apply_kwargs_and_colorbar(colorbar, kwargs)  # type: ignore[arg-type]
 
         self._validate_extend(self.default_options.get("extend"))
 
@@ -4628,42 +4642,7 @@ class ArrayGlyph(GeoMixin, Glyph):
             assert frame_location is not None
             label_location = frame_location
 
-        for key, val in kwargs.items():
-            if key not in self.default_options.keys():
-                raise ValueError(
-                    f"The given keyword argument:{key} is not correct, possible parameters are,"
-                    f" {DEFAULT_OPTIONS}"
-                )
-            else:
-                self.default_options[key] = val
-
-        # `colorbar=` (a ColorBar / bool) resolves last, so it wins over
-        # the default `add_colorbar` and any internal cbar_* key.
-        resolved_colorbar = _resolve_colorbar(colorbar)
-        self.default_options.update(resolved_colorbar)
-
-        # Record colour limits supplied to THIS animate() call so a styled
-        # animation honours an explicit caller override of the preset's fixed
-        # range (see `_style_color_overrides`); an auto-ranged plain animation
-        # adds nothing.
-        # `kwargs` is a real, mutable dict at runtime -- mypy's TypedDict model
-        # just does not support indexing it with a non-literal (loop) key.
-        kwargs_dict = cast(dict, kwargs)
-        for key in ("vmin", "vmax", "center", "cmap"):
-            if key in kwargs_dict and kwargs_dict[key] is not None:
-                self._style_color_overrides[key] = kwargs_dict[key]
-        # A `colorbar=` that requests PLACEMENT (a `ColorBar` with `location`/
-        # `inside`, or `colorbar=True`) overrides a preset's swatch with a real
-        # colorbar. A `ColorBar` carrying only colours/box styles the swatch in
-        # place instead, so the ECMWF swatch is kept.
-        self._style_wants_colorbar = colorbar is True or (
-            isinstance(colorbar, ColorBar)
-            and (
-                colorbar.location is not None
-                or colorbar.inside
-                or colorbar.orientation is not None
-            )
-        )
+        resolved_colorbar = self._apply_kwargs_and_colorbar(colorbar, kwargs)  # type: ignore[arg-type]
 
         # Tick-spacing precedence: a `colorbar=ColorBar(ticks_spacing=...)` spec
         # wins (already merged above), then a loose `ticks_spacing=` kwarg, then

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -831,12 +831,19 @@ class ColorBar:
             ticks_spacing: Spacing between the colorbar's ticks; `None` keeps
                 the default.
         """
+        if orientation is not None and orientation not in ("vertical", "horizontal"):
+            raise ValueError(
+                "ColorBar orientation must be 'vertical' or 'horizontal', got "
+                f"{orientation!r}."
+            )
         self.location = location
         self.orientation = orientation
         # `location` fixes the orientation (left/right -> vertical, top/bottom
         # -> horizontal). If an explicit `orientation` disagrees it is ignored
         # downstream, so warn here rather than dropping it silently (issue #235).
-        if location is not None and orientation is not None:
+        # Only a valid edge implies an orientation; an invalid `location` is left
+        # for `create_color_bar` to reject with a clearer message.
+        if location in ("left", "right", "top", "bottom") and orientation is not None:
             implied = "vertical" if location in ("left", "right") else "horizontal"
             if orientation != implied:
                 warnings.warn(

--- a/src/cleopatra/array_glyph.py
+++ b/src/cleopatra/array_glyph.py
@@ -953,6 +953,10 @@ def _resolve_colorbar(colorbar: bool | ColorBar | None) -> dict:
             "cbar_box": None,
             "cbar_label_color": None,
             "cbar_tick_color": None,
+            # Reset the placement family to defaults so a bare `True` really
+            # draws a default bar; orientation is placement, so a prior sticky
+            # `cbar_orientation` must not leak into it.
+            "cbar_orientation": "vertical",
         }
     if isinstance(colorbar, ColorBar):
         updates = {
@@ -3660,7 +3664,11 @@ class ArrayGlyph(GeoMixin, Glyph):
         # place instead, so the ECMWF swatch is kept.
         self._style_wants_colorbar = colorbar is True or (
             isinstance(colorbar, ColorBar)
-            and (colorbar.location is not None or colorbar.inside)
+            and (
+                colorbar.location is not None
+                or colorbar.inside
+                or colorbar.orientation is not None
+            )
         )
 
         self._validate_extend(self.default_options.get("extend"))
@@ -4650,7 +4658,11 @@ class ArrayGlyph(GeoMixin, Glyph):
         # place instead, so the ECMWF swatch is kept.
         self._style_wants_colorbar = colorbar is True or (
             isinstance(colorbar, ColorBar)
-            and (colorbar.location is not None or colorbar.inside)
+            and (
+                colorbar.location is not None
+                or colorbar.inside
+                or colorbar.orientation is not None
+            )
         )
 
         # Tick-spacing precedence: a `colorbar=ColorBar(ticks_spacing=...)` spec

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1373,6 +1373,15 @@ class Glyph:
                 "cbar_location must be one of 'left', 'right', 'top', "
                 f"'bottom', or None, got {location!r}."
             )
+        orientation_opt = self.default_options.get("cbar_orientation")
+        if orientation_opt is not None and orientation_opt not in ("vertical", "horizontal"):
+            # Validate at render too, so a bad value reaching this path -- via the
+            # deprecated loose `cbar_orientation` kwarg or a low-level Glyph -- gets
+            # an actionable error instead of an opaque matplotlib one.
+            raise ValueError(
+                "cbar_orientation must be 'vertical' or 'horizontal', got "
+                f"{orientation_opt!r}."
+            )
         inside = bool(self.default_options.get("cbar_inside", False))
         orientation = self._resolve_cbar_orientation(location)
         # Pull the user-supplied `label` (if any) out of cbar_kwargs before

--- a/src/cleopatra/glyph.py
+++ b/src/cleopatra/glyph.py
@@ -1384,8 +1384,15 @@ class Glyph:
         if inside:
             # An inset colorbar is a child of `ax`, so it tracks the axes
             # through `full_bleed` (never floats) and can sit on a backing box.
+            # With no explicit `location`, pick the inset edge from the resolved
+            # orientation so the geometry and the bar's orientation agree --
+            # otherwise a horizontal bar would inherit the vertical "right"
+            # layout and matplotlib rejects the mismatched tick position.
+            inset_location = location or (
+                "bottom" if orientation == "horizontal" else "right"
+            )
             cbar, box_info = self._inside_colorbar_axes(
-                ax, im, cbar_kw, location or "right", orientation, user_kwargs
+                ax, im, cbar_kw, inset_location, orientation, user_kwargs
             )
         else:
             cbar = self._outside_colorbar(

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -6472,6 +6472,19 @@ class TestColorbarPlacement:
         assert g.cbar.orientation == "horizontal", f"inside bottom should be horizontal, got {g.cbar.orientation}"
         plt.close("all")
 
+    def test_colorbar_true_resets_sticky_orientation(self):
+        """`colorbar=True` resets a previously sticky orientation to vertical (#235).
+
+        Test scenario:
+            After a horizontal spec on a reused glyph, a bare `colorbar=True`
+            draws the default vertical bar rather than inheriting horizontal.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", colorbar=ColorBar(orientation="horizontal"))
+        g.plot(cmap="viridis", colorbar=True)
+        assert g.cbar.orientation == "vertical", f"colorbar=True should reset to vertical, got {g.cbar.orientation}"
+        plt.close("all")
+
 
 class TestColorBar:
     """Tests for the `ColorBar` placement/box config object."""
@@ -6651,6 +6664,7 @@ class TestResolveColorbar:
             "cbar_box": None,
             "cbar_label_color": None,
             "cbar_tick_color": None,
+            "cbar_orientation": "vertical",
         }
         assert out == expected, f"True should reset to default placement, got {out}"
 
@@ -6803,6 +6817,19 @@ class TestDeprecatedCbarKwargs:
         assert g.cbar.orientation == "horizontal", f"deprecated kwarg should still work, got {g.cbar.orientation}"
         plt.close("all")
 
+    def test_invalid_loose_cbar_orientation_raises(self):
+        """A loose `cbar_orientation` typo raises a clear error at render (#235).
+
+        Test scenario:
+            The deprecated path is validated in `create_color_bar` too, so a bad
+            value surfaces as an actionable cleopatra error, not a matplotlib one.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 30.0, 20.0])
+        with pytest.warns(DeprecationWarning, match="cbar_orientation"):
+            with pytest.raises(ValueError, match="cbar_orientation must be 'vertical' or 'horizontal'"):
+                g.plot(cmap="viridis", cbar_orientation="horizontl")
+        plt.close("all")
+
 
 class TestStylePrecedence:
     """Explicit args override a `style=` preset (defaults < preset < explicit)."""
@@ -6841,6 +6868,21 @@ class TestStylePrecedence:
         g.plot(style="temperature_2m", vmin=-15, vmax=42,
                colorbar=ColorBar(location="right", inside=True))
         assert g.cbar is not None, "placement ColorBar should draw a real colorbar on a style"
+        plt.close("all")
+
+    def test_orientation_only_spec_draws_real_colorbar_on_style(self):
+        """An orientation-only `ColorBar` draws a real bar over a preset swatch (#235).
+
+        Test scenario:
+            Orientation is placement-like, so `colorbar=ColorBar(orientation=...)`
+            on a style forces a real (horizontal) colorbar instead of silently
+            keeping the swatch.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(style="temperature_2m", vmin=-15, vmax=42,
+               colorbar=ColorBar(orientation="horizontal"))
+        assert g.cbar is not None, "orientation-only ColorBar should draw a real colorbar on a style"
+        assert g.cbar.orientation == "horizontal", f"expected horizontal, got {g.cbar.orientation}"
         plt.close("all")
 
     def test_styled_colorbar_ticks_span_the_data_range(self):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -6596,6 +6596,27 @@ class TestColorBar:
             warnings.simplefilter("error", UserWarning)
             ColorBar(location="bottom", orientation="horizontal")
 
+    def test_orientation_invalid_raises(self):
+        """A non-{vertical,horizontal} `orientation` raises a clear ValueError (#235).
+
+        Test scenario:
+            cleopatra validates the value up front rather than letting a typo
+            surface as an opaque matplotlib error at render.
+        """
+        with pytest.raises(ValueError, match="orientation must be 'vertical' or 'horizontal'"):
+            ColorBar(orientation="horizontl")
+
+    def test_invalid_location_skips_conflict_warning(self):
+        """An invalid `location` does not raise the orientation-conflict warning (#235).
+
+        Test scenario:
+            Only a valid edge implies an orientation; a bad location is left for
+            the render to reject, so no misleading conflict warning fires first.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            ColorBar(location="middle", orientation="vertical")  # type: ignore[arg-type]
+
 
 class TestResolveColorbar:
     """Tests for the `_resolve_colorbar` front-door parser."""

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -6380,6 +6380,32 @@ class TestColorbarPlacement:
         assert top_y > bottom_y, f"label_location not applied: top_y={top_y}, bottom_y={bottom_y}"
         plt.close("all")
 
+    def test_orientation_via_spec_takes_effect(self):
+        """`ColorBar(orientation=...)` sets the drawn bar orientation (#235).
+
+        Test scenario:
+            With no `location`, a spec orientation reaches the rendered colorbar
+            instead of requiring the loose `cbar_orientation` kwarg.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", colorbar=ColorBar(orientation="horizontal"))
+        assert g.cbar.orientation == "horizontal", f"orientation not applied, got {g.cbar.orientation}"
+        plt.close("all")
+
+    def test_location_wins_over_conflicting_orientation(self):
+        """A set `location` fixes orientation; a conflicting `orientation` loses (#235).
+
+        Test scenario:
+            `ColorBar(location="bottom", orientation="vertical")` renders a
+            horizontal bar (location wins) after warning at construction.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        with pytest.warns(UserWarning, match="orientation"):
+            spec = ColorBar(location="bottom", orientation="vertical")
+        g.plot(cmap="viridis", colorbar=spec)
+        assert g.cbar.orientation == "horizontal", f"location should win, got {g.cbar.orientation}"
+        plt.close("all")
+
 
 class TestColorBar:
     """Tests for the `ColorBar` placement/box config object."""
@@ -6475,6 +6501,35 @@ class TestColorBar:
         assert spec.label_location == "center", f"label_location not stored: {spec.label_location}"
         assert spec.ticks_spacing == 5.0, f"ticks_spacing not stored: {spec.ticks_spacing}"
 
+    def test_orientation_defaults_none_and_stores(self):
+        """`orientation` defaults to `None` and stores verbatim (#235).
+
+        Test scenario:
+            The field is an optional holder, `None` when unset.
+        """
+        assert ColorBar().orientation is None, "orientation should default to None"
+        assert ColorBar(orientation="horizontal").orientation == "horizontal", "orientation not stored"
+
+    def test_orientation_conflicting_with_location_warns(self):
+        """A `location`/`orientation` disagreement warns at construction (#235).
+
+        Test scenario:
+            `location="bottom"` implies horizontal, so `orientation="vertical"`
+            is ignored -- with a UserWarning naming both -- rather than silently.
+        """
+        with pytest.warns(UserWarning, match=r"orientation='vertical'.*location='bottom'"):
+            ColorBar(location="bottom", orientation="vertical")
+
+    def test_orientation_agreeing_with_location_is_silent(self):
+        """An `orientation` matching the one `location` implies is warning-free (#235).
+
+        Test scenario:
+            `location="bottom"` + `orientation="horizontal"` agree, so no warning.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            ColorBar(location="bottom", orientation="horizontal")
+
 
 class TestResolveColorbar:
     """Tests for the `_resolve_colorbar` front-door parser."""
@@ -6561,8 +6616,20 @@ class TestResolveColorbar:
         """
         out = _resolve_colorbar(ColorBar(location="right"))
         for key in ("cbar_label", "cbar_length", "cbar_label_size",
-                    "cbar_label_rotation", "cbar_label_location", "ticks_spacing"):
+                    "cbar_label_rotation", "cbar_label_location", "cbar_orientation", "ticks_spacing"):
             assert key not in out, f"{key} should not be emitted when unset, got {out}"
+
+    def test_orientation_maps_only_when_set(self):
+        """`orientation` maps to `cbar_orientation` only when set (#235).
+
+        Test scenario:
+            A set orientation lands on `cbar_orientation`; an unset one is
+            omitted so a loose `cbar_orientation` is not clobbered.
+        """
+        out = _resolve_colorbar(ColorBar(orientation="horizontal"))
+        assert out["cbar_orientation"] == "horizontal", f"orientation not mapped: {out}"
+        unset = _resolve_colorbar(ColorBar(location="right"))
+        assert "cbar_orientation" not in unset, f"unset orientation should not be emitted: {unset}"
 
     @pytest.mark.parametrize("bad", ["right", 1, 1.5, ["right"], {"location": "right"}])
     def test_invalid_type_raises(self, bad):
@@ -6634,6 +6701,19 @@ class TestDeprecatedCbarKwargs:
         assert not any(
             "deprecated" in str(x.message) and "cbar" in str(x.message) for x in caught
         ), "typed ColorBar should not trigger the loose-kwarg deprecation"
+        plt.close("all")
+
+    def test_cbar_orientation_is_deprecated(self):
+        """A loose `cbar_orientation` warns, steering to `ColorBar(orientation=...)` (#235).
+
+        Test scenario:
+            The last colorbar kwarg folded into the spec now emits the
+            deprecation like the rest, while still taking effect.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 30.0, 20.0])
+        with pytest.warns(DeprecationWarning, match=r"cbar_orientation.*ColorBar\(orientation="):
+            g.plot(cmap="viridis", cbar_orientation="horizontal")
+        assert g.cbar.orientation == "horizontal", f"deprecated kwarg should still work, got {g.cbar.orientation}"
         plt.close("all")
 
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -6406,6 +6406,35 @@ class TestColorbarPlacement:
         assert g.cbar.orientation == "horizontal", f"location should win, got {g.cbar.orientation}"
         plt.close("all")
 
+    @pytest.mark.parametrize("orientation", ["vertical", "horizontal"])
+    def test_orientation_inside_does_not_crash(self, orientation):
+        """`ColorBar(orientation=..., inside=True)` renders without a crash (#235).
+
+        Args:
+            orientation: The spec orientation for an inset colorbar.
+
+        Test scenario:
+            With no `location`, an inset bar must derive its edge from the
+            orientation so a horizontal inset does not hit matplotlib's
+            tick-position mismatch (regression guard for the H1 crash).
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", colorbar=ColorBar(orientation=orientation, inside=True))
+        assert g.cbar.orientation == orientation, f"inset orientation not applied, got {g.cbar.orientation}"
+        plt.close("all")
+
+    def test_inside_location_bottom_is_horizontal(self):
+        """`ColorBar(inside=True, location="bottom")` renders a horizontal inset (#235).
+
+        Test scenario:
+            The explicit-location inset path stays consistent with the
+            orientation-derived one.
+        """
+        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
+        g.plot(cmap="viridis", colorbar=ColorBar(inside=True, location="bottom"))
+        assert g.cbar.orientation == "horizontal", f"inside bottom should be horizontal, got {g.cbar.orientation}"
+        plt.close("all")
+
 
 class TestColorBar:
     """Tests for the `ColorBar` placement/box config object."""

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2173,6 +2173,43 @@ class TestAnimateEdgeCases:
             f"spec ticks_spacing not honored in animate, got {glyph.default_options['ticks_spacing']}"
         )
 
+    def test_animate_orientation_via_spec(
+        self,
+        coello_data: np.ndarray,
+        animate_time_list: list,
+        no_data_value: float,
+    ):
+        """`animate(colorbar=ColorBar(orientation=...))` reaches the render (#235).
+
+        Test scenario:
+            The orientation field must apply on the animate path, not just plot.
+        """
+        glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
+        anim = glyph.animate(animate_time_list, colorbar=ColorBar(orientation="horizontal"))
+        assert anim is not None
+        assert glyph.cbar.orientation == "horizontal", (
+            f"orientation not honored in animate, got {glyph.cbar.orientation}"
+        )
+
+    def test_animate_cbar_orientation_is_deprecated(
+        self,
+        coello_data: np.ndarray,
+        animate_time_list: list,
+        no_data_value: float,
+    ):
+        """A loose `animate(cbar_orientation=...)` warns yet still applies (#235).
+
+        Test scenario:
+            The deprecation fires on the animate path too, steering to
+            `ColorBar(orientation=...)`, while the kwarg keeps working.
+        """
+        glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
+        with pytest.warns(DeprecationWarning, match="cbar_orientation"):
+            glyph.animate(animate_time_list, cbar_orientation="horizontal")
+        assert glyph.cbar.orientation == "horizontal", (
+            f"deprecated kwarg should still work in animate, got {glyph.cbar.orientation}"
+        )
+
     def test_data_getter_is_keyword_only(
         self,
         coello_data: np.ndarray,


### PR DESCRIPTION
# Description

Completes the `ColorBar` spec by giving it a typed `orientation` field, so the colorbar orientation can be requested
through `colorbar=ColorBar(...)` instead of the loose `cbar_orientation` kwarg — and resolves the silent-override
footgun that motivated issue #235.

- Adds `orientation: Literal["vertical", "horizontal"] | None` to `ColorBar`, mapped by `_resolve_colorbar` onto the
  internal `cbar_orientation` option **only when set** (so a loose `cbar_orientation` is not clobbered during the
  transition).
- Deprecates the loose `cbar_orientation` kwarg (added to `_DEPRECATED_CBAR_KWARGS`); it still works during the
  deprecation window but emits a `DeprecationWarning` steering callers to `ColorBar(orientation=...)`.
- Resolves the `location`/`orientation` conflict **inside the object**: because a set `location` already fixes the
  orientation (left/right → vertical, top/bottom → horizontal), an explicit `orientation` that disagrees now emits a
  `UserWarning` at construction naming both, instead of being dropped silently (`location` still wins at render).
- Validates `orientation` against `{"vertical", "horizontal"}` up front (and at render for the loose/low-level path),
  so a typo raises an actionable error rather than an opaque matplotlib one.
- Fixes a crash: an inset colorbar (`inside=True`) with `orientation="horizontal"` and no `location` used to inherit
  the vertical "right" inset geometry and hit `ValueError: 'left' is not a valid value for position`. The inset edge
  is now derived from the resolved orientation (bottom for horizontal, right for vertical).
- Makes `colorbar=True` reset a sticky `cbar_orientation` to the vertical default, and makes an orientation-only
  `ColorBar` draw a real colorbar over a `style` preset's swatch instead of being silently ignored.
- Migrates the `ColorBar`/`plot`/`animate` docstrings, both numpydoc blocks, a plot docstring example, and the
  `array_glyph_examples` notebook to the typed form.

This change is **non-breaking** and additive: the loose `cbar_orientation` kwarg keeps working (with a deprecation
warning) and the vertical default is unchanged.

Scope note: the typed `ColorBar` spec remains `ArrayGlyph`-only (extending it to the other glyph types is tracked
separately in #239). No new dependencies are required.

# Issues

- Closes #235 — `ColorBar` had no `orientation` field, so a loose `cbar_orientation` was silently overridden by
  `ColorBar(location=...)`

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Run from the repository root against the project environment:

```
PYTHONPATH=src python -m pytest -m "not live" -q
PYTHONPATH=src python -m pytest --doctest-modules src/cleopatra/array_glyph.py src/cleopatra/glyph.py -q
```

- [x] Full offline unit-test suite (`pytest -m "not live"`) — 1952 passed
- [x] Doctests for `array_glyph` and `glyph` — 43 passed

New tests cover: field storage/default; the `_resolve_colorbar` mapping (emitted only when set); the construction
`UserWarning` on a `location`/`orientation` conflict (and its absence when they agree or the location is invalid);
value validation (typed and loose paths); render-level effect on the **outside**, **inside** (both orientations,
regression guard for the crash), and **animate** paths; `location` precedence at render; the loose-kwarg
deprecation; `colorbar=True` resetting a sticky orientation; and an orientation-only spec forcing a real colorbar
over a `style` preset.

The branch also passed two full `/review` rounds (adversarial, isolated). The two review artifacts are kept locally.

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
