### PR TITLE
feat(array_glyph): colorbar=ColorBar on facet (#256); collapse redundant returns

### DIFF
--- a/src/cleopatra/config.py
+++ b/src/cleopatra/config.py
@@ -69,10 +69,7 @@ def is_notebook() -> bool:
     except ModuleNotFoundError:
         return False  # IPython is not installed.
 
+    # Only Jupyter / qtconsole report "ZMQInteractiveShell"; a terminal IPython
+    # ("TerminalInteractiveShell") or any other environment is not a notebook.
     shell = get_ipython().__class__.__name__
-    if shell == "ZMQInteractiveShell":
-        return True  # Jupyter notebook or qtconsole
-    elif shell == "TerminalInteractiveShell":
-        return False  # Terminal running IPython
-    else:
-        return False  # Other type (probably not an IPython environment)
+    return shell == "ZMQInteractiveShell"

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3756,7 +3756,9 @@ class ArrayGlyph(GeoMixin, Glyph):
             colorbar: The shared colour bar, mirroring `plot` / `animate`.
                 `None` (default) leaves the panels' colorbars untouched;
                 `False` suppresses them (`result.cbar` is then `None`);
-                `True` draws default ones; a `ColorBar` applies its
+                `True` draws default ones, resetting the resettable `cbar_*`
+                family to defaults so they do not inherit a prior sticky
+                spec; a `ColorBar` applies its
                 placement / caption / sizing to every panel (so the
                 `result.cbar` returned -- the first panel's -- carries the
                 spec). Prefer this typed form over the loose `cbar_*`
@@ -3831,9 +3833,9 @@ class ArrayGlyph(GeoMixin, Glyph):
 
                 ```
         """
-        _warn_deprecated_cbar_kwargs(kwargs)
         if col is None and row is None:
             raise ValueError("at least one of `col`/`row` must be given")
+        _warn_deprecated_cbar_kwargs(kwargs)
         if extents is not None:
             if self.extent is not None:
                 raise ValueError(

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3710,9 +3710,10 @@ class ArrayGlyph(GeoMixin, Glyph):
         or 4-D `(N, M, H, W)` when both `col` and `row` are set.
         All subplots share a common colour scale (`vmin`/`vmax`
         computed over the full stack unless the user passed explicit
-        limits); each panel draws its own colour bar on that shared
-        scale, and `result.cbar` exposes the first panel's. Pass
-        `colorbar=` to configure that bar or suppress it (see below).
+        limits); each panel draws its own colour legend on that shared
+        scale (a colour bar, or a preset style's swatch -- see `colorbar=`
+        below), and `result.cbar` exposes the first panel's bar when one
+        is drawn.
 
         Spatial extent: every panel is a slice of the *same* array, so by
         default they all share the parent glyph's `extent` (one spatial

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3936,10 +3936,6 @@ class ArrayGlyph(GeoMixin, Glyph):
         per_subplot_kwargs = dict(kwargs)
         per_subplot_kwargs["vmin"] = shared_vmin
         per_subplot_kwargs["vmax"] = shared_vmax
-        # Resolve the typed `colorbar=` onto the per-panel `cbar_*` options,
-        # after (so it wins over) any loose `cbar_*` in `kwargs` -- mirroring
-        # how `plot` layers `_resolve_colorbar` over the loose kwargs.
-        per_subplot_kwargs.update(_resolve_colorbar(colorbar))
 
         name_dicts: list[dict[str, Any]] = []
         cbar: Colorbar | None = None
@@ -3971,7 +3967,13 @@ class ArrayGlyph(GeoMixin, Glyph):
                 ax=ax,
                 **per_subplot_kwargs,
             )
-            sub.plot(kind=kind)
+            # Route `colorbar=` through `plot` (not the constructor) so the
+            # shared `_apply_kwargs_and_colorbar` logic runs per panel -- it
+            # merges the resolved spec *over* any loose `cbar_*` already folded
+            # into the sub-glyph's options and sets `_style_wants_colorbar`, so
+            # a placement-bearing colorbar overrides a preset swatch here just
+            # as it does on `plot` / `animate`.
+            sub.plot(kind=kind, colorbar=colorbar)
 
             col_label = col_coords[col_idx] if col_coords is not None else col_idx
             name_dict: dict[str, Any] = {col: col_label}

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3754,9 +3754,10 @@ class ArrayGlyph(GeoMixin, Glyph):
                 reuses the parent's `extent` on every panel (or index
                 space when the parent has none).
             colorbar: The shared colour bar, mirroring `plot` / `animate`.
-                `None` (default) keeps each panel's default colour bar (the
-                prior behaviour); `False` suppresses them (`result.cbar` is
-                then `None`);
+                `None` (default) keeps each panel's default colour legend --
+                a colour bar, or a preset style's swatch -- (the prior
+                behaviour); `False` suppresses them (`result.cbar` is then
+                `None`);
                 `True` draws default ones, resetting the resettable `cbar_*`
                 family to defaults so they do not inherit a prior sticky
                 spec; a `ColorBar` applies its
@@ -3836,7 +3837,6 @@ class ArrayGlyph(GeoMixin, Glyph):
         """
         if col is None and row is None:
             raise ValueError("at least one of `col`/`row` must be given")
-        _warn_deprecated_cbar_kwargs(kwargs)
         if extents is not None:
             if self.extent is not None:
                 raise ValueError(
@@ -3909,6 +3909,10 @@ class ArrayGlyph(GeoMixin, Glyph):
             )
 
         assert col is not None
+
+        # Warn only after the structural validation above, so a malformed call
+        # raises its `ValueError` without a spurious colorbar DeprecationWarning.
+        _warn_deprecated_cbar_kwargs(kwargs)
 
         if figsize is None:
             figsize = (4.0 * ncols, 3.5 * nrows)

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3754,8 +3754,9 @@ class ArrayGlyph(GeoMixin, Glyph):
                 reuses the parent's `extent` on every panel (or index
                 space when the parent has none).
             colorbar: The shared colour bar, mirroring `plot` / `animate`.
-                `None` (default) leaves the panels' colorbars untouched;
-                `False` suppresses them (`result.cbar` is then `None`);
+                `None` (default) keeps each panel's default colour bar (the
+                prior behaviour); `False` suppresses them (`result.cbar` is
+                then `None`);
                 `True` draws default ones, resetting the resettable `cbar_*`
                 family to defaults so they do not inherit a prior sticky
                 spec; a `ColorBar` applies its

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3700,6 +3700,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         kind: str = "auto",
         figsize: tuple[float, float] | None = None,
         extents: Sequence[Sequence[float]] | None = None,
+        colorbar: bool | ColorBar | None = None,
         **kwargs,
     ) -> FacetGrid:
         """Render a grid of subplots from a 3-D or 4-D stack.
@@ -3751,11 +3752,21 @@ class ArrayGlyph(GeoMixin, Glyph):
                 glyph's `extent` and with `coords`. `None` (default)
                 reuses the parent's `extent` on every panel (or index
                 space when the parent has none).
+            colorbar: The shared colour bar, mirroring `plot` / `animate`.
+                `None` (default) leaves the panels' colorbars untouched;
+                `False` suppresses them (`result.cbar` is then `None`);
+                `True` draws default ones; a `ColorBar` applies its
+                placement / caption / sizing to every panel (so the
+                `result.cbar` returned -- the first panel's -- carries the
+                spec). Prefer this typed form over the loose `cbar_*`
+                kwargs, which are deprecated here as they are on
+                `plot` / `animate`.
 
             **kwargs: Forwarded to each subplot. Recognised keys
                 include the same colour / colorbar / level kwargs as
                 `plot`. `vmin` / `vmax` win over the
-                stack-wide auto-computed limits.
+                stack-wide auto-computed limits. Passing the loose
+                `cbar_*` colorbar kwargs is deprecated -- use `colorbar`.
 
         Returns:
             FacetGrid: Result object exposing `fig`, `axes`,
@@ -3807,7 +3818,19 @@ class ArrayGlyph(GeoMixin, Glyph):
                 [(0, 10, 0, 10), (10, 20, 0, 10)]
 
                 ```
+            - Configure the shared colour bar with a typed `ColorBar`:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph
+                >>> from cleopatra.styling.colorbar import ColorBar
+                >>> stack = np.arange(3 * 5 * 5, dtype=float).reshape(3, 5, 5)
+                >>> g = ArrayGlyph(stack).facet(col="t", colorbar=ColorBar(label="mm"))
+                >>> g.cbar.ax.get_ylabel()
+                'mm'
+
+                ```
         """
+        _warn_deprecated_cbar_kwargs(kwargs)
         if col is None and row is None:
             raise ValueError("at least one of `col`/`row` must be given")
         if extents is not None:
@@ -3912,6 +3935,10 @@ class ArrayGlyph(GeoMixin, Glyph):
         per_subplot_kwargs = dict(kwargs)
         per_subplot_kwargs["vmin"] = shared_vmin
         per_subplot_kwargs["vmax"] = shared_vmax
+        # Resolve the typed `colorbar=` onto the per-panel `cbar_*` options,
+        # after (so it wins over) any loose `cbar_*` in `kwargs` -- mirroring
+        # how `plot` layers `_resolve_colorbar` over the loose kwargs.
+        per_subplot_kwargs.update(_resolve_colorbar(colorbar))
 
         name_dicts: list[dict[str, Any]] = []
         cbar: Colorbar | None = None

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3710,8 +3710,9 @@ class ArrayGlyph(GeoMixin, Glyph):
         or 4-D `(N, M, H, W)` when both `col` and `row` are set.
         All subplots share a common colour scale (`vmin`/`vmax`
         computed over the full stack unless the user passed explicit
-        limits) and a single shared colorbar attached to the first
-        rendered subplot.
+        limits); each panel draws its own colour bar on that shared
+        scale, and `result.cbar` exposes the first panel's. Pass
+        `colorbar=` to configure that bar or suppress it (see below).
 
         Spatial extent: every panel is a slice of the *same* array, so by
         default they all share the parent glyph's `extent` (one spatial

--- a/src/cleopatra/styling/colors.py
+++ b/src/cleopatra/styling/colors.py
@@ -1801,10 +1801,7 @@ class Colors:
 
         ```
         """
-        if not isinstance(hex_color, str):
-            return False
-        else:
-            return True if mcolors.is_color_like(hex_color) else False
+        return isinstance(hex_color, str) and mcolors.is_color_like(hex_color)
 
     def is_valid_rgb(self) -> list[bool]:
         """Check if each color value is a valid RGB color.
@@ -1897,10 +1894,12 @@ class Colors:
 
         ```
         """
-        if isinstance(rgb_tuple, tuple) and len(rgb_tuple) == 3:
-            if all(isinstance(value, int) for value in rgb_tuple):
-                return all(0 <= value <= 255 for value in rgb_tuple)
-        return False
+        return (
+            isinstance(rgb_tuple, tuple)
+            and len(rgb_tuple) == 3
+            and all(isinstance(value, int) for value in rgb_tuple)
+            and all(0 <= value <= 255 for value in rgb_tuple)
+        )
 
     @staticmethod
     def _is_valid_rgb_norm(rgb_tuple: Any) -> bool:
@@ -1942,10 +1941,12 @@ class Colors:
 
         ```
         """
-        if isinstance(rgb_tuple, tuple) and len(rgb_tuple) == 3:
-            if all(isinstance(value, float) for value in rgb_tuple):
-                return all(0.0 <= value <= 1.0 for value in rgb_tuple)
-        return False
+        return (
+            isinstance(rgb_tuple, tuple)
+            and len(rgb_tuple) == 3
+            and all(isinstance(value, float) for value in rgb_tuple)
+            and all(0.0 <= value <= 1.0 for value in rgb_tuple)
+        )
 
     def to_rgb(
         self, normalized: bool = True

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3195,10 +3195,9 @@ class TestFacetColorbar:
             `_resolve_colorbar` rejects unsupported types; `facet` surfaces that
             `TypeError` rather than silently ignoring the argument.
         """
+        glyph = ArrayGlyph(self._stack_3d())
         with pytest.raises(TypeError, match="colorbar must be a bool"):
-            ArrayGlyph(self._stack_3d()).facet(
-                col="time", col_coords=[0, 1, 2], colorbar=object()
-            )
+            glyph.facet(col="time", col_coords=[0, 1, 2], colorbar=object())
 
     def test_facet_4d_accepts_colorbar_spec(self):
         """The `ColorBar` spec also works on a 4-D (`col` + `row`) facet.

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3252,6 +3252,60 @@ class TestFacetColorbar:
             warnings.simplefilter("error", DeprecationWarning)
             ArrayGlyph(self._stack_3d()).facet(col="time", col_coords=[0, 1, 2])
 
+    def test_facet_placement_colorbar_overrides_preset_swatch(self):
+        """A placement-bearing `colorbar=` overrides a preset swatch on the facet path.
+
+        Test scenario:
+            This pins the exact regression that routing `colorbar=` through
+            `sub.plot` restored: a continuous preset (`flow_accumulation`)
+            normally draws an inset swatch legend, but a placement-bearing
+            `ColorBar(location=...)` sets `_style_wants_colorbar`, so each panel
+            draws a real colorbar instead. A revert to the constructor-baked
+            routing would leave the swatch and no colorbars, failing here.
+        """
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time", col_coords=[0, 1, 2], style="flow_accumulation",
+            colorbar=ColorBar(location="right"),
+        )
+        assert (
+            len(self._colorbar_axes(result)) == 3
+        ), "a placement colorbar should draw a real colorbar per panel"
+        swatches = sum(len(ax.child_axes) for ax in result.axes.ravel())
+        assert swatches == 0, f"the preset swatch should be overridden, got {swatches} swatch axes"
+
+    def test_facet_swatch_preset_without_colorbar_keeps_swatch(self):
+        """Without a placement `colorbar=`, the preset keeps its swatch (control).
+
+        Test scenario:
+            The companion to the override test: the same continuous preset with
+            no `colorbar=` draws its inset swatch on every panel and no real
+            colorbar axis, so the override test above is meaningfully guarded.
+        """
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time", col_coords=[0, 1, 2], style="flow_accumulation"
+        )
+        assert self._colorbar_axes(result) == [], "preset alone should draw no real colorbar"
+        swatches = sum(len(ax.child_axes) for ax in result.axes.ravel())
+        assert swatches == 3, f"each panel should keep its preset swatch, got {swatches}"
+
+    def test_facet_loose_cbar_warns_exactly_once(self):
+        """A loose `cbar_*` on `facet` deprecates exactly once, not once per panel.
+
+        Test scenario:
+            The single warning comes from `facet` itself; the per-panel sub-glyph
+            constructors fold the loose kwarg silently. This locks the invariant
+            that re-routing loose kwargs through `sub.plot` (which would warn per
+            panel) is not silently introduced.
+        """
+        with pytest.warns(DeprecationWarning) as record:
+            ArrayGlyph(self._stack_3d()).facet(
+                col="time", col_coords=[0, 1, 2], cbar_label="mm"
+            )
+        cbar_warnings = [w for w in record if "cbar_label" in str(w.message)]
+        assert (
+            len(cbar_warnings) == 1
+        ), f"expected exactly one cbar_label deprecation, got {len(cbar_warnings)}"
+
 
 @pytest.mark.plot
 class TestFacetExtents:

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2990,6 +2990,41 @@ class TestAnimateCbarAttribute:
 
 
 @pytest.mark.plot
+class TestFacetColorbar:
+    """`ArrayGlyph.facet(colorbar=...)` typed spec + loose-`cbar_*` deprecation (#256)."""
+
+    @staticmethod
+    def _stack_3d(n: int = 3, h: int = 6, w: int = 6) -> np.ndarray:
+        """Build a 3-D `(n, h, w)` stack for faceting."""
+        return np.random.default_rng(0).random((n, h, w)).astype("float32")
+
+    def test_facet_accepts_colorbar_spec(self):
+        """`facet(colorbar=ColorBar(...))` is accepted and configures the shared bar."""
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time", col_coords=[0, 1, 2], colorbar=ColorBar(label="mm")
+        )
+        assert isinstance(result, FacetGrid)
+        assert result.cbar is not None
+        assert result.cbar.ax.get_ylabel() == "mm"
+
+    def test_facet_colorbar_false_suppresses(self):
+        """`facet(colorbar=False)` draws no colorbar and leaves `result.cbar` None."""
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time", col_coords=[0, 1, 2], colorbar=False
+        )
+        colorbar_axes = [ax for ax in result.fig.axes if ax.get_label() == "<colorbar>"]
+        assert colorbar_axes == []
+        assert result.cbar is None
+
+    def test_facet_loose_cbar_kwargs_deprecated(self):
+        """Loose `cbar_*` on `facet` emit a `DeprecationWarning`, as on `plot`/`animate`."""
+        with pytest.warns(DeprecationWarning, match="cbar_label"):
+            ArrayGlyph(self._stack_3d()).facet(
+                col="time", col_coords=[0, 1, 2], cbar_label="mm"
+            )
+
+
+@pytest.mark.plot
 class TestFacetExtents:
     """Per-panel `extents=` on :py`ArrayGlyph.facet` (M4)."""
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3099,6 +3099,27 @@ class TestFacetColorbar:
             result.cbar.ax.get_ylabel() == ""
         ), f"colorbar=True should reset the loose label, got {result.cbar.ax.get_ylabel()!r}"
 
+    def test_facet_colorbar_none_honors_loose_cbar_label(self):
+        """The default `colorbar=None` leaves a loose `cbar_label` in force per panel.
+
+        Test scenario:
+            Complements the `True`-resets and typed-wins tests: with `None`
+            (which resolves to an empty update), a loose `cbar_label="loose"`
+            folded in by the constructor survives on every panel's bar -- the
+            prior behaviour the docstring promises. The loose kwarg still
+            deprecates.
+        """
+        with pytest.warns(DeprecationWarning, match="cbar_label"):
+            result = ArrayGlyph(self._stack_3d()).facet(
+                col="time", col_coords=[0, 1, 2], colorbar=None, cbar_label="loose"
+            )
+        labels = [ax.get_ylabel() for ax in self._colorbar_axes(result)]
+        assert labels == [
+            "loose",
+            "loose",
+            "loose",
+        ], f"colorbar=None should keep the loose label on every panel, got {labels}"
+
     def test_facet_colorbar_spec_shares_stack_vmin_vmax(self):
         """A `colorbar=` spec does not disturb the shared stack-wide `vmin`/`vmax`.
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2991,37 +2991,221 @@ class TestAnimateCbarAttribute:
 
 @pytest.mark.plot
 class TestFacetColorbar:
-    """`ArrayGlyph.facet(colorbar=...)` typed spec + loose-`cbar_*` deprecation (#256)."""
+    """`ArrayGlyph.facet(colorbar=...)` typed spec + loose-`cbar_*` deprecation (#256).
+
+    Pins the two behaviours from the issue's definition of done -- `facet`
+    accepts the same `colorbar: bool | ColorBar | None` spec as `plot` /
+    `animate` (no `ValueError`), and the loose `cbar_*` kwargs deprecate on the
+    faceted path -- plus the surrounding branches of `_resolve_colorbar`
+    (`None` / `True` / `False` / `ColorBar` / invalid) as routed through
+    `facet`.
+    """
 
     @staticmethod
     def _stack_3d(n: int = 3, h: int = 6, w: int = 6) -> np.ndarray:
-        """Build a 3-D `(n, h, w)` stack for faceting."""
+        """Build a deterministic 3-D `(n, h, w)` stack for faceting.
+
+        Returns:
+            np.ndarray: A `float32` stack seeded for reproducibility.
+        """
         return np.random.default_rng(0).random((n, h, w)).astype("float32")
 
+    @staticmethod
+    def _stack_4d(n_col: int = 2, n_row: int = 2, h: int = 6, w: int = 6) -> np.ndarray:
+        """Build a deterministic 4-D `(n_col, n_row, h, w)` stack for faceting.
+
+        Returns:
+            np.ndarray: A `float32` stack seeded for reproducibility.
+        """
+        return np.random.default_rng(1).random((n_col, n_row, h, w)).astype("float32")
+
+    @staticmethod
+    def _colorbar_axes(result: FacetGrid) -> list:
+        """Return the colorbar axes drawn on a `FacetGrid`'s figure.
+
+        Args:
+            result: The `FacetGrid` returned by `facet`.
+
+        Returns:
+            list: The axes whose matplotlib label marks them as colorbars.
+        """
+        return [ax for ax in result.fig.axes if ax.get_label() == "<colorbar>"]
+
+    @pytest.fixture(autouse=True)
+    def _close_figures(self):
+        """Close every figure after each test so leaks never warn or accumulate."""
+        yield
+        plt.close("all")
+
     def test_facet_accepts_colorbar_spec(self):
-        """`facet(colorbar=ColorBar(...))` is accepted and configures the shared bar."""
+        """`facet(colorbar=ColorBar(...))` is accepted and configures the shared bar.
+
+        Test scenario:
+            The typed spec that `plot` / `animate` already accept must not raise
+            on `facet`; the returned shared `cbar` (the first panel's) carries
+            the `ColorBar` label.
+        """
         result = ArrayGlyph(self._stack_3d()).facet(
             col="time", col_coords=[0, 1, 2], colorbar=ColorBar(label="mm")
         )
-        assert isinstance(result, FacetGrid)
-        assert result.cbar is not None
-        assert result.cbar.ax.get_ylabel() == "mm"
+        assert isinstance(result, FacetGrid), f"expected FacetGrid, got {type(result)}"
+        assert result.cbar is not None, "shared cbar should be present for a ColorBar spec"
+        assert (
+            result.cbar.ax.get_ylabel() == "mm"
+        ), f"shared cbar label should be 'mm', got {result.cbar.ax.get_ylabel()!r}"
+
+    def test_facet_colorbar_spec_applies_to_every_panel(self):
+        """A `ColorBar` spec labels the colorbar on *every* panel, not just the first.
+
+        Test scenario:
+            `facet` merges the resolved spec into each panel's options, so all
+            three panels' colorbars carry the label.
+        """
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time", col_coords=[0, 1, 2], colorbar=ColorBar(label="mm")
+        )
+        labels = [ax.get_ylabel() for ax in self._colorbar_axes(result)]
+        assert labels == ["mm", "mm", "mm"], f"every panel cbar should read 'mm', got {labels}"
+
+    def test_facet_colorbar_true_draws_default_bars(self):
+        """`facet(colorbar=True)` draws a colorbar per panel and returns a shared `cbar`.
+
+        Test scenario:
+            `True` requests default colorbars; the faceted figure gains one
+            colorbar axis per panel and `result.cbar` is not `None`.
+        """
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time", col_coords=[0, 1, 2], colorbar=True
+        )
+        assert result.cbar is not None, "colorbar=True should draw a shared cbar"
+        assert (
+            len(self._colorbar_axes(result)) == 3
+        ), f"expected 3 colorbar axes, got {len(self._colorbar_axes(result))}"
 
     def test_facet_colorbar_false_suppresses(self):
-        """`facet(colorbar=False)` draws no colorbar and leaves `result.cbar` None."""
+        """`facet(colorbar=False)` draws no colorbar and leaves `result.cbar` None.
+
+        Test scenario:
+            `False` maps to `add_colorbar=False` on every panel, so no colorbar
+            axes are created and the shared `cbar` is `None`.
+        """
         result = ArrayGlyph(self._stack_3d()).facet(
             col="time", col_coords=[0, 1, 2], colorbar=False
         )
-        colorbar_axes = [ax for ax in result.fig.axes if ax.get_label() == "<colorbar>"]
-        assert colorbar_axes == []
-        assert result.cbar is None
+        assert self._colorbar_axes(result) == [], "colorbar=False should draw no colorbars"
+        assert result.cbar is None, "result.cbar should be None when colorbar=False"
 
-    def test_facet_loose_cbar_kwargs_deprecated(self):
-        """Loose `cbar_*` on `facet` emit a `DeprecationWarning`, as on `plot`/`animate`."""
+    def test_facet_colorbar_none_preserves_default_behaviour(self):
+        """`facet()` with no `colorbar` keeps the prior per-panel colorbars.
+
+        Test scenario:
+            The default `colorbar=None` resolves to an empty update, so behaviour
+            is unchanged: one colorbar per panel and a non-None shared `cbar`.
+        """
+        result = ArrayGlyph(self._stack_3d()).facet(col="time", col_coords=[0, 1, 2])
+        assert (
+            len(self._colorbar_axes(result)) == 3
+        ), "default facet should keep one colorbar per panel"
+        assert result.cbar is not None, "default facet should still expose a shared cbar"
+
+    def test_facet_colorbar_orientation_applied(self):
+        """A horizontal `ColorBar` orientation reaches the drawn colorbar.
+
+        Test scenario:
+            `ColorBar(orientation="horizontal")` routes through `_resolve_colorbar`
+            into the panels, so the shared colorbar renders horizontally.
+        """
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time",
+            col_coords=[0, 1, 2],
+            colorbar=ColorBar(label="mm", orientation="horizontal"),
+        )
+        assert (
+            result.cbar.orientation == "horizontal"
+        ), f"expected horizontal cbar, got {result.cbar.orientation!r}"
+
+    def test_facet_colorbar_spec_wins_over_loose_kwargs(self):
+        """A `ColorBar` spec overrides a conflicting loose `cbar_*`, mirroring `plot`.
+
+        Test scenario:
+            When both `colorbar=ColorBar(label="typed")` and `cbar_label="loose"`
+            are given, the typed spec is applied last and wins; the loose form
+            still emits its deprecation warning.
+        """
         with pytest.warns(DeprecationWarning, match="cbar_label"):
-            ArrayGlyph(self._stack_3d()).facet(
-                col="time", col_coords=[0, 1, 2], cbar_label="mm"
+            result = ArrayGlyph(self._stack_3d()).facet(
+                col="time",
+                col_coords=[0, 1, 2],
+                colorbar=ColorBar(label="typed"),
+                cbar_label="loose",
             )
+        assert (
+            result.cbar.ax.get_ylabel() == "typed"
+        ), f"typed ColorBar should win, got {result.cbar.ax.get_ylabel()!r}"
+
+    def test_facet_invalid_colorbar_type_raises(self):
+        """A non-bool / non-`ColorBar` / non-`None` `colorbar` raises `TypeError`.
+
+        Test scenario:
+            `_resolve_colorbar` rejects unsupported types; `facet` surfaces that
+            `TypeError` rather than silently ignoring the argument.
+        """
+        with pytest.raises(TypeError, match="colorbar must be a bool"):
+            ArrayGlyph(self._stack_3d()).facet(
+                col="time", col_coords=[0, 1, 2], colorbar=object()
+            )
+
+    def test_facet_4d_accepts_colorbar_spec(self):
+        """The `ColorBar` spec also works on a 4-D (`col` + `row`) facet.
+
+        Test scenario:
+            The colorbar path is independent of facet dimensionality, so a
+            `row`+`col` grid still honours the typed spec on its shared `cbar`.
+        """
+        result = ArrayGlyph(self._stack_4d()).facet(
+            col="t", row="level", colorbar=ColorBar(label="mm")
+        )
+        assert result.axes.shape == (2, 2), f"expected a 2x2 grid, got {result.axes.shape}"
+        assert (
+            result.cbar.ax.get_ylabel() == "mm"
+        ), f"4-D facet shared cbar should read 'mm', got {result.cbar.ax.get_ylabel()!r}"
+
+    @pytest.mark.parametrize(
+        "kwarg, value",
+        [
+            ("cbar_label", "mm"),
+            ("cbar_length", 0.5),
+            ("cbar_orientation", "horizontal"),
+            ("ticks_spacing", 5),
+        ],
+    )
+    def test_facet_loose_cbar_kwargs_deprecated(self, kwarg, value):
+        """Each loose `cbar_*` on `facet` emits a `DeprecationWarning`.
+
+        Args:
+            kwarg: The deprecated loose colorbar keyword under test.
+            value: A value to pass for that keyword.
+
+        Test scenario:
+            `facet` now calls `_warn_deprecated_cbar_kwargs`, so every loose
+            colorbar keyword deprecates on the faceted path exactly as on
+            `plot` / `animate`.
+        """
+        with pytest.warns(DeprecationWarning, match=kwarg):
+            ArrayGlyph(self._stack_3d()).facet(
+                col="time", col_coords=[0, 1, 2], **{kwarg: value}
+            )
+
+    def test_facet_without_colorbar_kwargs_does_not_warn(self):
+        """A plain `facet()` call emits no colorbar `DeprecationWarning`.
+
+        Test scenario:
+            The deprecation fires only for the loose keys, so an ordinary facet
+            (no `cbar_*`, no `colorbar`) stays quiet.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            ArrayGlyph(self._stack_3d()).facet(col="time", col_coords=[0, 1, 2])
 
 
 @pytest.mark.plot

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3082,6 +3082,43 @@ class TestFacetColorbar:
             len(self._colorbar_axes(result)) == 3
         ), f"expected 3 colorbar axes, got {len(self._colorbar_axes(result))}"
 
+    def test_facet_colorbar_true_resets_loose_cbar_kwargs(self):
+        """`colorbar=True` resets a conflicting loose `cbar_*` to its default.
+
+        Test scenario:
+            Unlike the `None` default (which leaves loose kwargs in place),
+            `True` resets the resettable `cbar_*` family, so a loose
+            `cbar_label="loose"` does not survive -- the drawn bar has the
+            default (empty) label. The loose kwarg still deprecates.
+        """
+        with pytest.warns(DeprecationWarning, match="cbar_label"):
+            result = ArrayGlyph(self._stack_3d()).facet(
+                col="time", col_coords=[0, 1, 2], colorbar=True, cbar_label="loose"
+            )
+        assert (
+            result.cbar.ax.get_ylabel() == ""
+        ), f"colorbar=True should reset the loose label, got {result.cbar.ax.get_ylabel()!r}"
+
+    def test_facet_colorbar_spec_shares_stack_vmin_vmax(self):
+        """A `colorbar=` spec does not disturb the shared stack-wide `vmin`/`vmax`.
+
+        Test scenario:
+            The colour limits stay auto-computed over the whole stack even when
+            a `ColorBar` spec is supplied, so the shared bar spans the stack's
+            finite range.
+        """
+        stack = self._stack_3d()
+        result = ArrayGlyph(stack).facet(
+            col="time", col_coords=[0, 1, 2], colorbar=ColorBar(label="mm")
+        )
+        vmin, vmax = result.cbar.mappable.get_clim()
+        assert vmin == pytest.approx(
+            float(stack.min())
+        ), f"cbar vmin should match stack min, got {vmin}"
+        assert vmax == pytest.approx(
+            float(stack.max())
+        ), f"cbar vmax should match stack max, got {vmax}"
+
     def test_facet_colorbar_false_suppresses(self):
         """`facet(colorbar=False)` draws no colorbar and leaves `result.cbar` None.
 
@@ -3109,11 +3146,13 @@ class TestFacetColorbar:
         assert result.cbar is not None, "default facet should still expose a shared cbar"
 
     def test_facet_colorbar_orientation_applied(self):
-        """A horizontal `ColorBar` orientation reaches the drawn colorbar.
+        """A horizontal `ColorBar` orientation reaches every panel's colorbar.
 
         Test scenario:
             `ColorBar(orientation="horizontal")` routes through `_resolve_colorbar`
-            into the panels, so the shared colorbar renders horizontally.
+            into every panel, so the shared colorbar renders horizontally and,
+            since a horizontal bar carries its label on the x-axis, each panel's
+            colorbar shows the label there.
         """
         result = ArrayGlyph(self._stack_3d()).facet(
             col="time",
@@ -3123,6 +3162,12 @@ class TestFacetColorbar:
         assert (
             result.cbar.orientation == "horizontal"
         ), f"expected horizontal cbar, got {result.cbar.orientation!r}"
+        xlabels = [ax.get_xlabel() for ax in self._colorbar_axes(result)]
+        assert xlabels == [
+            "mm",
+            "mm",
+            "mm",
+        ], f"every panel's horizontal cbar should label the x-axis 'mm', got {xlabels}"
 
     def test_facet_colorbar_spec_wins_over_loose_kwargs(self):
         """A `ColorBar` spec overrides a conflicting loose `cbar_*`, mirroring `plot`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import matplotlib
 import matplotlib.pyplot as plt
+import pytest
 
 from cleopatra.config import Config, is_notebook
 
@@ -18,4 +19,26 @@ class TestSetMatplotlibBackend:
 
 
 def test_is_notebook():
+    assert not is_notebook()
+
+
+def test_is_notebook_true_in_zmq_shell(monkeypatch):
+    """A ZMQInteractiveShell (Jupyter / qtconsole) is detected as a notebook."""
+    ipython = pytest.importorskip("IPython")
+
+    class ZMQInteractiveShell:
+        pass
+
+    monkeypatch.setattr(ipython, "get_ipython", lambda: ZMQInteractiveShell())
+    assert is_notebook()
+
+
+def test_is_notebook_false_in_terminal_shell(monkeypatch):
+    """A TerminalInteractiveShell (plain IPython REPL) is not a notebook."""
+    ipython = pytest.importorskip("IPython")
+
+    class TerminalInteractiveShell:
+        pass
+
+    monkeypatch.setattr(ipython, "get_ipython", lambda: TerminalInteractiveShell())
     assert not is_notebook()


### PR DESCRIPTION
# Description

Two independent, low-risk changes:

**1. Collapse redundant multiple `return` statements (readability refactor).**
A package-wide audit found that the overwhelming majority of multi-`return` functions are idiomatic guard
clauses / early returns and were left untouched. Only four boolean helpers had genuinely redundant multiple
returns that collapse to a single, clearer expression, with behaviour preserved exactly:

- `config.is_notebook` — `if/elif/else` returning `True`/`False` → `return shell == "ZMQInteractiveShell"`.
- `Colors._is_valid_hex_i` — type guard + `True if … else False` → one `isinstance(…) and is_color_like(…)`.
- `Colors._is_valid_rgb_255` / `Colors._is_valid_rgb_norm` — nested type/range `if`s → a single `and`-chain.

**2. Accept `colorbar=ColorBar(...)` on `ArrayGlyph.facet` (feature / bug fix, issue #256).**
`ArrayGlyph.plot` / `.animate` already accept the typed `colorbar=ColorBar(...)` spec and deprecate the loose
`cbar_*` kwargs, but `facet` had no `colorbar=` parameter — the typed spec fell into `**kwargs` and was rejected
with a `ValueError`, leaving the deprecated loose kwargs as the only way to style a faceted colour bar (and
`facet` never warned about them).

`facet` now takes `colorbar: bool | ColorBar | None = None`, routed per panel through `sub.plot(colorbar=…)` so
the shared `_apply_kwargs_and_colorbar` logic runs (merges the resolved spec over any loose `cbar_*`, sets
`_style_wants_colorbar` so a placement-bearing colour bar overrides a preset swatch — consistent with `plot`),
and it calls `_warn_deprecated_cbar_kwargs` so the loose forms deprecate on the faceted path too. `colorbar=None`
(default) preserves the prior per-panel behaviour.

# Issues

- Closes #256 — `ArrayGlyph.facet` accepts `colorbar=ColorBar` and warns on loose `cbar_*`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

- Added `tests/test_array_glyph.py::TestFacetColorbar` (19 tests) covering `colorbar` = `None`/`True`/`False`/
  `ColorBar`/invalid, per-panel application, per-panel orientation, `True`-resets-loose, typed-wins-over-loose
  precedence, shared `vmin`/`vmax`, 4-D facets, the placement-colorbar-overrides-preset-swatch regression (plus a
  control), a parametrised loose-`cbar_*` deprecation matrix, and an exactly-once deprecation assertion.
- The four collapsed helpers are guarded by the existing config/colors suites (245 tests) and module doctests.
- Full suite (`pytest`, `MPLBACKEND=Agg`): **2176 passed**. Module doctests: green.

- [x] Test A — `TestFacetColorbar` (facet colorbar spec + loose-`cbar_*` deprecation)
- [x] Test B — full non-plot/plot suite + doctests green

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
