### PR TITLE
feat(config): surface the basemap cache dir via Config.get_cache_dir

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,8 +1,11 @@
 # Config Module
 
-The `cleopatra.config` module provides a small, **opt-in** helper for selecting the
-matplotlib backend. Importing `cleopatra` does *not* change the backend on its own —
-picking a backend is the application's job, not a library's.
+The `cleopatra.config` module gathers cleopatra's cross-cutting, user-facing settings in
+one discoverable place: an **opt-in** matplotlib-backend helper and the on-disk **cache
+directory** used for downloaded basemap assets. Importing `cleopatra` does *not* change
+the backend on its own — picking a backend is the application's job, not a library's.
+
+## Matplotlib backend
 
 Call `Config.set_matplotlib_backend()` yourself if you want cleopatra to choose a sensible
 one for you: `%matplotlib inline` inside a Jupyter notebook (or `%matplotlib notebook`
@@ -16,6 +19,25 @@ from cleopatra.config import Config
 
 Config.set_matplotlib_backend("Agg")          # explicit
 Config.set_matplotlib_backend()               # auto: inline in notebooks, Agg otherwise
+```
+
+## Cache directory
+
+`Config.get_cache_dir()` resolves where cleopatra caches the basemap assets it downloads —
+the Natural Earth vectors and hypsometric relief used by
+[`cleopatra.basemap.reference`](reference-data.md). It is the discoverable home for that
+setting, resolved in this order: an explicit `path` argument, then the
+`CLEOPATRA_CACHE_DIR` environment variable, then the default `~/.cleopatra/naturalearth`.
+A leading `~` is expanded. The getter only **resolves** the path — it does not create the
+directory (the download helpers create it on first use), so it is safe to call just to
+discover where the cache lives.
+
+```python
+from cleopatra.config import Config
+
+Config.get_cache_dir()                         # ~/.cleopatra/naturalearth (default)
+# or set CLEOPATRA_CACHE_DIR=/data/cleopatra to override, or:
+Config.get_cache_dir("/data/cleopatra")        # explicit override
 ```
 
 ## Module Documentation

--- a/docs/reference/reference-data.md
+++ b/docs/reference/reference-data.md
@@ -117,7 +117,8 @@ To discover the valid arguments, call `available_layers()` and
     [`basemap-data-v1`](https://github.com/serapeum-org/cleopatra/releases/tag/basemap-data-v1)
     release and caches it under `~/.cleopatra/naturalearth`; subsequent calls
     work offline. Override the location with the `CLEOPATRA_CACHE_DIR`
-    environment variable. Downloads are restricted to `http(s)` URLs.
+    environment variable, or discover/resolve it programmatically with
+    [`Config.get_cache_dir()`](config.md). Downloads are restricted to `http(s)` URLs.
 
 ## Migrating from `pyramids.basemap`
 

--- a/src/cleopatra/basemap/reference.py
+++ b/src/cleopatra/basemap/reference.py
@@ -26,8 +26,9 @@ and never touch GDAL/geopandas:
     (also in the `[tiles]` extra).
 
 The cache directory defaults to `~/.cleopatra/naturalearth` and can be
-overridden with the `CLEOPATRA_CACHE_DIR` environment variable. Downloads
-are restricted to `http(s)` URLs.
+overridden with the `CLEOPATRA_CACHE_DIR` environment variable; it is
+resolved by `cleopatra.config.Config.get_cache_dir`, where the setting is
+also discoverable. Downloads are restricted to `http(s)` URLs.
 
 Examples:
     Draw a relief backdrop and a coastline over data plotted in
@@ -49,7 +50,6 @@ import gzip
 import importlib.util
 import json
 import logging
-import os
 import shutil
 import time
 import urllib.error
@@ -64,6 +64,7 @@ from matplotlib.path import Path as MplPath
 
 from cleopatra import __version__
 from cleopatra.basemap._net import urlopen_http
+from cleopatra.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -89,14 +90,16 @@ _PILLOW_AVAILABLE = importlib.util.find_spec("PIL") is not None
 def _cache_dir() -> Path:
     """Resolve (and create) the on-disk cache directory.
 
-    Honours the `CLEOPATRA_CACHE_DIR` environment variable; defaults to
-    `~/.cleopatra/naturalearth`.
+    Resolution is delegated to `cleopatra.config.Config.get_cache_dir`
+    (honours the `CLEOPATRA_CACHE_DIR` environment variable; defaults to
+    `~/.cleopatra/naturalearth`), which is the single, user-discoverable
+    home for this setting. This helper additionally ensures the directory
+    exists, since it is called on the download path.
 
     Returns:
         pathlib.Path: The existing cache directory.
     """
-    root = os.environ.get("CLEOPATRA_CACHE_DIR")
-    base = Path(root) if root else Path.home() / ".cleopatra" / "naturalearth"
+    base = Config.get_cache_dir()
     base.mkdir(parents=True, exist_ok=True)
     return base
 

--- a/src/cleopatra/config.py
+++ b/src/cleopatra/config.py
@@ -7,7 +7,9 @@ discoverable place:
   Importing cleopatra does **not** change the active backend; picking one
   is the application's responsibility, not a library's.
 * `Config.get_cache_dir` — where cleopatra caches downloaded basemap
-  assets (honours the `CLEOPATRA_CACHE_DIR` environment variable).
+  assets. Resolves an explicit argument, then the `CLEOPATRA_CACHE_DIR`
+  environment variable, then the default `~/.cleopatra/naturalearth`; it
+  only resolves the path and does not create the directory.
 """
 
 import logging
@@ -89,8 +91,10 @@ class Config:
         Args:
             path: An explicit cache directory to use, overriding the
                 environment variable and the default. A falsy value
-                (`None` or `""`) is treated as not provided. Default
-                `None`.
+                (`None` or `""`) is treated as not provided. A relative
+                path (from `path` or the environment variable) is kept
+                relative and resolved against the current working
+                directory when the directory is created. Default `None`.
 
         Returns:
             pathlib.Path: The resolved (not necessarily existing) cache

--- a/src/cleopatra/config.py
+++ b/src/cleopatra/config.py
@@ -80,21 +80,25 @@ class Config:
         2. the `CLEOPATRA_CACHE_DIR` environment variable, if set;
         3. the default `~/.cleopatra/naturalearth`.
 
-        A falsy `path` (`None` or an empty string) is treated as "not
-        provided" and falls through to the environment variable and the
-        default, so `get_cache_dir("")` behaves like `get_cache_dir()`. A
-        leading `~` is expanded. This function only **resolves** the path;
-        it does not create the directory (the download helpers create it
-        on first use), so it is safe to call just to discover where the
-        cache lives.
+        A `path` (or `CLEOPATRA_CACHE_DIR` value) that is `None`, empty, or
+        whitespace-only is treated as "not provided" and falls through to
+        the next source, so `get_cache_dir("")` and `get_cache_dir("   ")`
+        behave like `get_cache_dir()`. Note that `Path("")` is `Path(".")`
+        under pathlib (indistinguishable from the current directory), so a
+        `Path("")` argument resolves to `.`, not the default — pass an empty
+        *string* (or `None`), not `Path("")`, to fall through. A leading `~`
+        is expanded. This function only **resolves** the path; it does not
+        create the directory (the download helpers create it on first use),
+        so it is safe to call just to discover where the cache lives.
 
         Args:
             path: An explicit cache directory to use, overriding the
-                environment variable and the default. A falsy value
-                (`None` or `""`) is treated as not provided. A relative
-                path (from `path` or the environment variable) is kept
-                relative and resolved against the current working
-                directory when the directory is created. Default `None`.
+                environment variable and the default. A value that is
+                `None`, empty, or whitespace-only is treated as not
+                provided. A relative path (from `path` or the environment
+                variable) is kept relative and resolved against the current
+                working directory when the directory is created. Default
+                `None`.
 
         Returns:
             pathlib.Path: The resolved (not necessarily existing) cache
@@ -138,10 +142,11 @@ class Config:
                 directory (its private `_cache_dir` resolves the location
                 through this method and creates the directory on first use).
         """
-        if not path:
-            path = os.environ.get("CLEOPATRA_CACHE_DIR")
-        if path:
-            return Path(path).expanduser()
+        candidate = os.fspath(path) if path is not None else None
+        if candidate is None or not candidate.strip():
+            candidate = os.environ.get("CLEOPATRA_CACHE_DIR")
+        if candidate and candidate.strip():
+            return Path(candidate).expanduser()
         return Path.home() / ".cleopatra" / "naturalearth"
 
 

--- a/src/cleopatra/config.py
+++ b/src/cleopatra/config.py
@@ -74,18 +74,23 @@ class Config:
         cache setting — the Natural Earth vectors and hypsometric relief
         downloaded by `cleopatra.basemap.reference`. Resolution order:
 
-        1. an explicit `path` argument, if given;
+        1. a non-empty explicit `path` argument;
         2. the `CLEOPATRA_CACHE_DIR` environment variable, if set;
         3. the default `~/.cleopatra/naturalearth`.
 
-        A leading `~` is expanded. This function only **resolves** the
-        path; it does not create the directory (the download helpers
-        create it on first use), so it is safe to call just to discover
-        where the cache lives.
+        A falsy `path` (`None` or an empty string) is treated as "not
+        provided" and falls through to the environment variable and the
+        default, so `get_cache_dir("")` behaves like `get_cache_dir()`. A
+        leading `~` is expanded. This function only **resolves** the path;
+        it does not create the directory (the download helpers create it
+        on first use), so it is safe to call just to discover where the
+        cache lives.
 
         Args:
             path: An explicit cache directory to use, overriding the
-                environment variable and the default. Default `None`.
+                environment variable and the default. A falsy value
+                (`None` or `""`) is treated as not provided. Default
+                `None`.
 
         Returns:
             pathlib.Path: The resolved (not necessarily existing) cache
@@ -129,7 +134,7 @@ class Config:
                 directory (its private `_cache_dir` resolves the location
                 through this method and creates the directory on first use).
         """
-        if path is None:
+        if not path:
             path = os.environ.get("CLEOPATRA_CACHE_DIR")
         if path:
             return Path(path).expanduser()

--- a/src/cleopatra/config.py
+++ b/src/cleopatra/config.py
@@ -1,13 +1,18 @@
-"""Matplotlib backend helpers for cleopatra.
+"""Configuration helpers for cleopatra.
 
-Importing cleopatra does **not** change the active matplotlib backend —
-picking a backend is the application's responsibility, not a library's.
-Use `Config.set_matplotlib_backend` if you want a one-liner that selects
-a sensible backend (`%matplotlib inline` in a Jupyter notebook, `Agg` in
-a plain script).
+`Config` gathers the package's cross-cutting, user-facing settings in one
+discoverable place:
+
+* `Config.set_matplotlib_backend` — opt-in matplotlib backend selection.
+  Importing cleopatra does **not** change the active backend; picking one
+  is the application's responsibility, not a library's.
+* `Config.get_cache_dir` — where cleopatra caches downloaded basemap
+  assets (honours the `CLEOPATRA_CACHE_DIR` environment variable).
 """
 
 import logging
+import os
+from pathlib import Path
 
 import matplotlib
 
@@ -60,6 +65,75 @@ class Config:
             plt.switch_backend("Agg")
             logger.info("Matplotlib backend set to Agg (non-interactive)")
         return matplotlib.get_backend()
+
+    @staticmethod
+    def get_cache_dir(path: str | os.PathLike | None = None) -> Path:
+        """Resolve the directory cleopatra caches downloaded basemap assets in.
+
+        This is the single, discoverable home for cleopatra's on-disk
+        cache setting — the Natural Earth vectors and hypsometric relief
+        downloaded by `cleopatra.basemap.reference`. Resolution order:
+
+        1. an explicit `path` argument, if given;
+        2. the `CLEOPATRA_CACHE_DIR` environment variable, if set;
+        3. the default `~/.cleopatra/naturalearth`.
+
+        A leading `~` is expanded. This function only **resolves** the
+        path; it does not create the directory (the download helpers
+        create it on first use), so it is safe to call just to discover
+        where the cache lives.
+
+        Args:
+            path: An explicit cache directory to use, overriding the
+                environment variable and the default. Default `None`.
+
+        Returns:
+            pathlib.Path: The resolved (not necessarily existing) cache
+            directory.
+
+        Examples:
+            - An explicit `path` is resolved as given (and overrides
+                everything else):
+                ```python
+                >>> from cleopatra.config import Config
+                >>> Config.get_cache_dir("/data/cleopatra").as_posix()
+                '/data/cleopatra'
+
+                ```
+            - With no argument, the `CLEOPATRA_CACHE_DIR` environment
+                variable is honoured:
+                ```python
+                >>> import os
+                >>> from cleopatra.config import Config
+                >>> os.environ["CLEOPATRA_CACHE_DIR"] = "/var/cache/cleopatra"
+                >>> Config.get_cache_dir().as_posix()
+                '/var/cache/cleopatra'
+                >>> del os.environ["CLEOPATRA_CACHE_DIR"]
+
+                ```
+            - An explicit argument wins over the environment variable, and
+                the returned path composes into an asset path:
+                ```python
+                >>> import os
+                >>> from cleopatra.config import Config
+                >>> os.environ["CLEOPATRA_CACHE_DIR"] = "/ignored"
+                >>> asset = Config.get_cache_dir("/data") / "ne_110m_coastline.geojson.gz"
+                >>> asset.as_posix()
+                '/data/ne_110m_coastline.geojson.gz'
+                >>> del os.environ["CLEOPATRA_CACHE_DIR"]
+
+                ```
+
+        See Also:
+            cleopatra.basemap.reference: Downloads basemap assets into this
+                directory (its private `_cache_dir` resolves the location
+                through this method and creates the directory on first use).
+        """
+        if path is None:
+            path = os.environ.get("CLEOPATRA_CACHE_DIR")
+        if path:
+            return Path(path).expanduser()
+        return Path.home() / ".cleopatra" / "naturalearth"
 
 
 def is_notebook() -> bool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,17 @@ class TestGetCacheDir:
         monkeypatch.setenv("CLEOPATRA_CACHE_DIR", "~/foo/bar")
         assert Config.get_cache_dir() == Path.home() / "foo" / "bar"
 
+    def test_explicit_arg_tilde_is_expanded(self, monkeypatch):
+        """A leading `~` in an explicit `path` argument is expanded too.
+
+        Test scenario:
+            The explicit-argument branch also calls `expanduser`, so
+            `get_cache_dir("~/foo")` resolves under the home directory
+            (guarding against the env branch being special-cased alone).
+        """
+        monkeypatch.delenv("CLEOPATRA_CACHE_DIR", raising=False)
+        assert Config.get_cache_dir("~/foo/bar") == Path.home() / "foo" / "bar"
+
     def test_empty_env_falls_back_to_default(self, monkeypatch):
         """An empty `CLEOPATRA_CACHE_DIR` is treated as unset."""
         monkeypatch.setenv("CLEOPATRA_CACHE_DIR", "")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,6 @@
+import inspect
+from pathlib import Path
+
 import matplotlib
 import matplotlib.pyplot as plt
 import pytest
@@ -7,6 +10,89 @@ from cleopatra.config import Config, is_notebook
 
 def test_create_config():
     assert Config()
+
+
+class TestGetCacheDir:
+    """`Config.get_cache_dir` resolves the basemap-asset cache directory."""
+
+    def test_default_when_unset(self, monkeypatch):
+        """With no override, it is `~/.cleopatra/naturalearth`."""
+        monkeypatch.delenv("CLEOPATRA_CACHE_DIR", raising=False)
+        assert (
+            Config.get_cache_dir() == Path.home() / ".cleopatra" / "naturalearth"
+        ), "default should be ~/.cleopatra/naturalearth"
+
+    def test_env_var_override(self, monkeypatch, tmp_path):
+        """`CLEOPATRA_CACHE_DIR` overrides the default."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path / "cache"))
+        assert Config.get_cache_dir() == tmp_path / "cache"
+
+    def test_explicit_arg_overrides_env(self, monkeypatch, tmp_path):
+        """An explicit `path` argument wins over the environment variable."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path / "from_env"))
+        assert (
+            Config.get_cache_dir(tmp_path / "explicit") == tmp_path / "explicit"
+        ), "explicit path should take precedence over the env var"
+
+    def test_tilde_is_expanded(self, monkeypatch):
+        """A leading `~` in the env var is expanded to the home directory."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", "~/foo/bar")
+        assert Config.get_cache_dir() == Path.home() / "foo" / "bar"
+
+    def test_empty_env_falls_back_to_default(self, monkeypatch):
+        """An empty `CLEOPATRA_CACHE_DIR` is treated as unset."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", "")
+        assert Config.get_cache_dir() == Path.home() / ".cleopatra" / "naturalearth"
+
+    def test_does_not_create_the_directory(self, monkeypatch, tmp_path):
+        """Resolving the path must not create it (the getter is side-effect free).
+
+        Test scenario:
+            A non-existent target is resolved but never created on disk, so
+            the getter is safe to call merely to discover the location.
+        """
+        target = tmp_path / "should_not_be_created"
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(target))
+        result = Config.get_cache_dir()
+        assert result == target
+        assert not target.exists(), "get_cache_dir must not create the directory"
+
+    def test_accepts_path_object_not_just_str(self, monkeypatch, tmp_path):
+        """The `path` argument accepts any `os.PathLike`, not only `str`.
+
+        Test scenario:
+            A `pathlib.Path` passed as `path` is honoured, confirming the
+            `str | os.PathLike` contract.
+        """
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path / "from_env"))
+        explicit = tmp_path / "as_path_object"
+        assert Config.get_cache_dir(explicit) == explicit
+
+    def test_always_returns_a_path(self, monkeypatch, tmp_path):
+        """The return value is always a `pathlib.Path`, for every branch.
+
+        Test scenario:
+            Default, env-var, and explicit-arg resolutions each return a
+            `Path` instance (so callers can chain path operations).
+        """
+        monkeypatch.delenv("CLEOPATRA_CACHE_DIR", raising=False)
+        assert isinstance(Config.get_cache_dir(), Path), "default branch must return Path"
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        assert isinstance(Config.get_cache_dir(), Path), "env branch must return Path"
+        assert isinstance(
+            Config.get_cache_dir(str(tmp_path)), Path
+        ), "explicit branch must return Path"
+
+    def test_is_a_staticmethod(self):
+        """`get_cache_dir` works without an instance (parity with the other helper).
+
+        Test scenario:
+            Calling it on the class (not an instance) resolves normally, and
+            it does not appear as a bound method requiring `self`.
+        """
+        assert isinstance(
+            inspect.getattr_static(Config, "get_cache_dir"), staticmethod
+        ), "get_cache_dir should be a staticmethod"
 
 
 class TestSetMatplotlibBackend:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,6 +50,37 @@ class TestGetCacheDir:
         monkeypatch.delenv("CLEOPATRA_CACHE_DIR", raising=False)
         assert Config.get_cache_dir("~/foo/bar") == Path.home() / "foo" / "bar"
 
+    def test_whitespace_only_arg_falls_through(self, monkeypatch, tmp_path):
+        """A whitespace-only `path` is treated as not provided (honours the env).
+
+        Test scenario:
+            `get_cache_dir("   ")` must not create a literally-named
+            whitespace directory; it strips to empty and falls through.
+        """
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path / "from_env"))
+        assert Config.get_cache_dir("   ") == tmp_path / "from_env"
+
+    def test_whitespace_only_env_falls_back_to_default(self, monkeypatch):
+        """A whitespace-only `CLEOPATRA_CACHE_DIR` falls back to the default.
+
+        Test scenario:
+            An all-spaces env value strips to empty and is treated as unset.
+        """
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", "   ")
+        assert Config.get_cache_dir() == Path.home() / ".cleopatra" / "naturalearth"
+
+    def test_empty_path_object_is_current_directory(self, monkeypatch):
+        """`Path("")` is `Path(".")` under pathlib and resolves to the CWD.
+
+        Test scenario:
+            An empty `Path` is indistinguishable from the current directory,
+            so it is used as-is (documented contract) rather than falling
+            through — callers pass an empty string, not `Path("")`, to fall
+            through.
+        """
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", "/ignored")
+        assert Config.get_cache_dir(Path("")) == Path(".")
+
     def test_empty_env_falls_back_to_default(self, monkeypatch):
         """An empty `CLEOPATRA_CACHE_DIR` is treated as unset."""
         monkeypatch.setenv("CLEOPATRA_CACHE_DIR", "")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,26 @@ class TestGetCacheDir:
         monkeypatch.setenv("CLEOPATRA_CACHE_DIR", "")
         assert Config.get_cache_dir() == Path.home() / ".cleopatra" / "naturalearth"
 
+    def test_empty_string_arg_falls_through_to_env(self, monkeypatch, tmp_path):
+        """A falsy explicit `path` is treated as not provided (honours the env var).
+
+        Test scenario:
+            `get_cache_dir("")` must not short-circuit to the default; an
+            empty argument falls through to `CLEOPATRA_CACHE_DIR`.
+        """
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path / "from_env"))
+        assert Config.get_cache_dir("") == tmp_path / "from_env"
+
+    def test_empty_string_arg_falls_back_to_default(self, monkeypatch):
+        """A falsy explicit `path` with no env var yields the default.
+
+        Test scenario:
+            With `CLEOPATRA_CACHE_DIR` unset, `get_cache_dir("")` behaves
+            exactly like `get_cache_dir()`.
+        """
+        monkeypatch.delenv("CLEOPATRA_CACHE_DIR", raising=False)
+        assert Config.get_cache_dir("") == Path.home() / ".cleopatra" / "naturalearth"
+
     def test_does_not_create_the_directory(self, monkeypatch, tmp_path):
         """Resolving the path must not create it (the getter is side-effect free).
 

--- a/tests/test_config_doctests.py
+++ b/tests/test_config_doctests.py
@@ -8,6 +8,8 @@ doctest runners.
 """
 
 import doctest
+import os
+from unittest import mock
 
 import cleopatra.config as config_module
 
@@ -22,11 +24,15 @@ def test_module_doctests_execute():
 
     Note:
         ``ELLIPSIS`` is enabled to match pytest's ``--doctest-modules``
-        behavior for any examples that use ``...``.
+        behavior for any examples that use ``...``. The doctests set and
+        delete `CLEOPATRA_CACHE_DIR` on the real `os.environ`; wrapping the
+        run in `mock.patch.dict` snapshots and restores the environment so
+        those mutations cannot leak into other tests in the same process.
     """
-    results = doctest.testmod(
-        config_module, verbose=False, optionflags=doctest.ELLIPSIS
-    )
+    with mock.patch.dict(os.environ):
+        results = doctest.testmod(
+            config_module, verbose=False, optionflags=doctest.ELLIPSIS
+        )
     assert results.failed == 0, f"{results.failed} doctest example(s) failed in config"
     assert results.attempted > 0, (
         "no doctest examples were collected from config; the module's docstring "

--- a/tests/test_config_doctests.py
+++ b/tests/test_config_doctests.py
@@ -1,0 +1,34 @@
+"""Doctest runner for `cleopatra.config`.
+
+Pytest is not configured with ``--doctest-modules``, so the docstring examples
+in ``src/cleopatra/config.py`` (notably ``Config.get_cache_dir``) would
+otherwise never run. This module executes them in-band so example drift fails
+CI — mirroring the existing ``test_styles_doctests`` / ``test_projection``
+doctest runners.
+"""
+
+import doctest
+
+import cleopatra.config as config_module
+
+
+def test_module_doctests_execute():
+    """Run every `cleopatra.config` docstring example in-band.
+
+    Test scenario:
+        All collected doctest examples in the module execute with zero
+        failures, and at least one example is collected (so the coverage is
+        not silently dropped if examples are moved or removed).
+
+    Note:
+        ``ELLIPSIS`` is enabled to match pytest's ``--doctest-modules``
+        behavior for any examples that use ``...``.
+    """
+    results = doctest.testmod(
+        config_module, verbose=False, optionflags=doctest.ELLIPSIS
+    )
+    assert results.failed == 0, f"{results.failed} doctest example(s) failed in config"
+    assert results.attempted > 0, (
+        "no doctest examples were collected from config; the module's docstring "
+        "examples may have been moved or removed, silently dropping this coverage"
+    )

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -29,6 +29,7 @@ from matplotlib.collections import LineCollection, PathCollection  # noqa: E402
 
 from cleopatra.basemap import reference  # noqa: E402
 from cleopatra.basemap.reference import (  # noqa: E402
+    _cache_dir,
     _is_4326,
     _paths,
     add_features,
@@ -46,6 +47,24 @@ def cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point the reference cache at a temp dir for the duration of a test."""
     monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
     return tmp_path
+
+
+def test_cache_dir_delegates_to_config_and_creates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`_cache_dir` resolves via `Config.get_cache_dir` and creates the dir.
+
+    The resolution is owned by `cleopatra.config.Config`; this download-path
+    helper adds only the create-on-use `mkdir`.
+    """
+    target = tmp_path / "nested" / "cache"
+    monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(target))
+    assert not target.exists(), "precondition: cache dir does not exist yet"
+
+    result = _cache_dir()
+
+    assert result == target, "should resolve to the CLEOPATRA_CACHE_DIR target"
+    assert target.is_dir(), "_cache_dir should create the directory on use"
 
 
 def _write_layer(cache: Path, stem: str, resolution: str, geometry: dict) -> None:


### PR DESCRIPTION
# Description

`CLEOPATRA_CACHE_DIR` — the location where cleopatra caches downloaded basemap
assets (Natural Earth vectors and hypsometric relief) — was a real, user-facing
global setting that lived only as a bare `os.environ.get(...)` read buried inside
the private `basemap/reference._cache_dir`. A user who opened `Config` to answer
"what can I configure?" had no way to discover it: `Config` exposed only
`set_matplotlib_backend`.

This adds `Config.get_cache_dir(path=None)` as the single, discoverable home for
that setting, following the pattern established by scikit-learn's `get_data_home`
(researched alongside pooch, astropy, and cartopy):

- **Resolution order:** a non-empty explicit `path` argument → the
  `CLEOPATRA_CACHE_DIR` environment variable → the default
  `~/.cleopatra/naturalearth`.
- **Pure getter:** it only *resolves* the path and does not create the directory,
  so it is safe to call just to discover where the cache lives (the download
  helper still creates it on first use). This deliberately avoids the
  create-in-getter footgun astropy hit (astropy/astropy#18436).
- **Correct dependency direction:** `config` (a leaf module) now owns resolution,
  and `basemap/reference._cache_dir` delegates to it and keeps only the
  create-on-use `mkdir`, so `reference` stays the sole consumer of the logic
  rather than `Config` reaching into a private helper.
- **Input-boundary handling:** any value that is `None`, empty, or whitespace-only
  (for both the explicit argument and the env var) is treated as "not provided"
  and falls through to the next source, so `get_cache_dir("")` /
  `get_cache_dir("   ")` behave like `get_cache_dir()`. A leading `~` is expanded
  (fixing a latent bug where `CLEOPATRA_CACHE_DIR=~/foo` previously created a
  literal `./~/foo`). Note that `Path("")` is `Path(".")` under pathlib and so
  resolves to the current directory — documented in the method docstring.

No runtime dependencies change; the default location is unchanged (a future
XDG/`platformdirs` default would relocate existing caches and is intentionally
left out of scope).

This branch has been through the two-round `/review` loop plus a SonarCloud sweep:
round 1 raised 6 informational findings, round 2 caught a real Medium — `Path("")`
bypassing the falsy guard — now fixed and covered. SonarCloud reports 0 open issues.

# Issues
- Closes #253 — surface CLEOPATRA_CACHE_DIR through Config

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

- [x] `tests/test_config.py::TestGetCacheDir` — 14 scenarios: default, env-var
  override, explicit-arg precedence, `~` expansion (env and explicit arg),
  empty-env fallback, empty-string arg (→ env / → default), whitespace-only arg
  and env, `Path("")` → current directory, pure-getter (no `mkdir`), `os.PathLike`
  argument, return-type invariant, and staticmethod callability.
- [x] `tests/test_reference.py` — a delegation/creation test proving `_cache_dir`
  resolves via `Config.get_cache_dir` and creates the directory on use; the
  existing cached-asset tests still pass unchanged.
- [x] `tests/test_config_doctests.py` — a CI doctest runner (mirroring
  `test_styles_doctests`) wrapped in `mock.patch.dict(os.environ)` so the
  env-mutating doctests are hermetic; `python -m doctest` passes.
- [x] `get_cache_dir` reaches 100% line + branch coverage on the changed code.
- [x] Full non-e2e suite green (**2196 passed**), run against the branch source via
  `PYTHONPATH` so the worktree copy is exercised, not an installed build.

# Checklist:

- [ ] updated version number in pyproject.toml (n/a — commitizen manages versioning from commits)
- [ ] added changes to History.rst (n/a — `docs/change-log.md` is auto-generated by commitizen)
- [ ] updated the latest version in README file (n/a — no version change)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
