### PR TITLE
feat(geo): add a relief backdrop to the ecmwf-dark reference map

### DIFF
--- a/src/cleopatra/basemap/geo.py
+++ b/src/cleopatra/basemap/geo.py
@@ -968,6 +968,8 @@ class GeoMixin:
                 used.
             resolution: Natural Earth resolution for the coastline/borders
                 (`"110m"`/`"50m"`/`"10m"`). Defaults to the style's value.
+                It does not change the `"ecmwf-dark"` relief backdrop, which
+                uses the preset's own relief resolution (`"low"`).
             graticule_step: Degree spacing for the graticule. Defaults to a
                 "nice" step giving ~6 divisions across the wider span.
             zorder: Draw order for the reference layers (drawn above the

--- a/src/cleopatra/basemap/geo.py
+++ b/src/cleopatra/basemap/geo.py
@@ -1056,10 +1056,15 @@ class GeoMixin:
                 self.add_relief(
                     relief_kwargs.pop("resolution"), ax=target, **relief_kwargs
                 )
-            except ImportError:
+            except (ImportError, OSError) as exc:
+                # ImportError -> Pillow (the [tiles] extra) is missing; OSError
+                # (incl. ConnectionError) -> the relief asset could not be
+                # fetched or decoded. Either way, skip the backdrop but still
+                # draw the independently cached coastline/border chrome; a bad
+                # relief resolution in a custom preset (ValueError) still raises.
                 warnings.warn(
-                    "add_reference_map: relief backdrop skipped; install "
-                    "cleopatra[tiles] for the hillshade.",
+                    "add_reference_map: relief backdrop skipped "
+                    f"({exc}); the coastline/border chrome is still drawn.",
                     stacklevel=2,
                 )
 

--- a/src/cleopatra/basemap/geo.py
+++ b/src/cleopatra/basemap/geo.py
@@ -939,8 +939,9 @@ class GeoMixin:
         One call composes the recipe that otherwise takes ~15 lines of
         matplotlib after `plot`/`animate`: grey Natural Earth `coastline`
         + `borders`, a dashed lon/lat graticule, `°W`/`°N` degree labels,
-        and a subtle frame. It layers on top of the existing data, so call
-        it after plotting.
+        and a subtle frame, plus -- for `"ecmwf-dark"` -- a dimmed relief
+        backdrop beneath the data. The chrome layers on top of the existing
+        data, so call it after plotting.
 
         The map is drawn in the axes' current geographic coordinates. Pass
         `extent` (or construct the glyph with `extent=`) so the axes are

--- a/src/cleopatra/basemap/geo.py
+++ b/src/cleopatra/basemap/geo.py
@@ -41,10 +41,12 @@ from cleopatra.basemap import reference, tiles
 #: Built-in reference-map style presets for `GeoMixin.add_reference_map`.
 #: `"ecmwf"` is tuned for light backgrounds; `"ecmwf-dark"` uses lighter
 #: greys so coastlines stay visible over a dark field (e.g. a satellite
-#: true-colour RGB). Each entry is a plain dict of the layer styles,
-#: graticule, tick-label, and frame (spine) parameters -- read or copy it to
-#: build a custom preset; `add_reference_map` itself exposes only the
-#: `resolution` and `graticule_step` knobs per call.
+#: true-colour RGB) and adds a dimmed hypsometric relief backdrop under the
+#: data. Each entry is a plain dict of the layer styles, graticule,
+#: tick-label, and frame (spine) parameters, plus an optional `"relief"`
+#: backdrop (a dict of `add_relief` kwargs, a resolution string, or `True`)
+#: -- read or copy it to build a custom preset; `add_reference_map` itself
+#: exposes only the `resolution` and `graticule_step` knobs per call.
 REFERENCE_MAP_STYLES: dict[str, dict[str, Any]] = {
     "ecmwf": {
         "resolution": "50m",
@@ -56,6 +58,7 @@ REFERENCE_MAP_STYLES: dict[str, dict[str, Any]] = {
     },
     "ecmwf-dark": {
         "resolution": "50m",
+        "relief": {"resolution": "low", "alpha": 0.5, "zorder": -2},
         "coastline": {"colors": "0.85", "linewidths": 0.8},
         "borders": {"colors": "0.85", "linewidths": 0.5},
         "graticule": {"color": "0.75", "linestyle": (0, (4, 4)), "linewidth": 0.5},
@@ -951,7 +954,10 @@ class GeoMixin:
                 `"ecmwf-dark"`), or `"auto"` to pick between them from the
                 background luminance (dark backgrounds get the lighter
                 `"ecmwf-dark"` greys so coastlines stay visible). Default
-                `"ecmwf"`.
+                `"ecmwf"`. `"ecmwf-dark"` also draws a dimmed relief backdrop
+                under the data (needs the `[tiles]` extra; if Pillow is
+                missing the backdrop is skipped with a warning and the
+                coastline/border chrome is still drawn).
             ax: Axes to draw on. Defaults to the glyph's `self.ax`.
             extent: Optional `[xmin, ymin, xmax, ymax]` (i.e.
                 `[west, south, east, north]`) in the axes' CRS -- the same
@@ -1032,6 +1038,29 @@ class GeoMixin:
                 "with extent=.",
                 stacklevel=2,
             )
+
+        # A preset may bundle a dimmed relief backdrop (ecmwf-dark). Draw it
+        # under the data, defaulting crs to self.crs like the other helpers.
+        # Skip it when the axes are not georeferenced (already warned above),
+        # and -- so the coastline chrome never hard-depends on Pillow --
+        # degrade with a warning when the [tiles] extra is missing.
+        relief = preset.get("relief")
+        if relief and (extent is not None or getattr(self, "extent", None) is not None):
+            relief_kwargs: dict = {"resolution": "low", "alpha": 0.5, "zorder": -2}
+            if isinstance(relief, str):
+                relief_kwargs["resolution"] = relief
+            elif isinstance(relief, dict):
+                relief_kwargs.update(relief)
+            try:
+                self.add_relief(
+                    relief_kwargs.pop("resolution"), ax=target, **relief_kwargs
+                )
+            except ImportError:
+                warnings.warn(
+                    "add_reference_map: relief backdrop skipped; install "
+                    "cleopatra[tiles] for the hillshade.",
+                    stacklevel=2,
+                )
 
         res = resolution or preset["resolution"]
         self.add_features(

--- a/src/cleopatra/basemap/geo.py
+++ b/src/cleopatra/basemap/geo.py
@@ -983,8 +983,10 @@ class GeoMixin:
                 glyph cannot create one (a bare `GeoMixin`); only `ArrayGlyph` creates and seeds
                 its axes on demand, so the pre-plot builder flow is ArrayGlyph-only
                 -- plot the other glyphs first (or pass `ax=`).
-            ValueError: If `style` is not a known preset or `"auto"`, or if
-                `graticule_step` is given and is not a positive number.
+            ValueError: If `style` is not a known preset or `"auto"`, if
+                `graticule_step` is given and is not a positive number, or if
+                a custom preset's `relief` resolution is unknown (an
+                environmental relief failure degrades with a warning instead).
 
         Examples:
             - Dress a georeferenced field in the ECMWF look:

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -616,6 +616,16 @@ class TestAddReferenceMap:
         host.add_features.assert_called()  # coastline/borders still drawn
         plt.close(fig)
 
+    def test_relief_fetch_failure_degrades_with_warning(self):
+        """A relief fetch/decode failure (ConnectionError/OSError) is skipped with
+        a warning; the coastline/border chrome is still drawn."""
+        host, fig, ax = self._host(extent=[-100, 15, -40, 55])
+        host.add_relief = MagicMock(side_effect=ConnectionError("offline"))
+        with pytest.warns(UserWarning, match="relief backdrop skipped"):
+            host.add_reference_map("ecmwf-dark")
+        host.add_features.assert_called()  # chrome unaffected by the relief failure
+        plt.close(fig)
+
     def test_no_extent_skips_relief(self):
         """With no geographic extent, the relief backdrop is skipped entirely."""
         host, fig, ax = self._host(extent=None)

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -858,6 +858,44 @@ def test_add_reference_map_dark_draws_real_relief(tmp_path: Path, monkeypatch):
     plt.close(fig)
 
 
+def test_add_reference_map_relief_warps_non_4326(tmp_path: Path, monkeypatch):
+    """ecmwf-dark forwards self.crs to the relief, so on a non-4326 axis the
+    backdrop is warped (RGBA) rather than placed in lon/lat."""
+    pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
+    Image = pytest.importorskip(
+        "PIL.Image", reason="Pillow not installed (tiles extra)"
+    )
+    monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+    arr = (np.random.default_rng(0).random((4, 8, 3)) * 255).astype("uint8")
+    Image.fromarray(arr).save(tmp_path / "ne_hypso_rgb_720x360.png")
+    line = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[-90, 20], [-50, 50]],
+                },
+            }
+        ],
+    }
+    for fname in (
+        "ne_110m_coastline.geojson.gz",
+        "ne_110m_admin_0_boundary_lines_land.geojson.gz",
+    ):
+        with gzip.open(tmp_path / fname, "wt", encoding="utf-8") as fh:
+            json.dump(line, fh)
+
+    glyph = ArrayGlyph(np.random.rand(20, 30), extent=[-2e7, -1e7, 2e7, 1e7])
+    glyph.crs = 3857  # axis CRS recorded once; add_reference_map defaults to it
+    fig, ax = glyph.plot()
+    glyph.add_reference_map("ecmwf-dark", resolution="110m")
+    placed = np.asarray(ax.images[-1].get_array())
+    assert placed.shape[2] == 4, f"relief should warp to RGBA, got {placed.shape}"
+    plt.close(fig)
+
+
 class TestBasemapAlignmentCheck:
     """`_check_basemap_alignment`: the opt-in mis-georeferencing warning."""
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -530,13 +530,14 @@ class TestAddReferenceMap:
 
     @staticmethod
     def _host(extent=None, im=None):
-        """A GeoMixin host with a real axes and a mocked `add_features`."""
+        """A GeoMixin host with a real axes and mocked `add_features`/`add_relief`."""
         fig, ax = plt.subplots()
         host = _Dummy(ax=ax)
         host.extent = extent
         host.im = im
         host.crs = None
         host.add_features = MagicMock(return_value=ax)
+        host.add_relief = MagicMock(return_value=ax)
         return host, fig, ax
 
     def test_available_map_styles(self):
@@ -584,6 +585,42 @@ class TestAddReferenceMap:
         host, fig, ax = self._host(extent=[-100, 20, -80, 40])
         host.add_reference_map("ecmwf-dark")
         assert host.add_features.call_args_list[0].kwargs["colors"] == "0.85"
+        plt.close(fig)
+
+    def test_dark_style_draws_relief_backdrop(self):
+        """`ecmwf-dark` draws a dimmed relief backdrop under the chrome."""
+        host, fig, ax = self._host(extent=[-100, 15, -40, 55])
+        host.add_reference_map("ecmwf-dark")
+        host.add_relief.assert_called_once()
+        call = host.add_relief.call_args
+        assert call.args[0] == "low", "relief resolution"
+        assert call.kwargs["alpha"] == 0.5
+        assert call.kwargs["zorder"] == -2
+        assert call.kwargs["ax"] is ax
+        plt.close(fig)
+
+    def test_light_style_draws_no_relief(self):
+        """Plain `ecmwf` stays chrome-only -- no relief backdrop."""
+        host, fig, ax = self._host(extent=[-100, 15, -40, 55])
+        host.add_reference_map("ecmwf")
+        host.add_relief.assert_not_called()
+        plt.close(fig)
+
+    def test_relief_missing_pillow_degrades_with_warning(self):
+        """Without Pillow the relief is skipped with a warning; chrome still drawn."""
+        host, fig, ax = self._host(extent=[-100, 15, -40, 55])
+        host.add_relief = MagicMock(side_effect=ImportError("no Pillow"))
+        with pytest.warns(UserWarning, match="relief backdrop skipped"):
+            host.add_reference_map("ecmwf-dark")
+        host.add_features.assert_called()  # coastline/borders still drawn
+        plt.close(fig)
+
+    def test_no_extent_skips_relief(self):
+        """With no geographic extent, the relief backdrop is skipped entirely."""
+        host, fig, ax = self._host(extent=None)
+        with pytest.warns(UserWarning, match="no geographic extent"):
+            host.add_reference_map("ecmwf-dark")
+        host.add_relief.assert_not_called()
         plt.close(fig)
 
     def test_auto_picks_dark_on_dark_background(self):
@@ -764,6 +801,44 @@ def test_add_reference_map_integration(tmp_path: Path, monkeypatch):
     # the preset styling reaches the real axes (frame + visible graticule)
     assert ax.spines["bottom"].get_edgecolor() == (0.6, 0.6, 0.6, 1.0)
     assert ax.xaxis.get_gridlines()[0].get_visible(), "graticule not drawn"
+    plt.close(fig)
+
+
+def test_add_reference_map_dark_draws_real_relief(tmp_path: Path, monkeypatch):
+    """Non-mocked: `ecmwf-dark` places a real dimmed relief image beneath data."""
+    Image = pytest.importorskip(
+        "PIL.Image", reason="Pillow not installed (tiles extra)"
+    )
+    monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+    arr = (np.random.default_rng(0).random((4, 8, 3)) * 255).astype("uint8")
+    Image.fromarray(arr).save(tmp_path / "ne_hypso_rgb_720x360.png")
+    line = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "geometry": {
+                    "type": "LineString",
+                    "coordinates": [[-90, 20], [-50, 50]],
+                },
+            }
+        ],
+    }
+    for fname in (
+        "ne_110m_coastline.geojson.gz",
+        "ne_110m_admin_0_boundary_lines_land.geojson.gz",
+    ):
+        with gzip.open(tmp_path / fname, "wt", encoding="utf-8") as fh:
+            json.dump(line, fh)
+
+    glyph = ArrayGlyph(np.random.rand(20, 30), extent=[-100, 15, -40, 55])
+    fig, ax = glyph.plot()
+    n_before = len(ax.images)
+    glyph.add_reference_map("ecmwf-dark", resolution="110m")
+    assert len(ax.images) == n_before + 1, "ecmwf-dark should add a relief image"
+    relief_img = ax.images[-1]
+    assert relief_img.get_zorder() == -2
+    assert relief_img.get_alpha() == 0.5
     plt.close(fig)
 
 

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -34,6 +34,7 @@ import cleopatra.basemap.tiles as tilesmod  # noqa: E402
 from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph  # noqa: E402
 from cleopatra.glyphs.primitives.flow_glyph import FlowGlyph  # noqa: E402
 from cleopatra.basemap.geo import (  # noqa: E402
+    REFERENCE_MAP_STYLES,
     Basemap,
     Feature,
     GeoMixin,
@@ -621,6 +622,21 @@ class TestAddReferenceMap:
         with pytest.warns(UserWarning, match="no geographic extent"):
             host.add_reference_map("ecmwf-dark")
         host.add_relief.assert_not_called()
+        plt.close(fig)
+
+    @pytest.mark.parametrize(
+        "relief_value,expected_resolution",
+        [("medium", "medium"), (True, "low")],
+    )
+    def test_relief_config_forms(self, monkeypatch, relief_value, expected_resolution):
+        """A preset `relief` as a resolution string or `True` selects the relief
+        resolution (a string overrides it; `True` keeps the `"low"` default)."""
+        host, fig, ax = self._host(extent=[-100, 15, -40, 55])
+        monkeypatch.setitem(REFERENCE_MAP_STYLES["ecmwf-dark"], "relief", relief_value)
+        host.add_reference_map("ecmwf-dark")
+        assert host.add_relief.call_args.args[0] == expected_resolution, (
+            f"expected relief resolution {expected_resolution!r}"
+        )
         plt.close(fig)
 
     def test_auto_picks_dark_on_dark_background(self):

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -804,9 +804,16 @@ class TestAddReferenceMap:
         plt.close(fig2)
 
 
-def test_add_reference_map_integration(tmp_path: Path, monkeypatch):
-    """Non-mocked: add_reference_map draws real coastline + border collections."""
+def _seed_reference_cache(tmp_path: Path, monkeypatch, *, relief: bool) -> None:
+    """Seed `CLEOPATRA_CACHE_DIR` with 110m coastline/border layers -- and, when
+    `relief` is true, a tiny relief PNG -- so the reference map runs offline."""
     monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+    if relief:
+        Image = pytest.importorskip(
+            "PIL.Image", reason="Pillow not installed (tiles extra)"
+        )
+        arr = (np.random.default_rng(0).random((4, 8, 3)) * 255).astype("uint8")
+        Image.fromarray(arr).save(tmp_path / "ne_hypso_rgb_720x360.png")
     line = {
         "type": "FeatureCollection",
         "features": [
@@ -825,6 +832,11 @@ def test_add_reference_map_integration(tmp_path: Path, monkeypatch):
     ):
         with gzip.open(tmp_path / fname, "wt", encoding="utf-8") as fh:
             json.dump(line, fh)
+
+
+def test_add_reference_map_integration(tmp_path: Path, monkeypatch):
+    """Non-mocked: add_reference_map draws real coastline + border collections."""
+    _seed_reference_cache(tmp_path, monkeypatch, relief=False)
 
     glyph = ArrayGlyph(np.random.rand(20, 30), extent=[-100, 15, -40, 55])
     fig, ax = glyph.plot()
@@ -846,30 +858,7 @@ def test_add_reference_map_integration(tmp_path: Path, monkeypatch):
 
 def test_add_reference_map_dark_draws_real_relief(tmp_path: Path, monkeypatch):
     """Non-mocked: `ecmwf-dark` places a real dimmed relief image beneath data."""
-    Image = pytest.importorskip(
-        "PIL.Image", reason="Pillow not installed (tiles extra)"
-    )
-    monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
-    arr = (np.random.default_rng(0).random((4, 8, 3)) * 255).astype("uint8")
-    Image.fromarray(arr).save(tmp_path / "ne_hypso_rgb_720x360.png")
-    line = {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "geometry": {
-                    "type": "LineString",
-                    "coordinates": [[-90, 20], [-50, 50]],
-                },
-            }
-        ],
-    }
-    for fname in (
-        "ne_110m_coastline.geojson.gz",
-        "ne_110m_admin_0_boundary_lines_land.geojson.gz",
-    ):
-        with gzip.open(tmp_path / fname, "wt", encoding="utf-8") as fh:
-            json.dump(line, fh)
+    _seed_reference_cache(tmp_path, monkeypatch, relief=True)
 
     glyph = ArrayGlyph(np.random.rand(20, 30), extent=[-100, 15, -40, 55])
     fig, ax = glyph.plot()
@@ -886,30 +875,7 @@ def test_add_reference_map_relief_warps_non_4326(tmp_path: Path, monkeypatch):
     """ecmwf-dark forwards self.crs to the relief, so on a non-4326 axis the
     backdrop is warped (RGBA) rather than placed in lon/lat."""
     pytest.importorskip("pyproj", reason="pyproj not installed (tiles extra)")
-    Image = pytest.importorskip(
-        "PIL.Image", reason="Pillow not installed (tiles extra)"
-    )
-    monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
-    arr = (np.random.default_rng(0).random((4, 8, 3)) * 255).astype("uint8")
-    Image.fromarray(arr).save(tmp_path / "ne_hypso_rgb_720x360.png")
-    line = {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "geometry": {
-                    "type": "LineString",
-                    "coordinates": [[-90, 20], [-50, 50]],
-                },
-            }
-        ],
-    }
-    for fname in (
-        "ne_110m_coastline.geojson.gz",
-        "ne_110m_admin_0_boundary_lines_land.geojson.gz",
-    ):
-        with gzip.open(tmp_path / fname, "wt", encoding="utf-8") as fh:
-            json.dump(line, fh)
+    _seed_reference_cache(tmp_path, monkeypatch, relief=True)
 
     glyph = ArrayGlyph(np.random.rand(20, 30), extent=[-2e7, -1e7, 2e7, 1e7])
     glyph.crs = 3857  # axis CRS recorded once; add_reference_map defaults to it

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -626,6 +626,20 @@ class TestAddReferenceMap:
         host.add_features.assert_called()  # chrome unaffected by the relief failure
         plt.close(fig)
 
+    def test_custom_relief_bad_resolution_raises(self, monkeypatch):
+        """A custom preset's bad relief resolution raises loudly (a config error),
+        it is not swallowed by the environmental degrade path."""
+        host, fig, ax = self._host(extent=[-100, 15, -40, 55])
+        host.add_relief = MagicMock(
+            side_effect=ValueError("Unknown relief resolution 'ultra'")
+        )
+        monkeypatch.setitem(
+            REFERENCE_MAP_STYLES["ecmwf-dark"], "relief", {"resolution": "ultra"}
+        )
+        with pytest.raises(ValueError, match="Unknown relief resolution"):
+            host.add_reference_map("ecmwf-dark")
+        plt.close(fig)
+
     def test_no_extent_skips_relief(self):
         """With no geographic extent, the relief backdrop is skipped entirely."""
         host, fig, ax = self._host(extent=None)


### PR DESCRIPTION
# Description

`add_reference_map` now draws a dimmed hypsometric relief backdrop beneath the data when the resolved preset carries
a `"relief"` entry — present on `ecmwf-dark`, absent on the chrome-only `ecmwf`. The relief config accepts a
resolution string, an `add_relief` kwargs dict, or `True` (mirroring the sibling `_draw_basemap`), and defaults
`crs` to `self.crs` via `_basemap_kwargs`, so it warps to match non-EPSG:4326 data.

The backdrop is **skipped when the axes are not georeferenced**, and an **environmental relief failure** — missing
Pillow (the `[tiles]` extra), an offline/uncached fetch, or a corrupt cache — **degrades with a warning** while the
coastline/border chrome still draws, so the chrome never hard-depends on the relief. A **bad relief resolution in a
custom preset still raises loudly** (a config error, not environmental). The per-call `resolution=` knob affects only
the features, not the relief.

No new dependencies (the relief uses the existing `cleopatra[tiles]` extra); no GDAL.

Note on tooling: the repo's black→ruff migration is in flight and `origin/main` is not yet ruff-clean. This PR keeps
its diff minimal — the added lines are ruff-format/check clean, but pre-existing lint/format drift in untouched code
(e.g. the `tests/test_geo.py` import order) is left to the `reformat/run-pre-commit-hooks` effort rather than swept
into this change.

# Issues
- Closes #216

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Unit + integration tests in `tests/test_geo.py`, run with
`VIRTUAL_ENV=…/uv/cleopatra uv run --active python -m pytest`:

- `ecmwf-dark` draws a relief backdrop under the chrome; plain `ecmwf` draws none; `auto` inherits.
- Relief config forms: a resolution string and `True` both select the relief resolution.
- Degrade paths: missing Pillow (`ImportError`) and a fetch/decode failure (`ConnectionError`/`OSError`) skip the
  backdrop with a warning while the coastline/border chrome still draws.
- A bad relief resolution in a custom preset raises `ValueError` (not swallowed by the degrade path).
- Axes with no geographic extent skip the relief entirely.
- Non-mocked integration: a real dimmed relief image lands at `zorder=-2`, `alpha=0.5`; on a `crs=3857` glyph the
  relief warps to RGBA (crs defaulting through `add_reference_map`). Deterministic and offline (seeded cache).
- Full suite: **2206 passed**; `basemap/geo.py` doctests pass; the new relief block is at 100% line + branch
  coverage. Two independent `/review-rounds` passes, all findings resolved.

- [x] Unit tests (mocked `add_relief`): dark draws relief, light doesn't, degrade-with-warning, config forms,
  bad-resolution raises, no-extent skips
- [x] Integration tests (real `add_relief`): image beneath data at `zorder=-2` / `alpha=0.5`; warps to RGBA on a
  `crs=3857` axis

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
