### PR TITLE
refactor(glyphs)!: remove legacy-kwarg shims and finish facet grouping

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,4 +1,102 @@
-# Migration guide — subpackage restructure
+# Migration guide
+
+This page collects cleopatra's breaking changes and how to update your code. Two migrations are covered:
+
+1. **[Grouped render-parameter objects](#grouped-render-parameter-objects)** — the loose styling keywords on
+   `plot` / `animate` / `facet` were replaced by typed *group objects*, and the temporary deprecation shims that
+   kept the old keywords working have now been **removed**. Read this section if you hit a `TypeError` about an
+   unexpected keyword argument, or an `AttributeError` from passing a bare array where an object is expected.
+2. **[Subpackage restructure](#subpackage-restructure)** — an earlier release moved the flat `cleopatra.*`
+   modules into `glyphs/` / `styling/` / `basemap/` subpackages (import paths only).
+
+---
+
+## Grouped render-parameter objects
+
+Related styling keywords that `plot` / `animate` (and the other glyphs) used to accept as long lists of loose
+arguments are now bundled into small typed objects. During one release the old keywords kept working behind a
+`DeprecationWarning`; **those shims are now gone**. Passing a removed keyword no longer warns — it raises the
+ordinary `TypeError: ... got an unexpected keyword argument`, and passing a bare `(N, 3)` array as `points`
+raises `AttributeError` instead of being auto-wrapped.
+
+There is no automated rewrite for this one: the changes are semantic (loose keywords → object fields), so update
+each call site by hand using the tables below.
+
+### Point overlays → `PointOverlay`
+
+`points` now takes a `PointOverlay` (or `None`); the marker/label styling lives on the object.
+
+```python
+from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph, PointOverlay
+
+# before
+glyph.plot(points=arr, point_color="red", point_size=80,
+           point_label_color="blue", point_label_size=10)
+# after
+glyph.plot(points=PointOverlay(arr, color="red", size=80,
+                               label_color="blue", label_size=10))
+```
+
+| Removed keyword | New `PointOverlay` field |
+| --- | --- |
+| `points=<array>` (bare) | `points=PointOverlay(<array>)` |
+| `point_color` | `color` |
+| `point_size` | `size` |
+| `point_label_color` (or oldest `pid_color`) | `label_color` |
+| `point_label_size` (or oldest `pid_size`) | `label_size` |
+
+### Frame labels → `FrameLabel`
+
+`animate`'s per-frame time-label styling now lives on a `FrameLabel` passed as `frame_label=` (a bare `[x, y]`
+list passed positionally is no longer accepted).
+
+```python
+from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph, FrameLabel
+
+# before
+glyph.animate(time, label_location=[0.1, 0.1], label_color="yellow")
+# after
+glyph.animate(time, frame_label=FrameLabel(location=[0.1, 0.1], color="yellow"))
+```
+
+| Removed keyword | New `FrameLabel` field |
+| --- | --- |
+| `label_location` (or oldest `text_loc`) | `location` |
+| `label_color` | `color` |
+
+### Renamed / restructured keywords
+
+| Old | New |
+| --- | --- |
+| `animate(text_colors=...)` | `animate(cell_value_text_colors=...)` |
+| `facet(col_coords=..., row_coords=...)` | `facet(labels=PanelLabels(col=..., row=...))` |
+| `facet(figsize=...)` | `facet(figure_size=...)` |
+| `ArrayGlyph.no_elem` | `ArrayGlyph.num_domain_cells` |
+
+`PanelLabels` is importable from `cleopatra.glyphs.gridded.array_glyph`.
+
+### Colour / scale / cell-value groups
+
+The colour-scale, discretisation, cell-value, and preset/relief keywords were already folded into typed group
+objects in a prior release; passing them as loose keywords **raises** with a pointer to the object:
+
+| Loose keywords | Group object |
+| --- | --- |
+| `color_scale`, `gamma`, `line_threshold`, `line_scale`, `bounds`, `midpoint` | `cleopatra.styling.scaling.ColorScaling` |
+| `levels`, `labels`, `label_kw` | `cleopatra.styling.params.Contour` |
+| `display_cell_value`, `num_size`, `background_color_threshold` | `cleopatra.styling.params.CellValues` |
+| `style`, `hillshade` | `cleopatra.styling.params.DataStyle` |
+
+### Colour bars — `cbar_*` still work
+
+The loose `cbar_*` / `ticks_spacing` keywords are **not** removed — they remain valid options and keep working.
+Only the `DeprecationWarning` that steered you toward `ColorBar` is gone. The typed
+`colorbar=ColorBar(...)` form (`cleopatra.styling.colorbar.ColorBar`) is still preferred and wins when both are
+given.
+
+---
+
+## Subpackage restructure
 
 This release reorganises cleopatra's previously flat `cleopatra.*` module layout into three subpackages
 (`glyphs/`, `styling/`, `basemap/`) and renames the histogram glyph. It is a **breaking change to import paths

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -77,7 +77,9 @@ glyph.animate(time, frame_label=FrameLabel(location=[0.1, 0.1], color="yellow"))
 | `facet(figsize=...)` | `facet(figure_size=...)` |
 | `ArrayGlyph.no_elem` | `ArrayGlyph.num_domain_cells` |
 
-`PanelLabels` is importable from `cleopatra.glyphs.gridded.array_glyph`.
+`PanelLabels` is importable from `cleopatra.glyphs.gridded.array_glyph`. Note that `facet`'s `labels=` names the
+per-panel *title* labels (a `PanelLabels`); it is unrelated to the loose `labels` contour-line keyword that now
+lives on `Contour` (see the colour/scale/cell groups table below).
 
 ### Colour / scale / cell-value groups
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -19,7 +19,9 @@ arguments are now bundled into small typed objects. During one release the old k
 `DeprecationWarning`; **those shims are now gone**. Passing a removed keyword no longer warns — it funnels through
 cleopatra's strict option validation and raises
 `ValueError: The given keyword argument:<name> is not correct, possible parameters are, [...]`. Passing a bare
-`(N, 3)` array as `points` raises `AttributeError` instead of being auto-wrapped. The one exception is
+`(N, 3)` array as `points` raises `AttributeError` instead of being auto-wrapped on the overlay-drawing kinds
+(`imshow` / `pcolormesh`); on `contour` / `contourf` the overlay is skipped, so a bare array is ignored rather
+than raising — either way, pass a `PointOverlay`. The one exception is
 `facet(figsize=...)`: because `figsize` is still a valid glyph option it would otherwise be absorbed silently, so
 `facet` raises a targeted `ValueError` telling you to use `figure_size` (see the table below).
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,8 +4,9 @@ This page collects cleopatra's breaking changes and how to update your code. Two
 
 1. **[Grouped render-parameter objects](#grouped-render-parameter-objects)** — the loose styling keywords on
    `plot` / `animate` / `facet` were replaced by typed *group objects*, and the temporary deprecation shims that
-   kept the old keywords working have now been **removed**. Read this section if you hit a `TypeError` about an
-   unexpected keyword argument, or an `AttributeError` from passing a bare array where an object is expected.
+   kept the old keywords working have now been **removed**. Read this section if you hit a
+   `ValueError: The given keyword argument:... is not correct`, an `AttributeError` from passing a bare array
+   where an object is expected, or a `ValueError` from `facet` saying `figsize` was renamed to `figure_size`.
 2. **[Subpackage restructure](#subpackage-restructure)** — an earlier release moved the flat `cleopatra.*`
    modules into `glyphs/` / `styling/` / `basemap/` subpackages (import paths only).
 
@@ -15,9 +16,12 @@ This page collects cleopatra's breaking changes and how to update your code. Two
 
 Related styling keywords that `plot` / `animate` (and the other glyphs) used to accept as long lists of loose
 arguments are now bundled into small typed objects. During one release the old keywords kept working behind a
-`DeprecationWarning`; **those shims are now gone**. Passing a removed keyword no longer warns — it raises the
-ordinary `TypeError: ... got an unexpected keyword argument`, and passing a bare `(N, 3)` array as `points`
-raises `AttributeError` instead of being auto-wrapped.
+`DeprecationWarning`; **those shims are now gone**. Passing a removed keyword no longer warns — it funnels through
+cleopatra's strict option validation and raises
+`ValueError: The given keyword argument:<name> is not correct, possible parameters are, [...]`. Passing a bare
+`(N, 3)` array as `points` raises `AttributeError` instead of being auto-wrapped. The one exception is
+`facet(figsize=...)`: because `figsize` is still a valid glyph option it would otherwise be absorbed silently, so
+`facet` raises a targeted `ValueError` telling you to use `figure_size` (see the table below).
 
 There is no automated rewrite for this one: the changes are semantic (loose keywords → object fields), so update
 each call site by hand using the tables below.

--- a/docs/reference/array-glyph.md
+++ b/docs/reference/array-glyph.md
@@ -47,8 +47,7 @@ animations exported to GIF / MP4 / MOV / AVI.
 
 !!! note "Changes from earlier versions"
     - `ArrayGlyph.plot()` returns `(fig, ax)`.
-    - The cell-value count is exposed as `num_domain_cells` (`no_elem` still works as a
-      deprecated alias).
+    - The cell-value count is exposed as `num_domain_cells` (previously `no_elem`, now removed).
     - `ArrayGlyph(arr)` on an all-NaN / fully-masked array raises `ValueError` instead of
       producing an unusable colour range.
 

--- a/docs/reference/array-glyph.md
+++ b/docs/reference/array-glyph.md
@@ -36,9 +36,10 @@ animations exported to GIF / MP4 / MOV / AVI.
 - **`ArrayGlyph(..., coords=(x, y))`** — plot curvilinear / non-uniform grids (1-D cell
   centres or 2-D meshgrids); with `kind="auto"` this routes to `pcolormesh`. Mutually
   exclusive with `extent`.
-- **`ArrayGlyph.facet(col=, row=, col_wrap=, col_coords=, row_coords=, kind=, figsize=,
-  extents=)`** — a grid of subplots from a 3-D `(N, H, W)` or 4-D `(N, M, H, W)` stack
-  with one shared colour scale and colorbar.
+- **`ArrayGlyph.facet(col=, row=, col_wrap=, labels=, kind=, figure_size=, extents=)`** — a grid
+  of subplots from a 3-D `(N, H, W)` or 4-D `(N, M, H, W)` stack with one shared colour scale
+  and colorbar. Pass `labels=PanelLabels(col=..., row=...)` to title panels by coordinate
+  value instead of the integer slice index.
 - **`animate(..., data_getter=callable)`** — supply each frame lazily (e.g. a NetCDF time
   slab) instead of holding the whole stack in memory.
 - `color_scale` is validated against `cleopatra.styling.styles.ColorScale` (also re-exported as

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,6 +100,7 @@ nav:
   - Home: index.md
   - Installation: installation.md
   - Scope: scope.md
+  - Migration guide: migration.md
   - User Guide:
     - Unstructured meshes: unstructured-mesh-guide.md
     - Glyph architecture: diagrams/glyph-architecture.md

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -4105,7 +4105,7 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         frame_location = frame_label.location
         label_location_is_default = frame_location is None
-        if frame_location is None:
+        if label_location_is_default:
             label_location = [0.02, 0.95]
         else:
             label_location = frame_location

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3651,66 +3651,70 @@ class ArrayGlyph(GeoMixin, Glyph):
         cbar: Colorbar | None = None
         flat_axes = axes.ravel()
 
-        for panel_idx, (col_idx, row_idx) in enumerate(panel_indices):
-            ax = flat_axes[panel_idx]
-            if row is None:
-                panel_arr = arr[col_idx]
-            else:
-                panel_arr = arr[col_idx, row_idx]
+        try:
+            for panel_idx, (col_idx, row_idx) in enumerate(panel_indices):
+                ax = flat_axes[panel_idx]
+                if row is None:
+                    panel_arr = arr[col_idx]
+                else:
+                    panel_arr = arr[col_idx, row_idx]
 
-            if extents is not None:
-                sub_extent = list(extents[panel_idx])
-            elif self.extent is None:
-                sub_extent = None
-            else:
-                sub_extent = [
-                    self.extent[0],  # xmin
-                    self.extent[2],  # ymin
-                    self.extent[1],  # xmax
-                    self.extent[3],  # ymax
-                ]
-            sub = ArrayGlyph(
-                panel_arr,
-                coords=self._coords,
-                extent=sub_extent,
-                fig=fig,
-                ax=ax,
-                **per_subplot_kwargs,
-            )
-            # Route `colorbar=` through `plot` (not the constructor) so the
-            # shared `_apply_kwargs_and_colorbar` logic runs per panel -- it
-            # merges the resolved spec *over* any loose `cbar_*` already folded
-            # into the sub-glyph's options and sets `_style_wants_colorbar`, so
-            # a placement-bearing colorbar overrides a preset swatch here just
-            # as it does on `plot` / `animate`.
-            sub.plot(
-                kind=kind,
-                colorbar=colorbar,
-                color=color,
-                contour=contour,
-                cells=cells,
-                data_style=data_style,
-            )
+                if extents is not None:
+                    sub_extent = list(extents[panel_idx])
+                elif self.extent is None:
+                    sub_extent = None
+                else:
+                    sub_extent = [
+                        self.extent[0],  # xmin
+                        self.extent[2],  # ymin
+                        self.extent[1],  # xmax
+                        self.extent[3],  # ymax
+                    ]
+                sub = ArrayGlyph(
+                    panel_arr,
+                    coords=self._coords,
+                    extent=sub_extent,
+                    fig=fig,
+                    ax=ax,
+                    **per_subplot_kwargs,
+                )
+                # Route `colorbar=` through `plot` (not the constructor) so the
+                # shared `_apply_kwargs_and_colorbar` logic runs per panel -- it
+                # merges the resolved spec *over* any loose `cbar_*` already folded
+                # into the sub-glyph's options and sets `_style_wants_colorbar`, so
+                # a placement-bearing colorbar overrides a preset swatch here just
+                # as it does on `plot` / `animate`.
+                sub.plot(
+                    kind=kind,
+                    colorbar=colorbar,
+                    color=color,
+                    contour=contour,
+                    cells=cells,
+                    data_style=data_style,
+                )
 
-            col_label = col_coords[col_idx] if col_coords is not None else col_idx
-            name_dict: dict[str, Any] = {col: col_label}
-            if row is not None:
-                row_idx = cast(int, row_idx)  # non-None whenever `row` is set
-                row_label = row_coords[row_idx] if row_coords is not None else row_idx
-                name_dict[row] = row_label
-                title = f"{col}={col_label}, {row}={row_label}"
-            else:
-                title = f"{col}={col_label}"
-            ax.set_title(title)
-            name_dicts.append(name_dict)
+                col_label = col_coords[col_idx] if col_coords is not None else col_idx
+                name_dict: dict[str, Any] = {col: col_label}
+                if row is not None:
+                    row_idx = cast(int, row_idx)  # non-None whenever `row` is set
+                    row_label = row_coords[row_idx] if row_coords is not None else row_idx
+                    name_dict[row] = row_label
+                    title = f"{col}={col_label}, {row}={row_label}"
+                else:
+                    title = f"{col}={col_label}"
+                ax.set_title(title)
+                name_dicts.append(name_dict)
 
-            if panel_idx == 0 and getattr(sub, "cbar", None) is not None:
-                cbar = sub.cbar
+                if panel_idx == 0 and getattr(sub, "cbar", None) is not None:
+                    cbar = sub.cbar
 
-        for hidden_idx in range(n_panels, nrows * ncols):
-            flat_axes[hidden_idx].set_visible(False)
+            for hidden_idx in range(n_panels, nrows * ncols):
+                flat_axes[hidden_idx].set_visible(False)
 
-        fig.tight_layout()
+            fig.tight_layout()
+        except Exception:
+            plt.close(fig)
+            raise
         result = FacetGrid(fig=fig, axes=axes, cbar=cbar, name_dicts=name_dicts)
         return result
 

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3458,9 +3458,10 @@ class ArrayGlyph(GeoMixin, Glyph):
                 dimensions, if `labels.col` / `labels.row` lengths
                 are wrong, if `extents` is combined with the parent's
                 `extent` or `coords`, if `extents` has the wrong
-                length or a non-length-4 element, or if the removed
-                `figsize` keyword is passed (it was renamed to
-                `figure_size`).
+                length or a non-length-4 element, or if a removed keyword is
+                passed -- `figsize` (renamed to `figure_size`) or
+                `col_coords` / `row_coords` (replaced by
+                `labels=PanelLabels(...)`).
 
         Examples:
             - Facet a 3-D stack into a 1xN row of subplots:

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3528,6 +3528,11 @@ class ArrayGlyph(GeoMixin, Glyph):
         """
         if col is None and row is None:
             raise ValueError("at least one of `col`/`row` must be given")
+        if "figsize" in kwargs:
+            raise ValueError(
+                "`figsize` is not a valid `facet` argument; it was renamed to "
+                "`figure_size`. Pass `figure_size=(width, height)` instead."
+            )
         labels = labels or PanelLabels()
         col_coords = labels.col
         row_coords = labels.row

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -139,7 +139,7 @@ class _Unset:
     A plain `object()` sentinel would work too, but this gives `help()` /
     IDE signature tooltips a readable `<unset>` instead of
     `<object object at 0x...>` for the option default that uses it (the
-    `hillshade` key resolved inside `ArrayGlyph.plot`).
+    `hillshade` key resolved inside `ArrayGlyph.apply_style`).
     """
 
     def __repr__(self) -> str:
@@ -148,7 +148,7 @@ class _Unset:
 
 #: Sentinel distinguishing "the `hillshade` key was not passed" from
 #: "`hillshade` was passed as `None`" when it is popped from `**kwargs`
-#: (see `ArrayGlyph.plot`), which a plain `.get`/default check cannot.
+#: (see `ArrayGlyph.apply_style`), which a plain `.get`/default check cannot.
 _UNSET = _Unset()
 
 

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3528,13 +3528,19 @@ class ArrayGlyph(GeoMixin, Glyph):
 
                 ```
         """
-        if col is None and row is None:
-            raise ValueError("at least one of `col`/`row` must be given")
         if "figsize" in kwargs:
             raise ValueError(
                 "`figsize` is not a valid `facet` argument; it was renamed to "
                 "`figure_size`. Pass `figure_size=(width, height)` instead."
             )
+        if "col_coords" in kwargs or "row_coords" in kwargs:
+            raise ValueError(
+                "`col_coords` / `row_coords` are no longer valid `facet` "
+                "arguments; pass panel-title labels via "
+                "`labels=PanelLabels(col=..., row=...)` instead."
+            )
+        if col is None and row is None:
+            raise ValueError("at least one of `col`/`row` must be given")
         labels = labels or PanelLabels()
         col_coords = labels.col
         row_coords = labels.row

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -36,6 +36,7 @@ from hpc.indexing import get_indices2
 from matplotlib.animation import FuncAnimation
 from matplotlib.axes import Axes
 from matplotlib.cm import ScalarMappable
+from matplotlib.collections import PathCollection
 from matplotlib.colorbar import Colorbar
 from matplotlib.colors import BoundaryNorm, Colormap, ListedColormap, Normalize
 from matplotlib.figure import Figure
@@ -58,13 +59,9 @@ from cleopatra.glyphs.base.glyph import (
 )
 from cleopatra.glyphs.base.hillshade import resolve_hillshade, shade_grid, shade_rgb
 from cleopatra.styling.colorbar import (
-    _DEPRECATED_CBAR_KWARGS as _DEPRECATED_CBAR_KWARGS,
-)
-from cleopatra.styling.colorbar import (
     ColorBar,
     _resolve_colorbar,
     _swatch_text_default,
-    _warn_deprecated_cbar_kwargs,
 )
 from cleopatra.styling.colors import (
     DATA_STYLES,
@@ -141,121 +138,18 @@ class _Unset:
 
     A plain `object()` sentinel would work too, but this gives `help()` /
     IDE signature tooltips a readable `<unset>` instead of
-    `<object object at 0x...>` for the parameter default that uses it
-    (`ArrayGlyph.animate`'s `cell_value_text_colors`).
+    `<object object at 0x...>` for the option default that uses it (the
+    `hillshade` key resolved inside `ArrayGlyph.plot`).
     """
 
     def __repr__(self) -> str:
         return "<unset>"
 
 
-#: Sentinel default for a renamed parameter whose *real* default is
-#: resolved inside `_resolve_renamed_kwarg` rather than in the method
-#: signature. Distinguishes "caller didn't pass this parameter" from
-#: "caller explicitly passed a value equal to its default" -- an ambiguity
-#: a plain equality-with-default check cannot resolve, which previously
-#: made the "both old and new given" conflict detection silently prefer
-#: the deprecated value in that case (the opposite of the documented
-#: "new wins" behaviour).
+#: Sentinel distinguishing "the `hillshade` key was not passed" from
+#: "`hillshade` was passed as `None`" when it is popped from `**kwargs`
+#: (see `ArrayGlyph.plot`), which a plain `.get`/default check cannot.
 _UNSET = _Unset()
-
-
-def _resolve_renamed_kwarg(
-    kwargs: dict, old_name: str, new_name: str, new_value: Any, default: Any
-) -> Any:
-    """Resolve a renamed keyword argument, honouring its deprecated alias.
-
-    Several `ArrayGlyph.animate` parameters were renamed for clarity
-    (e.g. `text_colors` -> `cell_value_text_colors`). Since the old name is
-    no longer an explicit parameter, a caller still using it arrives here
-    through `**kwargs` instead -- this pops it out, emits a
-    `DeprecationWarning`, and returns its value. Must be called *before*
-    `plot`/`animate` validate `kwargs` against `self.default_options` (the
-    old name is never a valid option key, so it would otherwise raise
-    there instead of being resolved).
-
-    Args:
-        kwargs: The method's `**kwargs` dict; mutated in place (the old
-            key, if present, is popped so it never reaches the strict
-            `default_options` validation).
-        old_name: The deprecated parameter name to look for in `kwargs`.
-        new_name: The current parameter name, used in the warning message.
-        new_value: The value the caller's `new_name` argument resolved to.
-            `new_name`'s own signature default must be the `_UNSET`
-            sentinel (not a concrete value) so this can tell "the caller
-            didn't pass `new_name`" apart from "the caller explicitly
-            passed `new_name` equal to its real default" -- the two cases
-            a plain equality-with-default check cannot distinguish.
-        default: `new_name`'s real default value, substituted when
-            neither name was given.
-
-    Returns:
-        Any: `new_value` when `old_name` is absent from `kwargs`, or when
-            both names were given (new wins, i.e. `new_value` is not
-            `_UNSET`); otherwise the popped `old_name` value, or `default`
-            when neither was given.
-
-    Examples:
-        - The old name is used and a `DeprecationWarning` is raised:
-            ```python
-            >>> import warnings
-            >>> kwargs = {"text_colors": ("yellow", "purple")}
-            >>> with warnings.catch_warnings(record=True) as caught:
-            ...     warnings.simplefilter("always")
-            ...     resolved = _resolve_renamed_kwarg(
-            ...         kwargs, "text_colors", "cell_value_text_colors",
-            ...         _UNSET, ("white", "black"),
-            ...     )
-            >>> resolved
-            ('yellow', 'purple')
-            >>> "text_colors" in kwargs
-            False
-            >>> issubclass(caught[0].category, DeprecationWarning)
-            True
-
-            ```
-        - Both names given: the new one wins even when it is equal to its
-            own default (the false-negative a plain equality check would
-            miss):
-            ```python
-            >>> kwargs = {"text_colors": ("yellow", "purple")}
-            >>> _resolve_renamed_kwarg(
-            ...     kwargs, "text_colors", "cell_value_text_colors",
-            ...     ("white", "black"), ("white", "black"),
-            ... )
-            ('white', 'black')
-
-            ```
-        - With no old-name alias present, the new value passes through
-            untouched and `kwargs` is unaffected:
-            ```python
-            >>> kwargs = {"cmap": "viridis"}
-            >>> _resolve_renamed_kwarg(
-            ...     kwargs, "text_colors", "cell_value_text_colors",
-            ...     ("yellow", "purple"), ("white", "black"),
-            ... )
-            ('yellow', 'purple')
-            >>> kwargs
-            {'cmap': 'viridis'}
-
-            ```
-    """
-    if old_name not in kwargs:
-        return default if new_value is _UNSET else new_value
-    old_value = kwargs.pop(old_name)
-    warnings.warn(
-        f"`{old_name}` is deprecated; use `{new_name}` instead.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-    if new_value is not _UNSET:
-        warnings.warn(
-            f"Both `{old_name}` (deprecated) and `{new_name}` were given; "
-            f"`{new_name}` wins.",
-            stacklevel=3,
-        )
-        return new_value
-    return old_value
 
 
 #: Static typing for the loose **kwargs `plot`/`animate` still accept --
@@ -516,199 +410,75 @@ class FrameLabel:
         self.size = size
 
 
-#: Deprecated `plot`/`animate` kwargs that `_resolve_point_overlay` folds
-#: into a `PointOverlay` instead of the (now-removed) individual keywords.
-#: `pid_color`/`pid_size` are the oldest generation (pre-dating even
-#: `point_label_color`/`point_label_size`) and are honoured too, so the
-#: deprecation chain from either generation still lands on `PointOverlay`.
-_DEPRECATED_POINT_STYLE_KWARGS = (
-    "point_color",
-    "point_size",
-    "point_label_color",
-    "point_label_size",
-    "pid_color",
-    "pid_size",
-)
+class PanelLabels:
+    """Per-panel title labels for the axes of an `ArrayGlyph.facet` grid.
 
+    Bundles the two coordinate-label sequences (`col`, `row`) that `facet`
+    previously accepted as separate `col_coords` / `row_coords` arguments.
+    Pass an instance as `facet(labels=...)` instead of the individual
+    keywords. Each sequence supplies one label per slice along its facet
+    axis; when given, the per-subplot title (and `FacetGrid.name_dicts`)
+    uses that label instead of the integer slice index.
 
-def _pop_first(
-    kwargs: dict, names: tuple[str, ...], default: Any
-) -> tuple[Any, str | None]:
-    """Pop every one of `names` present in `kwargs`; return the most-preferred value.
+    Attributes:
+        col: Labels for the column-facet axis, by default `None` (titles
+            use the integer index). When given, its length must match the
+            column axis size of the stack.
+        row: Labels for the row-facet axis, by default `None`. Only
+            honoured on a 4-D (row+col) facet; when given, its length must
+            match the row axis size.
 
-    All matching keys are removed (not just the winner) so none of them
-    linger to fail the caller's subsequent strict `kwargs` validation --
-    e.g. `plot(points=arr, point_label_color=..., pid_color=...)` must pop
-    both, even though only `point_label_color`'s value is used.
+    Examples:
+        - A bare instance leaves both axes unlabelled (titles fall back to
+            the integer slice index):
+            ```python
+            >>> from cleopatra.glyphs.gridded.array_glyph import PanelLabels
+            >>> labels = PanelLabels()
+            >>> (labels.col, labels.row)
+            (None, None)
 
-    Args:
-        kwargs: Dict to pop from; mutated in place.
-        names: Candidate keys, most-preferred first.
-        default: Value to return if none of `names` are present.
+            ```
+        - Label the columns of a 3-D stack and read them back off the grid:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph, PanelLabels
+            >>> stack = np.arange(3 * 5 * 5, dtype=float).reshape(3, 5, 5)
+            >>> labels = PanelLabels(col=["Jan", "Feb", "Mar"])
+            >>> g = ArrayGlyph(stack).facet(col="month", labels=labels)
+            >>> g.name_dicts[0]
+            {'month': 'Jan'}
 
-    Returns:
-        tuple[Any, str | None]: The most-preferred present value (or
-            `default`), and the key it came from (`None` if none were
-            present).
+            ```
+        - Label both axes of a 4-D stack; each panel's `name_dict` carries
+            the coordinate for both facet dimensions:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph, PanelLabels
+            >>> stack = np.arange(2 * 2 * 4 * 4, dtype=float).reshape(2, 2, 4, 4)
+            >>> labels = PanelLabels(col=["A", "B"], row=[10, 20])
+            >>> g = ArrayGlyph(stack).facet(col="t", row="lev", labels=labels)
+            >>> g.name_dicts[0]
+            {'t': 'A', 'lev': 10}
+
+            ```
     """
-    present = [name for name in names if name in kwargs]
-    values = {name: kwargs.pop(name) for name in present}
-    if not present:
-        return default, None
-    winner = present[0]
-    return values[winner], winner
 
+    def __init__(
+        self,
+        *,
+        col: Sequence[Any] | None = None,
+        row: Sequence[Any] | None = None,
+    ) -> None:
+        """Initialise a `PanelLabels`.
 
-def _resolve_point_overlay(
-    points: np.ndarray | PointOverlay | None, kwargs: dict
-) -> PointOverlay | None:
-    """Normalise `plot`/`animate`'s `points` argument into a `PointOverlay`.
-
-    Accepts the current calling convention (`points` is already a
-    `PointOverlay`, or `None`) as well as two deprecated generations
-    (`points` is a plain array, styled via separate `point_color` /
-    `point_size` / `point_label_color` / `point_label_size` keywords, or
-    the even older `pid_color` / `pid_size` for the label styling) -- any
-    of these emit a `DeprecationWarning` and are folded into a
-    `PointOverlay` here. The deprecated style keys are drained out of
-    `kwargs` even when `points` is `None` (a no-op, matching their
-    pre-`PointOverlay` behaviour as named parameters with defaults) so
-    they never reach the caller's strict `kwargs` validation. Must be
-    called *before* `plot`/`animate` validate `kwargs` against
-    `self.default_options`, which would otherwise reject the deprecated
-    keys outright.
-
-    Args:
-        points: The raw `points` argument as received by `plot`/`animate`:
-            a `PointOverlay`, a plain `(N, 3)` array, or `None`.
-        kwargs: The method's `**kwargs` dict; mutated in place (any
-            deprecated point-style keys are popped out).
-
-    Returns:
-        PointOverlay | None: `points` unchanged if it was already a
-            `PointOverlay` or `None`; otherwise a new `PointOverlay`
-            wrapping the array and the (possibly deprecated) style kwargs.
-    """
-    if isinstance(points, PointOverlay):
-        used_deprecated = [k for k in _DEPRECATED_POINT_STYLE_KWARGS if k in kwargs]
-        if used_deprecated:
-            warnings.warn(
-                f"{used_deprecated} are ignored when `points` is a "
-                "`PointOverlay` -- set them on the `PointOverlay` instance "
-                "instead.",
-                stacklevel=3,
-            )
-            for key in used_deprecated:
-                kwargs.pop(key)
-        return points
-    if points is None:
-        _, color_key = _pop_first(kwargs, ("point_color",), None)
-        _, size_key = _pop_first(kwargs, ("point_size",), None)
-        _, label_color_key = _pop_first(
-            kwargs, ("point_label_color", "pid_color"), None
-        )
-        _, label_size_key = _pop_first(kwargs, ("point_label_size", "pid_size"), None)
-        used = [k for k in (color_key, size_key, label_color_key, label_size_key) if k]
-        if used:
-            warnings.warn(
-                f"{used} have no effect without `points`; pass a "
-                "`cleopatra.glyphs.gridded.array_glyph.PointOverlay` as `points` instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )
-        return None
-    color, color_key = _pop_first(kwargs, ("point_color",), "red")
-    size, size_key = _pop_first(kwargs, ("point_size",), 100)
-    label_color, label_color_key = _pop_first(
-        kwargs, ("point_label_color", "pid_color"), "blue"
-    )
-    label_size, label_size_key = _pop_first(
-        kwargs, ("point_label_size", "pid_size"), 10
-    )
-    used = [k for k in (color_key, size_key, label_color_key, label_size_key) if k]
-    if used:
-        warnings.warn(
-            f"Passing `points` as a plain array together with {used} is "
-            "deprecated; pass a `cleopatra.glyphs.gridded.array_glyph.PointOverlay` instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-    return PointOverlay(
-        points, color=color, size=size, label_color=label_color, label_size=label_size
-    )
-
-
-#: Deprecated `animate` kwargs that `_resolve_frame_label` folds into a
-#: `FrameLabel` instead of the (now-removed) individual keywords.
-#: `text_loc` is the oldest generation (pre-dating `label_location`) and is
-#: honoured too.
-_DEPRECATED_FRAME_LABEL_KWARGS = ("label_location", "label_color", "text_loc")
-
-
-def _resolve_frame_label(frame_label: Any, kwargs: dict) -> FrameLabel:
-    """Normalise `animate`'s `frame_label` argument into a `FrameLabel`.
-
-    Accepts the current calling convention (`frame_label` is already a
-    `FrameLabel`, or `None` for the defaults) as well as two deprecated
-    ones: separate `label_location` / `label_color` keywords (or the even
-    older `text_loc` for the location), and a bare `[x, y]` value at the
-    `frame_label` position itself -- the pre-`FrameLabel` calling shape,
-    still reachable positionally (`animate(time, None, colors, interval,
-    [x, y])`) even though `label_location`/`text_loc` were never
-    positional-only. Any of these emit a `DeprecationWarning` and are
-    folded into a `FrameLabel` here. Unlike `_resolve_point_overlay`, this
-    never returns `None`: `animate` always draws a frame label, so
-    `frame_label=None` means "use `FrameLabel`'s own defaults", not "no
-    label". Must be called *before* `animate` validates `kwargs` against
-    `self.default_options`, which would otherwise reject the deprecated
-    keys outright.
-
-    Args:
-        frame_label: The raw `frame_label` argument as received by
-            `animate`: a `FrameLabel`, `None`, or (deprecated) a plain
-            `[x, y]` value passed positionally.
-        kwargs: The method's `**kwargs` dict; mutated in place (any
-            deprecated frame-label keys are popped out).
-
-    Returns:
-        FrameLabel: `frame_label` unchanged if it was already a
-            `FrameLabel`; otherwise a new `FrameLabel` built from the
-            positional value and/or the (possibly deprecated)
-            location/color kwargs, or the defaults.
-    """
-    if isinstance(frame_label, FrameLabel):
-        used_deprecated = [k for k in _DEPRECATED_FRAME_LABEL_KWARGS if k in kwargs]
-        if used_deprecated:
-            warnings.warn(
-                f"{used_deprecated} are ignored when `frame_label` is a "
-                "`FrameLabel` -- set them on the `FrameLabel` instance "
-                "instead.",
-                stacklevel=3,
-            )
-            for key in used_deprecated:
-                kwargs.pop(key)
-        return frame_label
-    color, color_key = _pop_first(kwargs, ("label_color",), "black")
-    kwarg_location, kwarg_location_key = _pop_first(
-        kwargs, ("label_location", "text_loc"), None
-    )
-    if frame_label is not None:
-        location = frame_label
-        location_keys = ["frame_label (positional)"]
-        if kwarg_location_key:
-            location_keys.append(kwarg_location_key)
-    else:
-        location = kwarg_location
-        location_keys = [kwarg_location_key] if kwarg_location_key else []
-    used = location_keys + ([color_key] if color_key else [])
-    if used:
-        warnings.warn(
-            f"Passing {used} directly is deprecated; pass a "
-            "`cleopatra.glyphs.gridded.array_glyph.FrameLabel` as `frame_label` instead.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
-    return FrameLabel(location=location, color=color)
+        Args:
+            col: Labels for the column-facet axis, by default `None`
+                (titles fall back to the integer slice index).
+            row: Labels for the row-facet axis, by default `None`; only
+                honoured on a 4-D (row+col) facet.
+        """
+        self.col = col
+        self.row = row
 
 
 class FacetGrid:
@@ -820,7 +590,6 @@ class ArrayGlyph(GeoMixin, Glyph):
             that are neither masked (via `exclude_value`) nor NaN. For a
             3-D stack this is counted on the first frame. Equals the number
             of per-cell value labels drawn when `display_cell_value=True`.
-            (The legacy alias `no_elem` still works but is deprecated.)
         anim (matplotlib.animation.FuncAnimation): The animation object if created.
         im (matplotlib.cm.ScalarMappable): The colour-mapped artist produced by
             the most recent `plot`/`animate` call (e.g. the `AxesImage` for
@@ -1210,38 +979,6 @@ class ArrayGlyph(GeoMixin, Glyph):
             value: The new array to store (see the `arr` property).
         """
         self._arr = value
-
-    @property
-    def no_elem(self) -> int:
-        """Deprecated alias for `num_domain_cells`.
-
-        Kept for backward compatibility; emits a `DeprecationWarning`.
-        Will be removed in a future release.
-
-        Returns:
-            int: Same value as `num_domain_cells`.
-
-        Examples:
-            - The deprecated alias returns the same count as
-                `num_domain_cells`:
-                ```python
-                >>> import warnings
-                >>> import numpy as np
-                >>> from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph
-                >>> glyph = ArrayGlyph(np.array([[1.0, 2.0], [3.0, 4.0]]))
-                >>> with warnings.catch_warnings():
-                ...     warnings.simplefilter("ignore")
-                ...     glyph.no_elem == glyph.num_domain_cells
-                True
-
-                ```
-        """
-        warnings.warn(
-            "`ArrayGlyph.no_elem` is deprecated; use `num_domain_cells` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.num_domain_cells
 
     def prepare_array(
         self,
@@ -2396,8 +2133,7 @@ class ArrayGlyph(GeoMixin, Glyph):
             self.default_options["title"], fontsize=self.default_options["title_size"]
         )
         _mark_render_artists(self.ax, self.cbar, self.im)
-        assert self.fig is not None
-        return self.fig, self.ax
+        return cast(Figure, self.fig), self.ax
 
     def _flat_axis_bounds(self) -> tuple[float, float, float, float]:
         """Return the `(x_min, x_max, y_min, y_max)` axis limits of the flat view.
@@ -2842,7 +2578,7 @@ class ArrayGlyph(GeoMixin, Glyph):
 
     def plot(
         self,
-        points: np.ndarray | PointOverlay | None = None,
+        points: PointOverlay | None = None,
         kind: str = "auto",
         ax: Axes | None = None,
         title: str | None = None,
@@ -2863,14 +2599,10 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         Args:
             points: Points to display on the array, by default None. A
-                `PointOverlay` (locations plus marker/label styling), or a
-                plain `(N, 3)` array of `[value, row, col]` per point (a
-                bare array is styled with `PointOverlay`'s own defaults).
-                (Styling `points` via separate `point_color` /
-                `point_size` / `point_label_color` / `point_label_size`
-                keywords is deprecated; pass a `PointOverlay` instead —
-                the old keywords still work as `**kwargs` and emit a
-                `DeprecationWarning`.)
+                `PointOverlay` bundling the `(N, 3)` array of
+                `[value, row, col]` per point together with the marker /
+                value-label styling (`color` / `size` / `label_color` /
+                `label_size`).
             kind: Render kind, by default `"auto"`. One of:
 
                 - `"auto"` — picks the best renderer for the data.
@@ -2995,29 +2727,29 @@ class ArrayGlyph(GeoMixin, Glyph):
                         color bar is skipped (with a warning) even when
                         `add_colorbar` is True, and `self.cbar` stays None.
                     cbar_orientation : str, optional
-                        Deprecated; use `colorbar=ColorBar(orientation=...)`.
+                        Prefer `colorbar=ColorBar(orientation=...)`.
                         Orientation of the color bar, by default 'vertical'.
                         Can be 'horizontal' or 'vertical'.
                     cbar_label_rotation : float, optional
-                        Deprecated; use `colorbar=ColorBar(label_rotation=...)`.
+                        Prefer `colorbar=ColorBar(label_rotation=...)`.
                         Rotation angle (degrees) of the color bar label, by
                         default None (matplotlib's own label orientation).
                     cbar_label_location : str, optional
-                        Deprecated; use `colorbar=ColorBar(label_location=...)`.
+                        Prefer `colorbar=ColorBar(label_location=...)`.
                         Location of the color bar label, by default 'center'.
                         Valid values depend on the bar orientation -- vertical:
                         'top'/'center'/'bottom'; horizontal: 'left'/'center'/'right'.
                     cbar_length : float, optional
-                        Deprecated; use `colorbar=ColorBar(length=...)`. Ratio to
+                        Prefer `colorbar=ColorBar(length=...)`. Ratio to
                         control the height/width of the color bar, by default 0.75.
                     ticks_spacing : int, optional
-                        Deprecated; use `colorbar=ColorBar(ticks_spacing=...)`.
+                        Prefer `colorbar=ColorBar(ticks_spacing=...)`.
                         Spacing between ticks on the color bar, by default 5.
                     cbar_label_size : int, optional
-                        Deprecated; use `colorbar=ColorBar(label_size=...)`. Font
+                        Prefer `colorbar=ColorBar(label_size=...)`. Font
                         size of the color bar label, by default 12.
                     cbar_label : str, optional
-                        Deprecated; use `colorbar=ColorBar(label=...)`. Label text
+                        Prefer `colorbar=ColorBar(label=...)`. Label text
                         for the color bar, by default None.
 
                 Colour scale (moved to the `color=` object):
@@ -3418,9 +3150,6 @@ class ArrayGlyph(GeoMixin, Glyph):
                 f"RGB compositing requires kind='imshow'. Got kind={kind!r}."
             )
 
-        points = _resolve_point_overlay(points, kwargs)  # type: ignore[arg-type]
-        _warn_deprecated_cbar_kwargs(kwargs)
-
         # Snapshot the pre-merge value of every option key these group objects
         # will touch, so an invalid `style` (validated below) can roll back the
         # WHOLE merge -- not just `style` -- and a co-passed color=/contour=/cells=
@@ -3638,10 +3367,9 @@ class ArrayGlyph(GeoMixin, Glyph):
         col: str | None = None,
         row: str | None = None,
         col_wrap: int | None = None,
-        col_coords: Sequence[Any] | None = None,
-        row_coords: Sequence[Any] | None = None,
+        labels: PanelLabels | None = None,
         kind: str = "auto",
-        figsize: tuple[float, float] | None = None,
+        figure_size: tuple[float, float] | None = None,
         extents: Sequence[Sequence[float]] | None = None,
         colorbar: bool | ColorBar | None = None,
         color: ColorScaling | None = None,
@@ -3681,17 +3409,17 @@ class ArrayGlyph(GeoMixin, Glyph):
             col_wrap: When only `col` is given, wrap the N subplots
                 into `col_wrap` columns × `ceil(N/col_wrap)` rows.
                 Ignored when `row` is set.
-            col_coords: Optional sequence of coordinate labels for the
-                column dimension. Length must match the column axis of
-                the stack. When given, the per-subplot title contains
-                the coord value instead of the integer index.
-            row_coords: Optional sequence of coordinate labels for the
-                row dimension. Length must match the row axis of the
-                stack. Only honoured when `row` is set.
+            labels: Optional `PanelLabels` supplying per-panel title
+                labels for the facet axes (`labels.col` / `labels.row`).
+                Each sequence's length must match its axis size; when
+                given, the per-subplot title contains the label instead of
+                the integer index. `labels.row` is only honoured when
+                `row` is set. `None` (default) titles every panel with its
+                integer slice index.
             kind: Render kind, forwarded to the per-subplot dispatch.
                 One of `"auto"`, `"imshow"`, `"pcolormesh"`,
                 `"contour"`, `"contourf"`. Default `"auto"`.
-            figsize: Optional `(width, height)` for the shared figure.
+            figure_size: Optional `(width, height)` for the shared figure.
                 Defaults to `(4 * ncols, 3.5 * nrows)`.
             extents: Optional per-panel spatial extents — one
                 `[xmin, ymin, xmax, ymax]` (user-facing order) for each
@@ -3712,14 +3440,13 @@ class ArrayGlyph(GeoMixin, Glyph):
                 placement / caption / sizing to every panel (so the
                 `result.cbar` returned -- the first panel's -- carries the
                 spec). Prefer this typed form over the loose `cbar_*`
-                kwargs, which are deprecated here as they are on
-                `plot` / `animate`.
+                kwargs, here as on `plot` / `animate`.
 
             **kwargs: Forwarded to each subplot. Recognised keys
                 include the same colour / colorbar / level kwargs as
                 `plot`. `vmin` / `vmax` win over the
-                stack-wide auto-computed limits. Passing the loose
-                `cbar_*` colorbar kwargs is deprecated -- use `colorbar`.
+                stack-wide auto-computed limits. Prefer the typed
+                `colorbar` over the loose `cbar_*` kwargs.
 
         Returns:
             FacetGrid: Result object exposing `fig`, `axes`,
@@ -3728,7 +3455,7 @@ class ArrayGlyph(GeoMixin, Glyph):
         Raises:
             ValueError: If neither `col` nor `row` is given, if the
                 array shape does not match the requested facet
-                dimensions, if `col_coords` / `row_coords` lengths
+                dimensions, if `labels.col` / `labels.row` lengths
                 are wrong, if `extents` is combined with the parent's
                 `extent` or `coords`, or if `extents` has the wrong
                 length or a non-length-4 element.
@@ -3754,6 +3481,22 @@ class ArrayGlyph(GeoMixin, Glyph):
                 >>> g = ArrayGlyph(stack).facet(col="t", col_wrap=3)
                 >>> g.axes.shape
                 (2, 3)
+
+                ```
+            - Title each panel with a coordinate label via `PanelLabels`:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.glyphs.gridded.array_glyph import (
+                ...     ArrayGlyph,
+                ...     PanelLabels,
+                ... )
+                >>> stack = np.arange(3 * 5 * 5, dtype=float).reshape(3, 5, 5)
+                >>> g = ArrayGlyph(stack).facet(
+                ...     col="month",
+                ...     labels=PanelLabels(col=["Jan", "Feb", "Mar"]),
+                ... )
+                >>> [d["month"] for d in g.name_dicts]
+                ['Jan', 'Feb', 'Mar']
 
                 ```
             - Per-panel extents for same-shape grids over different
@@ -3785,6 +3528,9 @@ class ArrayGlyph(GeoMixin, Glyph):
         """
         if col is None and row is None:
             raise ValueError("at least one of `col`/`row` must be given")
+        labels = labels or PanelLabels()
+        col_coords = labels.col
+        row_coords = labels.row
         if extents is not None:
             if self.extent is not None:
                 raise ValueError(
@@ -3820,7 +3566,7 @@ class ArrayGlyph(GeoMixin, Glyph):
                 nrows = 1
             if col_coords is not None and len(col_coords) != n_col:
                 raise ValueError(
-                    f"`col_coords` length {len(col_coords)} does not match "
+                    f"`labels.col` length {len(col_coords)} does not match "
                     f"the column axis size {n_col}."
                 )
             panel_indices: list[tuple[int, int | None]] = [
@@ -3840,12 +3586,12 @@ class ArrayGlyph(GeoMixin, Glyph):
             nrows = n_row
             if col_coords is not None and len(col_coords) != n_col:
                 raise ValueError(
-                    f"`col_coords` length {len(col_coords)} does not match "
+                    f"`labels.col` length {len(col_coords)} does not match "
                     f"the column axis size {n_col}."
                 )
             if row_coords is not None and len(row_coords) != n_row:
                 raise ValueError(
-                    f"`row_coords` length {len(row_coords)} does not match "
+                    f"`labels.row` length {len(row_coords)} does not match "
                     f"the row axis size {n_row}."
                 )
             panel_indices = [(i, j) for j in range(n_row) for i in range(n_col)]
@@ -3856,16 +3602,12 @@ class ArrayGlyph(GeoMixin, Glyph):
                 f"`extents` has {len(extents)} entries but there are {n_panels} panels."
             )
 
-        assert col is not None
+        col = cast(str, col)  # guaranteed non-None by the validation above
 
-        # Warn only after the structural validation above, so a malformed call
-        # raises its `ValueError` without a spurious colorbar DeprecationWarning.
-        _warn_deprecated_cbar_kwargs(kwargs)
-
-        if figsize is None:
-            figsize = (4.0 * ncols, 3.5 * nrows)
+        if figure_size is None:
+            figure_size = (4.0 * ncols, 3.5 * nrows)
         fig, axes = plt.subplots(
-            nrows=nrows, ncols=ncols, figsize=figsize, squeeze=False
+            nrows=nrows, ncols=ncols, figsize=figure_size, squeeze=False
         )
 
         vmin_user = kwargs.get("vmin")
@@ -3940,7 +3682,7 @@ class ArrayGlyph(GeoMixin, Glyph):
             col_label = col_coords[col_idx] if col_coords is not None else col_idx
             name_dict: dict[str, Any] = {col: col_label}
             if row is not None:
-                assert row_idx is not None
+                row_idx = cast(int, row_idx)  # non-None whenever `row` is set
                 row_label = row_coords[row_idx] if row_coords is not None else row_idx
                 name_dict[row] = row_label
                 title = f"{col}={col_label}, {row}={row_label}"
@@ -3998,8 +3740,8 @@ class ArrayGlyph(GeoMixin, Glyph):
     def animate(
         self,
         time: list[Any],
-        points: np.ndarray | PointOverlay | None = None,
-        cell_value_text_colors: tuple[str, str] | _Unset = _UNSET,
+        points: PointOverlay | None = None,
+        cell_value_text_colors: tuple[str, str] = ("white", "black"),
         interval: int = 200,
         frame_label: FrameLabel | None = None,
         *,
@@ -4038,21 +3780,15 @@ class ArrayGlyph(GeoMixin, Glyph):
                 These could be timestamps, frame numbers, or any other identifiers.
                 The length of this list should match the first dimension of the array.
             points: Points to display on the array, by default None. A
-                `PointOverlay` (locations plus marker/label styling), or a
-                plain `(N, 3)` array of `[value, row, col]` per point (a
-                bare array is styled with `PointOverlay`'s own defaults).
-                (Styling `points` via separate `point_color` /
-                `point_size` / `point_label_color` / `point_label_size`
-                keywords is deprecated; pass a `PointOverlay` instead —
-                the old keywords still work as `**kwargs` and emit a
-                `DeprecationWarning`.)
+                `PointOverlay` bundling the `(N, 3)` array of
+                `[value, row, col]` per point together with the marker /
+                value-label styling (`color` / `size` / `label_color` /
+                `label_size`).
             cell_value_text_colors: Two colors to be used for cell value
                 text, by default ("white", "black"). The first color is
                 used when the cell value is below the
                 background_color_threshold, and the second color is used
-                when the cell value is above the threshold. (Renamed from
-                `text_colors`; the old name still works as a keyword and
-                emits a `DeprecationWarning`.)
+                when the cell value is above the threshold.
             interval: Delay between frames in milliseconds, by default 200.
                 Controls the speed of the animation (smaller values = faster animation).
             frame_label: Styling for the per-frame time label, by default
@@ -4061,11 +3797,6 @@ class ArrayGlyph(GeoMixin, Glyph):
                 `location`/`color` fields and the top-left anchoring
                 behaviour when `location` is left unset. `ArrayGlyph`-only;
                 `MeshGlyph.animate()` does not yet expose this option.
-                (Styling the frame label via separate `label_location` /
-                `label_color` keywords — or the even older `text_loc` for
-                the location — is deprecated; pass a `FrameLabel` instead —
-                the old keywords still work as `**kwargs` and emit a
-                `DeprecationWarning`.)
             color: Colour-scale group object
                 (`cleopatra.styling.scaling.ColorScaling`), e.g.
                 `ColorScaling.power(gamma=0.7)`. Replaces the loose
@@ -4162,29 +3893,29 @@ class ArrayGlyph(GeoMixin, Glyph):
                         None and no axes space is taken by a color bar.
                         The mappable is still reachable via `self.im`.
                     cbar_orientation : str, optional
-                        Deprecated; use `colorbar=ColorBar(orientation=...)`.
+                        Prefer `colorbar=ColorBar(orientation=...)`.
                         Orientation of the color bar, by default 'vertical'.
                         Can be 'horizontal' or 'vertical'.
                     cbar_label_rotation : float, optional
-                        Deprecated; use `colorbar=ColorBar(label_rotation=...)`.
+                        Prefer `colorbar=ColorBar(label_rotation=...)`.
                         Rotation angle (degrees) of the color bar label, by
                         default None (matplotlib's own label orientation).
                     cbar_label_location : str, optional
-                        Deprecated; use `colorbar=ColorBar(label_location=...)`.
+                        Prefer `colorbar=ColorBar(label_location=...)`.
                         Location of the color bar label, by default 'center'.
                         Valid values depend on the bar orientation -- vertical:
                         'top'/'center'/'bottom'; horizontal: 'left'/'center'/'right'.
                     cbar_length : float, optional
-                        Deprecated; use `colorbar=ColorBar(length=...)`. Ratio to
+                        Prefer `colorbar=ColorBar(length=...)`. Ratio to
                         control the height/width of the color bar, by default 0.75.
                     ticks_spacing : int, optional
-                        Deprecated; use `colorbar=ColorBar(ticks_spacing=...)`.
+                        Prefer `colorbar=ColorBar(ticks_spacing=...)`.
                         Spacing between ticks on the color bar, by default 5.
                     cbar_label_size : int, optional
-                        Deprecated; use `colorbar=ColorBar(label_size=...)`. Font
+                        Prefer `colorbar=ColorBar(label_size=...)`. Font
                         size of the color bar label, by default 12.
                     cbar_label : str, optional
-                        Deprecated; use `colorbar=ColorBar(label=...)`. Label text
+                        Prefer `colorbar=ColorBar(label=...)`. Label text
                         for the color bar, by default None.
 
                 Grouped options (moved off `**kwargs`):
@@ -4365,26 +4096,13 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         ```
         """
-        cell_value_text_colors = cast(
-            "tuple[str, str]",
-            _resolve_renamed_kwarg(
-                kwargs,  # type: ignore[arg-type]
-                "text_colors",
-                "cell_value_text_colors",
-                cell_value_text_colors,
-                ("white", "black"),
-            ),
-        )
-        frame_label = _resolve_frame_label(frame_label, kwargs)  # type: ignore[arg-type]
-        points = _resolve_point_overlay(points, kwargs)  # type: ignore[arg-type]
-        _warn_deprecated_cbar_kwargs(kwargs)
+        frame_label = frame_label or FrameLabel()
 
         frame_location = frame_label.location
         label_location_is_default = frame_location is None
-        if label_location_is_default:
+        if frame_location is None:
             label_location = [0.02, 0.95]
         else:
-            assert frame_location is not None
             label_location = frame_location
 
         self._merge_group_params(color, contour, cells, data_style)
@@ -4708,9 +4426,9 @@ class ArrayGlyph(GeoMixin, Glyph):
             output = [im, day_text]
 
             if points is not None:
-                assert points_scatter is not None
-                points_scatter.set_offsets(np.c_[col, row])
-                output.append(points_scatter)
+                scatter = cast(PathCollection, points_scatter)  # set when points given
+                scatter.set_offsets(np.c_[col, row])
+                output.append(scatter)
                 update_points = lambda x: points_id[x].set_text(points.points[x, 0])
                 list(map(update_points, range(len(col))))
 
@@ -4732,9 +4450,9 @@ class ArrayGlyph(GeoMixin, Glyph):
             output = [im, day_text]
 
             if points is not None:
-                assert points_scatter is not None
-                points_scatter.set_offsets(np.c_[col, row])
-                output.append(points_scatter)
+                scatter = cast(PathCollection, points_scatter)  # set when points given
+                scatter.set_offsets(np.c_[col, row])
+                output.append(scatter)
 
                 for x in range(len(col)):
                     points_id[x].set_text(points.points[x, 0])

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -3457,8 +3457,10 @@ class ArrayGlyph(GeoMixin, Glyph):
                 array shape does not match the requested facet
                 dimensions, if `labels.col` / `labels.row` lengths
                 are wrong, if `extents` is combined with the parent's
-                `extent` or `coords`, or if `extents` has the wrong
-                length or a non-length-4 element.
+                `extent` or `coords`, if `extents` has the wrong
+                length or a non-length-4 element, or if the removed
+                `figsize` keyword is passed (it was renamed to
+                `figure_size`).
 
         Examples:
             - Facet a 3-D stack into a 1xN row of subplots:

--- a/src/cleopatra/glyphs/gridded/mesh_glyph.py
+++ b/src/cleopatra/glyphs/gridded/mesh_glyph.py
@@ -56,7 +56,6 @@ from cleopatra.glyphs.base.hillshade import resolve_hillshade, shade_faces
 from cleopatra.styling.colorbar import (
     ColorBar,
     _resolve_colorbar,
-    _warn_deprecated_cbar_kwargs,
 )
 from cleopatra.styling.colors import (
     category_boundaries,
@@ -916,8 +915,8 @@ class MeshGlyph(GeoMixin, Glyph):
             **kwargs: Construction-time-style overrides for the non-grouped
                 `default_options` (`cmap`, `vmin`, `vmax`, `title_size`,
                 `figsize`, …). The loose `ticks_spacing` / `cbar_*` keys
-                still work but are deprecated -- pass `colorbar=ColorBar(...)`
-                instead. The colour-scale, discretisation/label, and
+                still work, but prefer `colorbar=ColorBar(...)`.
+                The colour-scale, discretisation/label, and
                 preset/relief options moved onto the `color=` / `contour=` /
                 `data_style=` group objects above; passing any of them as a
                 loose keyword now raises.
@@ -1050,7 +1049,6 @@ class MeshGlyph(GeoMixin, Glyph):
                 render_kwargs[key] = val
         self._merge_kwargs(option_kwargs)
         self._merge_group_params(color, contour, data_style)
-        _warn_deprecated_cbar_kwargs(kwargs)
         resolved_colorbar = (
             _resolve_colorbar(colorbar) if isinstance(colorbar, ColorBar) else {}
         )
@@ -1244,8 +1242,7 @@ class MeshGlyph(GeoMixin, Glyph):
             **kwargs: Override any key in `default_options` (cmap,
                 vmin, vmax, color_scale, gamma, midpoint, figsize,
                 title, etc.). The loose `ticks_spacing` / `cbar_*` keys
-                still work but are deprecated -- pass
-                `colorbar=ColorBar(...)` instead.
+                still work, but prefer `colorbar=ColorBar(...)`.
 
         Returns:
             FuncAnimation: The animation object. Use
@@ -1299,7 +1296,6 @@ class MeshGlyph(GeoMixin, Glyph):
         self._default_options = MESH_DEFAULT_OPTIONS.copy()
         self._merge_kwargs(kwargs)
         self._merge_group_params(color, contour, data_style)
-        _warn_deprecated_cbar_kwargs(kwargs)
         resolved_colorbar = (
             _resolve_colorbar(colorbar) if isinstance(colorbar, ColorBar) else {}
         )

--- a/src/cleopatra/glyphs/gridded/vector_glyph.py
+++ b/src/cleopatra/glyphs/gridded/vector_glyph.py
@@ -46,7 +46,6 @@ from cleopatra.glyphs.base.glyph import (
 from cleopatra.styling.colorbar import (
     ColorBar,
     _resolve_colorbar,
-    _warn_deprecated_cbar_kwargs,
 )
 from cleopatra.styling.colors import resolve_colormap
 from cleopatra.styling.params import Classify, Contour
@@ -130,7 +129,6 @@ class VectorGlyph(GeoMixin, Glyph):
         fig: Figure | None = None,
         **kwargs,
     ):
-        _warn_deprecated_cbar_kwargs(kwargs)
         super().__init__(
             default_options=VECTOR_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
         )

--- a/src/cleopatra/glyphs/primitives/flow_glyph.py
+++ b/src/cleopatra/glyphs/primitives/flow_glyph.py
@@ -45,7 +45,6 @@ from cleopatra.glyphs.base.glyph import Glyph, _root_figure
 from cleopatra.styling.colorbar import (
     ColorBar,
     _resolve_colorbar,
-    _warn_deprecated_cbar_kwargs,
 )
 from cleopatra.styling.colors import resolve_colormap, resolve_glow_options
 from cleopatra.styling.params import Classify, Contour
@@ -164,7 +163,6 @@ class FlowGlyph(GeoMixin, Glyph):
         fig: Figure | None = None,
         **kwargs,
     ):
-        _warn_deprecated_cbar_kwargs(kwargs)
         super().__init__(default_options=FLOW_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs)
         self.paths = [np.asarray(p, dtype=float) for p in paths]
         n_paths = len(self.paths)

--- a/src/cleopatra/glyphs/primitives/polygon_glyph.py
+++ b/src/cleopatra/glyphs/primitives/polygon_glyph.py
@@ -49,7 +49,6 @@ from cleopatra.glyphs.base.glyph import Glyph, _root_figure
 from cleopatra.styling.colorbar import (
     ColorBar,
     _resolve_colorbar,
-    _warn_deprecated_cbar_kwargs,
 )
 from cleopatra.styling.colors import resolve_colormap
 from cleopatra.styling.params import Classify, Contour
@@ -146,7 +145,6 @@ class PolygonGlyph(GeoMixin, Glyph):
         fig: Figure | None = None,
         **kwargs,
     ):
-        _warn_deprecated_cbar_kwargs(kwargs)
         super().__init__(
             default_options=POLYGON_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
         )

--- a/src/cleopatra/glyphs/primitives/scatter_glyph.py
+++ b/src/cleopatra/glyphs/primitives/scatter_glyph.py
@@ -46,7 +46,6 @@ from cleopatra.glyphs.base.glyph import Glyph, _root_figure
 from cleopatra.styling.colorbar import (
     ColorBar,
     _resolve_colorbar,
-    _warn_deprecated_cbar_kwargs,
 )
 from cleopatra.styling.colors import resolve_colormap
 from cleopatra.styling.params import Classify, Contour
@@ -178,7 +177,6 @@ class ScatterGlyph(GeoMixin, Glyph):
         fig: Figure | None = None,
         **kwargs,
     ):
-        _warn_deprecated_cbar_kwargs(kwargs)
         super().__init__(
             default_options=SCATTER_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs
         )

--- a/src/cleopatra/glyphs/stats/kde_glyph.py
+++ b/src/cleopatra/glyphs/stats/kde_glyph.py
@@ -46,7 +46,6 @@ from cleopatra.glyphs.base.hillshade import resolve_hillshade, shade_grid
 from cleopatra.styling.colorbar import (
     ColorBar,
     _resolve_colorbar,
-    _warn_deprecated_cbar_kwargs,
 )
 from cleopatra.styling.colors import (
     resolve_colormap,
@@ -158,7 +157,6 @@ class KDEGlyph(Glyph):
         fig: Figure | None = None,
         **kwargs,
     ):
-        _warn_deprecated_cbar_kwargs(kwargs)
         super().__init__(default_options=KDE_DEFAULT_OPTIONS, fig=fig, ax=ax, **kwargs)
         self.x = np.asarray(x, dtype=float)
         self.y = np.asarray(y, dtype=float)

--- a/src/cleopatra/styling/colorbar.py
+++ b/src/cleopatra/styling/colorbar.py
@@ -3,8 +3,7 @@
 `ColorBar` bundles the colorbar layout / caption / sizing choices into one value
 passed as `plot(colorbar=...)` / `animate(colorbar=...)`. `_resolve_colorbar`
 maps it onto the internal `cbar_*` / `ticks_spacing` options that the base
-`Glyph.create_color_bar` renders, and `_warn_deprecated_cbar_kwargs` steers
-callers off the loose `cbar_*` kwargs it supersedes.
+`Glyph.create_color_bar` renders.
 
 Kept in its own module (rather than in any single glyph) so every glyph type can
 import it without depending on `array_glyph`. `cleopatra.glyphs.gridded.array_glyph` re-exports
@@ -350,40 +349,3 @@ def _resolve_colorbar(colorbar: bool | ColorBar | None) -> dict:
     raise TypeError(
         f"colorbar must be a bool, ColorBar, or None, got {type(colorbar).__name__}."
     )
-
-
-#: Loose colorbar kwargs now superseded by `ColorBar` fields (issue #234).
-#: Passing any of these to `plot` / `animate` is deprecated -- use the mapped
-#: `ColorBar` field instead. This set includes the non-`cbar_`-prefixed
-#: `ticks_spacing`, deprecated in favour of `ColorBar(ticks_spacing=...)`, not
-#: only the `cbar_*` keys. They still take effect (folded into
-#: `default_options`) so nothing breaks during the deprecation window.
-_DEPRECATED_CBAR_KWARGS = {
-    "cbar_label": "label",
-    "cbar_length": "length",
-    "cbar_label_size": "label_size",
-    "cbar_label_rotation": "label_rotation",
-    "cbar_label_location": "label_location",
-    "cbar_orientation": "orientation",
-    "ticks_spacing": "ticks_spacing",
-}
-
-
-def _warn_deprecated_cbar_kwargs(kwargs: dict) -> None:
-    """Warn for any loose `cbar_*` kwarg that a `ColorBar` field now replaces.
-
-    The kwargs still take effect (the caller folds them into `default_options`);
-    this only steers callers toward the typed `colorbar=ColorBar(...)` spec.
-
-    Args:
-        kwargs: The `plot` / `animate` keyword arguments to inspect for the
-            deprecated loose colorbar keys.
-    """
-    for key, field in _DEPRECATED_CBAR_KWARGS.items():
-        if key in kwargs:
-            warnings.warn(
-                f"The '{key}' keyword is deprecated; pass "
-                f"colorbar=ColorBar({field}=...) instead.",
-                DeprecationWarning,
-                stacklevel=3,
-            )

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -1881,6 +1881,25 @@ class TestAnimateEdgeCases:
             f"loose kwarg should still work in animate, got {glyph.cbar.orientation}"
         )
 
+    def test_animate_invalid_cbar_orientation_raises(
+        self,
+        coello_data: np.ndarray,
+        animate_time_list: list,
+        no_data_value: float,
+    ):
+        """An invalid loose `cbar_orientation` value still raises at render.
+
+        Test scenario:
+            The loose `cbar_*` kwargs survive (only their deprecation warning
+            was removed), so their render-time validation must still reject a
+            bad orientation with an actionable `ValueError`.
+        """
+        glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
+        with pytest.raises(
+            ValueError, match="cbar_orientation must be 'vertical' or 'horizontal'"
+        ):
+            glyph.animate(animate_time_list, cbar_orientation="horizontl")
+
     def test_data_getter_is_keyword_only(
         self,
         coello_data: np.ndarray,

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3782,6 +3782,20 @@ class TestFacetingEdgeCases:
             glyph.facet(col="t", **{kwarg: [0, 1, 2]})
         assert len(plt.get_fignums()) == n_before, "no figure should be created on the error path"
 
+    def test_facet_bad_forwarded_kwarg_does_not_leak_figure(self) -> None:
+        """A sub-glyph kwarg rejected mid-loop closes the facet figure.
+
+        Test scenario:
+            An unknown forwarded kwarg is only caught once the first
+            sub-`ArrayGlyph` is built -- after `plt.subplots`. `facet` must
+            close that figure on the exception rather than orphaning it.
+        """
+        glyph = ArrayGlyph(self._stack(n=3))
+        n_before = len(plt.get_fignums())
+        with pytest.raises(ValueError):
+            glyph.facet(col="t", definitely_not_a_real_kwarg=1)
+        assert len(plt.get_fignums()) == n_before, "the facet figure must be closed on error"
+
     def test_facet_with_extent_propagates_to_subplots(self) -> None:
         """A parent `extent` propagates to each sub-glyph during faceting.
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3712,6 +3712,19 @@ class TestFacetingEdgeCases:
         finally:
             plt.close(result.fig)
 
+    def test_facet_stale_figsize_raises(self) -> None:
+        """The renamed `figsize` keyword is rejected loudly, not silently dropped.
+
+        Test scenario:
+            `figsize` is still a valid glyph option, so without a guard it
+            would be absorbed into `default_options` with no effect. `facet`
+            must instead raise a `ValueError` steering the caller to
+            `figure_size`.
+        """
+        glyph = ArrayGlyph(self._stack(n=3))
+        with pytest.raises(ValueError, match="renamed to `figure_size`"):
+            glyph.facet(col="t", figsize=(12.0, 4.0))
+
     def test_facet_with_extent_propagates_to_subplots(self) -> None:
         """A parent `extent` propagates to each sub-glyph during faceting.
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3764,6 +3764,24 @@ class TestFacetingEdgeCases:
         with pytest.raises(ValueError, match="renamed to `figure_size`"):
             glyph.facet(col="t", figsize=(12.0, 4.0))
 
+    @pytest.mark.parametrize("kwarg", ["col_coords", "row_coords"])
+    def test_facet_stale_coords_raise_pointing_to_panel_labels(self, kwarg) -> None:
+        """Removed `col_coords`/`row_coords` raise a targeted error, not a deep one.
+
+        Args:
+            kwarg: The removed coordinate-label keyword under test.
+
+        Test scenario:
+            Both were replaced by `labels=PanelLabels(...)`; `facet` must
+            reject them up front with a message naming `PanelLabels`, rather
+            than failing deep in the per-panel loop.
+        """
+        glyph = ArrayGlyph(self._stack(n=3))
+        n_before = len(plt.get_fignums())
+        with pytest.raises(ValueError, match="labels=PanelLabels"):
+            glyph.facet(col="t", **{kwarg: [0, 1, 2]})
+        assert len(plt.get_fignums()) == n_before, "no figure should be created on the error path"
+
     def test_facet_with_extent_propagates_to_subplots(self) -> None:
         """A parent `extent` propagates to each sub-glyph during faceting.
 

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -3499,24 +3499,27 @@ class TestFacetingEdgeCases:
         """`labels.col` whose length differs from N raises `ValueError`."""
         stack = self._stack(n=4)
         labels = PanelLabels(col=[0, 1, 2])
+        glyph = ArrayGlyph(stack)
         with pytest.raises(ValueError, match="`labels.col` length"):
-            ArrayGlyph(stack).facet(col="t", labels=labels)
+            glyph.facet(col="t", labels=labels)
 
     def test_labels_col_length_mismatch_4d_raises(self) -> None:
         """`labels.col` length wrong on a 4-D stack raises."""
         rng = np.random.default_rng(1337)
         stack = rng.uniform(0.0, 1.0, size=(2, 3, 4, 4))
         labels = PanelLabels(col=[0])
+        glyph = ArrayGlyph(stack)
         with pytest.raises(ValueError, match="`labels.col` length"):
-            ArrayGlyph(stack).facet(col="t", row="lev", labels=labels)
+            glyph.facet(col="t", row="lev", labels=labels)
 
     def test_labels_row_length_mismatch_raises(self) -> None:
         """`labels.row` whose length differs from Nrow raises."""
         rng = np.random.default_rng(1337)
         stack = rng.uniform(0.0, 1.0, size=(2, 3, 4, 4))
         labels = PanelLabels(col=[0, 1], row=[0])
+        glyph = ArrayGlyph(stack)
         with pytest.raises(ValueError, match="`labels.row` length"):
-            ArrayGlyph(stack).facet(col="t", row="lev", labels=labels)
+            glyph.facet(col="t", row="lev", labels=labels)
 
     def test_shared_vmin_vmax_global_min_max(self) -> None:
         """Stack-wide `vmin`/`vmax` reflect the *global* min/max across frames.

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -260,6 +260,18 @@ class TestPlotArray:
 
         assert isinstance(fig, Figure)
 
+    def test_plot_bare_array_points_raises(self, arr: np.ndarray, no_data_value: float):
+        """A bare `(N, 3)` array for `points` is no longer auto-wrapped.
+
+        Test scenario:
+            The auto-wrap shim was removed, so on an overlay-drawing kind the
+            bare array's missing `.points` attribute surfaces as `AttributeError`
+            -- callers must pass a `PointOverlay`.
+        """
+        array = ArrayGlyph(arr, exclude_value=[no_data_value])
+        with pytest.raises(AttributeError):
+            array.plot(points=np.array([[5.0, 1, 1]]), kind="imshow")
+
 
 class TestAnimate:
     def test_numpy_array(

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2877,8 +2877,9 @@ class TestFacetColorbar:
             `TypeError` rather than silently ignoring the argument.
         """
         glyph = ArrayGlyph(self._stack_3d())
+        labels = PanelLabels(col=[0, 1, 2])
         with pytest.raises(TypeError, match="colorbar must be a bool"):
-            glyph.facet(col="time", labels=PanelLabels(col=[0, 1, 2]), colorbar=object())
+            glyph.facet(col="time", labels=labels, colorbar=object())
 
     def test_facet_4d_accepts_colorbar_spec(self):
         """The `ColorBar` spec also works on a 4-D (`col` + `row`) facet.
@@ -3497,24 +3498,25 @@ class TestFacetingEdgeCases:
     def test_labels_col_length_mismatch_raises(self) -> None:
         """`labels.col` whose length differs from N raises `ValueError`."""
         stack = self._stack(n=4)
+        labels = PanelLabels(col=[0, 1, 2])
         with pytest.raises(ValueError, match="`labels.col` length"):
-            ArrayGlyph(stack).facet(col="t", labels=PanelLabels(col=[0, 1, 2]))
+            ArrayGlyph(stack).facet(col="t", labels=labels)
 
     def test_labels_col_length_mismatch_4d_raises(self) -> None:
         """`labels.col` length wrong on a 4-D stack raises."""
         rng = np.random.default_rng(1337)
         stack = rng.uniform(0.0, 1.0, size=(2, 3, 4, 4))
+        labels = PanelLabels(col=[0])
         with pytest.raises(ValueError, match="`labels.col` length"):
-            ArrayGlyph(stack).facet(col="t", row="lev", labels=PanelLabels(col=[0]))
+            ArrayGlyph(stack).facet(col="t", row="lev", labels=labels)
 
     def test_labels_row_length_mismatch_raises(self) -> None:
         """`labels.row` whose length differs from Nrow raises."""
         rng = np.random.default_rng(1337)
         stack = rng.uniform(0.0, 1.0, size=(2, 3, 4, 4))
+        labels = PanelLabels(col=[0, 1], row=[0])
         with pytest.raises(ValueError, match="`labels.row` length"):
-            ArrayGlyph(stack).facet(
-                col="t", row="lev", labels=PanelLabels(col=[0, 1], row=[0])
-            )
+            ArrayGlyph(stack).facet(col="t", row="lev", labels=labels)
 
     def test_shared_vmin_vmax_global_min_max(self) -> None:
         """Stack-wide `vmin`/`vmax` reflect the *global* min/max across frames.

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -417,6 +417,26 @@ class TestKwargsTypedDicts:
         }
         assert cell_texts == {"1.2", "2.3", "3.5", "4.6"}
 
+    def test_cell_value_text_colors_split_by_threshold(self):
+        """`cell_value_text_colors` picks the text colour by the threshold split.
+
+        Test scenario:
+            With a normalized `background_threshold` of 0.5, the low cell
+            (norm 0) uses the first colour and the high cell (norm 1) uses
+            the second.
+        """
+        stack = np.stack([np.array([[0.0, 10.0]]), np.array([[0.0, 10.0]])])
+        array = ArrayGlyph(stack)
+        array.animate(
+            list(range(2)),
+            cells=CellValues(show=True, background_threshold=0.5),
+            cell_value_text_colors=("yellow", "blue"),
+        )
+        array.anim._func(0)
+        colors = {to_rgba(t.get_color()) for t in array.ax.texts if t.get_text()}
+        assert to_rgba("yellow") in colors, f"low cell should be yellow; got {colors}"
+        assert to_rgba("blue") in colors, f"high cell should be blue; got {colors}"
+
 
 class TestUnsetSentinel:
     """`_Unset`/`_UNSET`: the sentinel distinguishing "the caller did not

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -17,17 +17,17 @@ from cleopatra.glyphs.gridded.array_glyph import (
     _COORD_DTYPE_MISMATCH,
     _COORD_SHAPE_MISMATCH,
     _UNSET,
+    _Unset,
     AnimateKwargs,
     ArrayGlyph,
     ColorBar,
     FacetGrid,
     FrameLabel,
+    PanelLabels,
     PlotKwargs,
     PointOverlay,
-    _pop_first,
     _resolve_colorbar,
     _swatch_text_default,
-    _warn_deprecated_cbar_kwargs,
 )
 from cleopatra.styling.params import CellValues, Contour, DataStyle
 from cleopatra.styling.scaling import ColorScaling
@@ -50,13 +50,6 @@ class TestCreateArray:
         assert array.num_domain_cells == 89
         assert array.vmin == 0
         assert array.vmax == 88
-
-    def test_no_elem_is_deprecated_alias(self, arr: np.ndarray, no_data_value: float):
-        """The legacy `no_elem` attribute still works but warns."""
-        array = ArrayGlyph(arr, exclude_value=[no_data_value])
-        with pytest.warns(DeprecationWarning, match="num_domain_cells"):
-            value = array.no_elem
-        assert value == array.num_domain_cells == 89
 
 
 class TestRGB:
@@ -381,350 +374,6 @@ class TestAnimate:
         # os.remove(path)
 
 
-class TestRenamedKwargAliases:
-    """The legacy `plot`/`animate` kwarg names still work but warn.
-
-    `text_colors` was renamed to `cell_value_text_colors`. The old name is
-    still accepted as a keyword (routed through `**kwargs`), emits a
-    `DeprecationWarning` naming its replacement, and is forwarded to the
-    same effective behaviour as the new name. The point-styling kwargs
-    (`point_color`, `pid_color`, ...) have since been superseded by
-    `PointOverlay` -- see `TestPointOverlayAliases`; the frame-label
-    kwargs (`label_location`, `label_color`, `text_loc`) by `FrameLabel`
-    -- see `TestFrameLabelAliases`.
-    """
-
-    def test_animate_text_colors_alias_still_works(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`animate(text_colors=...)` warns and is forwarded unchanged."""
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="cell_value_text_colors"):
-            array.animate(
-                animate_time_list,
-                cells=CellValues(show=True),
-                text_colors=("yellow", "purple"),
-            )
-
-    def test_no_warning_with_only_new_names(self, coello_data: np.ndarray):
-        """Using only the current names raises no deprecation warning."""
-        array = ArrayGlyph(coello_data)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            array.animate(
-                ["t0", "t1", "t2"],
-                cell_value_text_colors=("yellow", "purple"),
-                frame_label=FrameLabel(location=[0.1, 0.1]),
-            )
-
-    def test_both_given_new_wins_even_at_its_own_default(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`cell_value_text_colors` wins even when equal to its own default.
-
-        Test scenario:
-            Regression for a false-negative in the "both given" conflict
-            check: passing both the deprecated `text_colors=` and the
-            current `cell_value_text_colors=` -- with the current one
-            happening to equal its own default -- must still fire the
-            conflict warning (not silently prefer the deprecated value,
-            which a plain equality-with-default check cannot tell apart
-            from "the new name was never passed").
-        """
-        array = ArrayGlyph(coello_data)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            array.animate(
-                animate_time_list,
-                cells=CellValues(show=True),
-                cell_value_text_colors=("white", "black"),
-                text_colors=("yellow", "purple"),
-            )
-        messages = [str(w.message) for w in caught]
-        assert any("is deprecated" in m for m in messages)
-        assert any("were given" in m and "wins" in m for m in messages)
-
-
-class TestFrameLabelAliases:
-    """`FrameLabel` is the current way to style `animate`'s frame/time
-    label; the flat keywords it replaces (`label_location`/`label_color`,
-    and the older `text_loc`) still work but warn.
-    """
-
-    def test_frame_label_no_warning(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """Passing a `FrameLabel` is the current style and warns nothing."""
-        array = ArrayGlyph(coello_data)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            array.animate(
-                animate_time_list,
-                frame_label=FrameLabel(location=[0.1, 0.1], color="yellow"),
-            )
-        assert array._day_text.get_color() == "yellow"
-        assert array._day_text.get_transform() is array.ax.transData
-
-    def test_label_location_alias_still_works(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`animate(label_location=...)` warns and positions the frame label."""
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="FrameLabel"):
-            array.animate(animate_time_list, label_location=[0.1, 0.1])
-        assert array._day_text.get_transform() is array.ax.transData
-
-    def test_text_loc_oldest_alias_still_works(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`animate(text_loc=...)` (the oldest name) warns and positions the label."""
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="FrameLabel"):
-            array.animate(animate_time_list, text_loc=[0.1, 0.1])
-        assert array._day_text.get_transform() is array.ax.transData
-
-    def test_label_color_alias_still_works(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`animate(label_color=...)` warns and colours the frame label."""
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="FrameLabel"):
-            array.animate(animate_time_list, label_color="yellow")
-        assert array._day_text.get_color() == "yellow"
-
-    def test_deprecated_kwargs_ignored_with_frame_label(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """A deprecated kwarg alongside a `FrameLabel` is ignored, with a warning."""
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(UserWarning, match="ignored"):
-            array.animate(
-                animate_time_list,
-                frame_label=FrameLabel(color="yellow"),
-                label_color="orange",
-            )
-        assert array._day_text.get_color() == "yellow"
-
-    def test_positional_legacy_location_still_works(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """A plain `[x, y]` passed positionally at the old `text_loc` slot still works.
-
-        Test scenario:
-            On `main`, `animate`'s 5th positional-or-keyword parameter was
-            `text_loc` (a plain `[x, y]` list); it is now `frame_label`. A
-            stale positional call with a plain list at that position must
-            still position the label (not silently drop it) and warn.
-        """
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="FrameLabel"):
-            array.animate(animate_time_list, None, ("white", "black"), 200, [0.3, 0.3])
-        assert array._day_text.get_position() == (0.3, 0.3)
-        assert array._day_text.get_transform() is array.ax.transData
-
-    def test_deprecation_warning_attributes_to_caller(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """The `FrameLabel`-alias deprecation warning points at the caller's line.
-
-        Test scenario:
-            Regression for a `stacklevel` bug: the warning must name this
-            test file/line, not an internal frame (e.g. `warnings.py`).
-        """
-        array = ArrayGlyph(coello_data)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            array.animate(animate_time_list, label_color="yellow")
-        assert len(caught) == 1
-        assert caught[0].filename == __file__
-
-    def test_positional_and_keyword_location_both_reported(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """Combining a positional legacy location with `label_location=` warns about both.
-
-        Test scenario:
-            Regression for a message-accuracy bug: when a bare `[x, y]` is
-            passed positionally at the old `text_loc` slot *and*
-            `label_location=` is also given, the keyword is drained (so it
-            can't fail the strict `kwargs` check) even though the
-            positional value wins -- but the warning previously only named
-            `frame_label (positional)`, silently omitting the also-consumed
-            `label_location`. Both must now appear in the message.
-        """
-        array = ArrayGlyph(coello_data)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            array.animate(
-                animate_time_list,
-                None,
-                ("white", "black"),
-                200,
-                [0.3, 0.3],
-                label_location=[0.5, 0.5],
-            )
-        messages = [str(w.message) for w in caught]
-        assert any(
-            "frame_label (positional)" in m and "label_location" in m for m in messages
-        ), f"Expected both aliases named in one message, got: {messages}"
-        assert array._day_text.get_position() == (
-            0.3,
-            0.3,
-        ), "The positional value must still win over the keyword"
-
-
-class TestPointOverlayAliases:
-    """`PointOverlay` is the current way to style `points`; the flat
-    keywords it replaces (`point_color`/`point_size`/`point_label_color`/
-    `point_label_size`, and the older `pid_color`/`pid_size`) still work
-    on a plain array but warn.
-    """
-
-    def test_plain_array_uses_point_overlay_defaults(self, arr: np.ndarray):
-        """A bare array (no styling kwargs) needs no `PointOverlay` and warns nothing."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(arr)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            fig, ax = array.plot(points=points)
-        label = [t for t in ax.texts if t.get_text() == "5"][0]
-        assert to_rgba(label.get_color()) == to_rgba("blue")  # PointOverlay default
-
-    def test_plot_point_overlay_no_warning(self, arr: np.ndarray):
-        """Passing a `PointOverlay` is the current style and warns nothing."""
-        overlay = PointOverlay(np.array([[5, 1, 1]]), label_color="lime")
-        array = ArrayGlyph(arr)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            fig, ax = array.plot(points=overlay)
-        label = [t for t in ax.texts if t.get_text() == "5"][0]
-        assert to_rgba(label.get_color()) == to_rgba("lime")
-
-    def test_plot_point_color_alias_still_works(self, arr: np.ndarray):
-        """`plot(points=array, point_color=...)` warns and colours the marker."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="PointOverlay"):
-            fig, ax = array.plot(points=points, point_color="lime")
-        assert to_rgba(ax.collections[0].get_facecolor()[0]) == to_rgba("lime")
-
-    def test_plot_point_label_color_alias_still_works(self, arr: np.ndarray):
-        """`plot(points=array, point_label_color=...)` warns and colours the label."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="PointOverlay"):
-            fig, ax = array.plot(points=points, point_label_color="lime")
-        label = [t for t in ax.texts if t.get_text() == "5"][0]
-        assert to_rgba(label.get_color()) == to_rgba("lime")
-
-    def test_plot_pid_color_oldest_alias_still_works(self, arr: np.ndarray):
-        """The oldest `pid_color` alias still resolves to the label colour."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="PointOverlay"):
-            fig, ax = array.plot(points=points, pid_color="lime")
-        label = [t for t in ax.texts if t.get_text() == "5"][0]
-        assert to_rgba(label.get_color()) == to_rgba("lime")
-
-    def test_plot_point_label_color_wins_over_pid_color(self, arr: np.ndarray):
-        """When both label-colour generations are given, the newer one wins."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="PointOverlay"):
-            fig, ax = array.plot(
-                points=points, point_label_color="lime", pid_color="orange"
-            )
-        label = [t for t in ax.texts if t.get_text() == "5"][0]
-        assert to_rgba(label.get_color()) == to_rgba("lime")
-
-    def test_plot_deprecated_kwargs_ignored_with_point_overlay(self, arr: np.ndarray):
-        """A deprecated kwarg alongside a `PointOverlay` is ignored, with a warning."""
-        overlay = PointOverlay(np.array([[5, 1, 1]]), label_color="lime")
-        array = ArrayGlyph(arr)
-        with pytest.warns(UserWarning, match="ignored"):
-            fig, ax = array.plot(points=overlay, point_label_color="orange")
-        label = [t for t in ax.texts if t.get_text() == "5"][0]
-        assert to_rgba(label.get_color()) == to_rgba("lime")
-
-    def test_plot_point_color_without_points_does_not_raise(self, arr: np.ndarray):
-        """`plot(point_color=...)` with no `points` warns instead of raising.
-
-        Test scenario:
-            Regression for a bug where `_resolve_point_overlay` only
-            drained the deprecated point-style kwargs out of `kwargs`
-            when `points` was a plain array or `PointOverlay`, leaving
-            them to fail the strict `kwargs`-vs-`default_options`
-            validation when `points is None` -- contradicting the
-            documented "the old keywords still work as `**kwargs`"
-            guarantee (on `main`, these were named parameters, legal --
-            if pointless -- without `points`).
-        """
-        array = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="have no effect"):
-            fig, ax = array.plot(point_color="red")
-        assert fig is not None, "plot() must still succeed, not raise"
-
-    def test_plot_pid_size_without_points_does_not_raise(self, arr: np.ndarray):
-        """The oldest `pid_size` alias with no `points` also warns instead of raising."""
-        array = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="have no effect"):
-            fig, ax = array.plot(pid_size=42)
-        assert fig is not None, "plot() must still succeed, not raise"
-
-    def test_animate_point_label_color_without_points_does_not_raise(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`animate(point_label_color=...)` with no `points` warns instead of raising."""
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="have no effect"):
-            anim = array.animate(animate_time_list, point_label_color="lime")
-        assert anim is not None, "animate() must still succeed, not raise"
-
-    def test_plot_no_deprecated_kwargs_and_no_points_warns_nothing(
-        self, arr: np.ndarray
-    ):
-        """Neither `points` nor any deprecated point-style kwarg: no warning at all."""
-        array = ArrayGlyph(arr)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            fig, ax = array.plot()
-        assert fig is not None
-
-    def test_animate_pid_size_oldest_alias_still_works(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """`animate(points=array, pid_size=...)` warns and sizes the label."""
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(coello_data)
-        with pytest.warns(DeprecationWarning, match="PointOverlay"):
-            array.animate(animate_time_list, points=points, pid_size=42)
-
-    def test_animate_point_overlay_no_warning(
-        self, coello_data: np.ndarray, animate_time_list: list
-    ):
-        """Passing a `PointOverlay` to `animate` is the current style and warns nothing."""
-        overlay = PointOverlay(np.array([[5, 1, 1]]), size=42)
-        array = ArrayGlyph(coello_data)
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            array.animate(animate_time_list, points=overlay)
-
-    def test_deprecation_warning_attributes_to_caller(self, arr: np.ndarray):
-        """The `PointOverlay`-alias deprecation warning points at the caller's line.
-
-        Test scenario:
-            Regression for a `stacklevel` bug: the warning must name this
-            test file/line, not an internal frame (e.g. `warnings.py`).
-        """
-        points = np.array([[5, 1, 1]])
-        array = ArrayGlyph(arr)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            array.plot(points=points, pid_color="lime")
-        assert len(caught) == 1
-        assert caught[0].filename == __file__
-
-
 class TestKwargsTypedDicts:
     """`PlotKwargs`/`AnimateKwargs` should track every kwarg each method
     actually reads and uses -- a regression test for the kind of drift
@@ -770,9 +419,9 @@ class TestKwargsTypedDicts:
 
 
 class TestUnsetSentinel:
-    """`_Unset`/`_UNSET`: the sentinel distinguishing "not passed" from
-    "passed, equal to its default" for `_resolve_renamed_kwarg`'s
-    `new_value` parameter.
+    """`_Unset`/`_UNSET`: the sentinel distinguishing "the caller did not
+    pass this" from "passed as `None`" for the `hillshade` key resolved
+    inside `ArrayGlyph.plot`.
     """
 
     def test_repr_is_readable(self):
@@ -790,83 +439,14 @@ class TestUnsetSentinel:
         """`_UNSET` is a single shared instance, compared with `is` not `==`.
 
         Test scenario:
-            `_resolve_renamed_kwarg` tests `new_value is _UNSET`; a second
-            `_Unset()` instance must NOT be `is _UNSET` (no `__eq__`
-            override makes two instances equal either), confirming the
-            sentinel can only be obtained by importing `_UNSET` itself.
+            Callers test `value is _UNSET`; a second `_Unset()` instance
+            must NOT be `is _UNSET` (no `__eq__` override makes two
+            instances equal either), confirming the sentinel can only be
+            obtained by importing `_UNSET` itself.
         """
-        from cleopatra.glyphs.gridded.array_glyph import _Unset
-
         other = _Unset()
         assert other is not _UNSET, "A fresh _Unset() must not be the _UNSET singleton"
         assert other != _UNSET, "Two distinct _Unset instances must not compare equal"
-
-
-class TestPopFirst:
-    """Direct unit tests for `_pop_first`, the helper `_resolve_point_overlay`
-    and `_resolve_frame_label` use to drain every deprecated alias out of
-    `kwargs` while keeping only the highest-priority value.
-    """
-
-    def test_no_names_present_returns_default(self):
-        """None of `names` in `kwargs`: returns `(default, None)`, `kwargs` untouched."""
-        kwargs = {"cmap": "viridis"}
-        value, key = _pop_first(kwargs, ("point_color", "pid_color"), "red")
-        assert (value, key) == (
-            "red",
-            None,
-        ), f"Expected ('red', None), got {(value, key)}"
-        assert kwargs == {"cmap": "viridis"}, (
-            f"kwargs should be untouched, got {kwargs}"
-        )
-
-    def test_single_name_present_pops_it(self):
-        """Exactly one of `names` present: it is popped and returned with its key."""
-        kwargs = {"point_color": "lime", "cmap": "viridis"}
-        value, key = _pop_first(kwargs, ("point_color",), "red")
-        assert (value, key) == ("lime", "point_color"), f"Got {(value, key)}"
-        assert "point_color" not in kwargs, "The matched key must be popped"
-        assert kwargs == {"cmap": "viridis"}, (
-            f"Unrelated keys must survive, got {kwargs}"
-        )
-
-    def test_multiple_names_present_pops_all_returns_highest_priority(self):
-        """Two aliases present: both are popped, but the first-listed one wins.
-
-        Test scenario:
-            Regression for a bug where only the winning name was popped,
-            leaving the loser in `kwargs` to fail the caller's subsequent
-            strict `kwargs`-vs-`default_options` validation.
-        """
-        kwargs = {"point_label_color": "lime", "pid_color": "orange"}
-        value, key = _pop_first(kwargs, ("point_label_color", "pid_color"), "blue")
-        assert (value, key) == ("lime", "point_label_color"), f"Got {(value, key)}"
-        assert kwargs == {}, f"Both aliases must be popped, got {kwargs}"
-
-    def test_priority_order_is_names_order_not_insertion_order(self):
-        """The winner is the first name in `names`, regardless of `kwargs` insertion order.
-
-        Test scenario:
-            `pid_color` is inserted into `kwargs` before `point_label_color`,
-            but `names=("point_label_color", "pid_color")` still prefers
-            `point_label_color` -- priority is positional in `names`, not
-            dict insertion order.
-        """
-        kwargs = {"pid_color": "orange", "point_label_color": "lime"}
-        value, key = _pop_first(kwargs, ("point_label_color", "pid_color"), "blue")
-        assert (value, key) == ("lime", "point_label_color"), f"Got {(value, key)}"
-
-    def test_empty_names_returns_default(self):
-        """An empty `names` tuple always returns `(default, None)`."""
-        kwargs = {"cmap": "viridis"}
-        value, key = _pop_first(kwargs, (), "red")
-        assert (value, key) == (
-            "red",
-            None,
-        ), f"Expected ('red', None), got {(value, key)}"
-        assert kwargs == {"cmap": "viridis"}, (
-            f"kwargs should be untouched, got {kwargs}"
-        )
 
 
 class TestPointOverlay:
@@ -924,6 +504,57 @@ class TestFrameLabel:
         assert label.location == [0.3, 0.4], f"Got {label.location!r}"
         assert label.color == "yellow", f"Got {label.color!r}"
         assert label.size == 18, f"Got {label.size!r}"
+
+
+class TestPanelLabels:
+    """Direct unit tests for `PanelLabels.__init__`'s defaults, attribute
+    assignment, and keyword-only signature, independent of `facet` rendering.
+    """
+
+    def test_defaults(self):
+        """No arguments given: both `col` and `row` default to `None`.
+
+        Test scenario:
+            A bare `PanelLabels()` leaves both facet-axis label sequences
+            unset so `facet` falls back to integer slice indices.
+        """
+        labels = PanelLabels()
+        assert labels.col is None, f"Expected default col None, got {labels.col!r}"
+        assert labels.row is None, f"Expected default row None, got {labels.row!r}"
+
+    def test_explicit_values_stored_verbatim(self):
+        """Both keywords, when given, are stored unchanged (same object).
+
+        Test scenario:
+            The sequences passed for `col`/`row` are retained by identity,
+            not copied or coerced, so callers keep full control of them.
+        """
+        col = ["Jan", "Feb", "Mar"]
+        row = [10, 20]
+        labels = PanelLabels(col=col, row=row)
+        assert labels.col is col, f"col must be stored as given, got {labels.col!r}"
+        assert labels.row is row, f"row must be stored as given, got {labels.row!r}"
+
+    def test_col_only(self):
+        """Setting only `col` leaves `row` at its `None` default.
+
+        Test scenario:
+            The common 3-D facet case supplies just `col`; `row` must stay
+            `None` rather than mirroring `col`.
+        """
+        labels = PanelLabels(col=[0, 1, 2])
+        assert labels.col == [0, 1, 2], f"Got {labels.col!r}"
+        assert labels.row is None, f"Expected row None, got {labels.row!r}"
+
+    def test_signature_is_keyword_only(self):
+        """`col`/`row` are keyword-only: positional args raise `TypeError`.
+
+        Test scenario:
+            Mirrors `PointOverlay`/`FrameLabel` -- passing the label
+            sequences positionally is rejected so call sites stay explicit.
+        """
+        with pytest.raises(TypeError):
+            PanelLabels(["Jan", "Feb"])  # type: ignore[misc]
 
 
 @pytest.mark.plot
@@ -1790,13 +1421,12 @@ class TestPlotRecomputeBranch:
             glyph.plot(banana_count=12)
 
     def test_recompute_with_explicit_ticks_spacing(self):
-        """A loose `ticks_spacing=` (deprecated) still wins over the recompute path."""
+        """A loose `ticks_spacing=` still wins over the recompute path."""
         rng = np.random.default_rng(1337)
         body = rng.random(98)
         arr = np.concatenate([body, [-1000.0, 1000.0]]).reshape(10, 10)
         glyph = ArrayGlyph(arr)
-        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
-            glyph.plot(robust=True, ticks_spacing=0.1)
+        glyph.plot(robust=True, ticks_spacing=0.1)
         assert glyph.default_options["ticks_spacing"] == 0.1, (
             "Explicit ticks_spacing must win over the recompute path"
         )
@@ -2004,7 +1634,7 @@ class TestSharedAxesArtistCleanup:
             second call.
         """
         arr = np.arange(25.0).reshape(5, 5)
-        points = np.array([[5.0, 1, 1], [6.0, 2, 2]])
+        points = PointOverlay(np.array([[5.0, 1, 1], [6.0, 2, 2]]))
         glyph = ArrayGlyph(arr)
         glyph.plot(points=points)
         collections_after_first = len(glyph.ax.collections)
@@ -2036,7 +1666,7 @@ class TestSharedAxesArtistCleanup:
         self, coello_data: np.ndarray, animate_time_list: list
     ):
         """A second `animate(points=...)` call replaces the scatter/label overlay."""
-        points = np.array([[5.0, 1, 1], [6.0, 2, 2]])
+        points = PointOverlay(np.array([[5.0, 1, 1], [6.0, 2, 2]]))
         glyph = ArrayGlyph(coello_data)
         glyph.animate(animate_time_list, points=points)
         collections_after_first = len(glyph.ax.collections)
@@ -2158,7 +1788,7 @@ class TestAnimateEdgeCases:
     ):
         """`animate(points=...)` adds scatter overlays without raising."""
         glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
-        points = np.array([[1.0, 0, 0], [2.0, 1, 1]])
+        points = PointOverlay(np.array([[1.0, 0, 0], [2.0, 1, 1]]))
         anim = glyph.animate(animate_time_list, points=points)
         assert anim is not None
 
@@ -2168,10 +1798,9 @@ class TestAnimateEdgeCases:
         animate_time_list: list,
         no_data_value: float,
     ):
-        """A loose `animate(ticks_spacing=...)` (deprecated) overrides the auto spacing."""
+        """A loose `animate(ticks_spacing=...)` overrides the auto spacing."""
         glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
-        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
-            anim = glyph.animate(animate_time_list, ticks_spacing=50.0)
+        anim = glyph.animate(animate_time_list, ticks_spacing=50.0)
         assert anim is not None
         assert glyph.default_options["ticks_spacing"] == 50.0
 
@@ -2220,17 +1849,16 @@ class TestAnimateEdgeCases:
         animate_time_list: list,
         no_data_value: float,
     ):
-        """A loose `animate(cbar_orientation=...)` warns yet still applies (#235).
+        """A loose `animate(cbar_orientation=...)` still applies (#235).
 
         Test scenario:
-            The deprecation fires on the animate path too, steering to
-            `ColorBar(orientation=...)`, while the kwarg keeps working.
+            The loose kwarg keeps working on the animate path, mapping to
+            the same effect as `ColorBar(orientation=...)`.
         """
         glyph = ArrayGlyph(coello_data, exclude_value=[no_data_value])
-        with pytest.warns(DeprecationWarning, match="cbar_orientation"):
-            glyph.animate(animate_time_list, cbar_orientation="horizontal")
+        glyph.animate(animate_time_list, cbar_orientation="horizontal")
         assert glyph.cbar.orientation == "horizontal", (
-            f"deprecated kwarg should still work in animate, got {glyph.cbar.orientation}"
+            f"loose kwarg should still work in animate, got {glyph.cbar.orientation}"
         )
 
     def test_data_getter_is_keyword_only(
@@ -2910,10 +2538,10 @@ class TestFaceting:
         assert result.cbar is not None
 
     def test_coord_aware_titles(self):
-        """`col_coords` plugs into the per-subplot title and name_dicts."""
+        """`labels.col` plugs into the per-subplot title and name_dicts."""
         stack = self._stack_3d(n=4)
         coords = [0, 6, 12, 18]
-        result = ArrayGlyph(stack).facet(col="hour", col_coords=coords)
+        result = ArrayGlyph(stack).facet(col="hour", labels=PanelLabels(col=coords))
         # Each title must reference the coord value, not the index.
         for ax, want in zip(result.axes.ravel(), coords):
             assert str(want) in ax.get_title()
@@ -3075,7 +2703,7 @@ class TestFacetColorbar:
             the `ColorBar` label.
         """
         result = ArrayGlyph(self._stack_3d()).facet(
-            col="time", col_coords=[0, 1, 2], colorbar=ColorBar(label="mm")
+            col="time", labels=PanelLabels(col=[0, 1, 2]), colorbar=ColorBar(label="mm")
         )
         assert isinstance(result, FacetGrid), f"expected FacetGrid, got {type(result)}"
         assert result.cbar is not None, (
@@ -3093,7 +2721,7 @@ class TestFacetColorbar:
             three panels' colorbars carry the label.
         """
         result = ArrayGlyph(self._stack_3d()).facet(
-            col="time", col_coords=[0, 1, 2], colorbar=ColorBar(label="mm")
+            col="time", labels=PanelLabels(col=[0, 1, 2]), colorbar=ColorBar(label="mm")
         )
         labels = [ax.get_ylabel() for ax in self._colorbar_axes(result)]
         assert labels == ["mm", "mm", "mm"], (
@@ -3108,7 +2736,7 @@ class TestFacetColorbar:
             colorbar axis per panel and `result.cbar` is not `None`.
         """
         result = ArrayGlyph(self._stack_3d()).facet(
-            col="time", col_coords=[0, 1, 2], colorbar=True
+            col="time", labels=PanelLabels(col=[0, 1, 2]), colorbar=True
         )
         assert result.cbar is not None, "colorbar=True should draw a shared cbar"
         assert len(self._colorbar_axes(result)) == 3, (
@@ -3122,12 +2750,11 @@ class TestFacetColorbar:
             Unlike the `None` default (which leaves loose kwargs in place),
             `True` resets the resettable `cbar_*` family, so a loose
             `cbar_label="loose"` does not survive -- the drawn bar has the
-            default (empty) label. The loose kwarg still deprecates.
+            default (empty) label.
         """
-        with pytest.warns(DeprecationWarning, match="cbar_label"):
-            result = ArrayGlyph(self._stack_3d()).facet(
-                col="time", col_coords=[0, 1, 2], colorbar=True, cbar_label="loose"
-            )
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time", labels=PanelLabels(col=[0, 1, 2]), colorbar=True, cbar_label="loose"
+        )
         assert result.cbar.ax.get_ylabel() == "", (
             f"colorbar=True should reset the loose label, got {result.cbar.ax.get_ylabel()!r}"
         )
@@ -3139,13 +2766,11 @@ class TestFacetColorbar:
             Complements the `True`-resets and typed-wins tests: with `None`
             (which resolves to an empty update), a loose `cbar_label="loose"`
             folded in by the constructor survives on every panel's bar -- the
-            prior behaviour the docstring promises. The loose kwarg still
-            deprecates.
+            prior behaviour the docstring promises.
         """
-        with pytest.warns(DeprecationWarning, match="cbar_label"):
-            result = ArrayGlyph(self._stack_3d()).facet(
-                col="time", col_coords=[0, 1, 2], colorbar=None, cbar_label="loose"
-            )
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time", labels=PanelLabels(col=[0, 1, 2]), colorbar=None, cbar_label="loose"
+        )
         labels = [ax.get_ylabel() for ax in self._colorbar_axes(result)]
         assert labels == [
             "loose",
@@ -3163,7 +2788,7 @@ class TestFacetColorbar:
         """
         stack = self._stack_3d()
         result = ArrayGlyph(stack).facet(
-            col="time", col_coords=[0, 1, 2], colorbar=ColorBar(label="mm")
+            col="time", labels=PanelLabels(col=[0, 1, 2]), colorbar=ColorBar(label="mm")
         )
         vmin, vmax = result.cbar.mappable.get_clim()
         assert vmin == pytest.approx(float(stack.min())), (
@@ -3181,7 +2806,7 @@ class TestFacetColorbar:
             axes are created and the shared `cbar` is `None`.
         """
         result = ArrayGlyph(self._stack_3d()).facet(
-            col="time", col_coords=[0, 1, 2], colorbar=False
+            col="time", labels=PanelLabels(col=[0, 1, 2]), colorbar=False
         )
         assert self._colorbar_axes(result) == [], (
             "colorbar=False should draw no colorbars"
@@ -3195,7 +2820,7 @@ class TestFacetColorbar:
             The default `colorbar=None` resolves to an empty update, so behaviour
             is unchanged: one colorbar per panel and a non-None shared `cbar`.
         """
-        result = ArrayGlyph(self._stack_3d()).facet(col="time", col_coords=[0, 1, 2])
+        result = ArrayGlyph(self._stack_3d()).facet(col="time", labels=PanelLabels(col=[0, 1, 2]))
         assert len(self._colorbar_axes(result)) == 3, (
             "default facet should keep one colorbar per panel"
         )
@@ -3214,7 +2839,7 @@ class TestFacetColorbar:
         """
         result = ArrayGlyph(self._stack_3d()).facet(
             col="time",
-            col_coords=[0, 1, 2],
+            labels=PanelLabels(col=[0, 1, 2]),
             colorbar=ColorBar(label="mm", orientation="horizontal"),
         )
         assert result.cbar.orientation == "horizontal", (
@@ -3232,16 +2857,14 @@ class TestFacetColorbar:
 
         Test scenario:
             When both `colorbar=ColorBar(label="typed")` and `cbar_label="loose"`
-            are given, the typed spec is applied last and wins; the loose form
-            still emits its deprecation warning.
+            are given, the typed spec is applied last and wins.
         """
-        with pytest.warns(DeprecationWarning, match="cbar_label"):
-            result = ArrayGlyph(self._stack_3d()).facet(
-                col="time",
-                col_coords=[0, 1, 2],
-                colorbar=ColorBar(label="typed"),
-                cbar_label="loose",
-            )
+        result = ArrayGlyph(self._stack_3d()).facet(
+            col="time",
+            labels=PanelLabels(col=[0, 1, 2]),
+            colorbar=ColorBar(label="typed"),
+            cbar_label="loose",
+        )
         assert result.cbar.ax.get_ylabel() == "typed", (
             f"typed ColorBar should win, got {result.cbar.ax.get_ylabel()!r}"
         )
@@ -3255,7 +2878,7 @@ class TestFacetColorbar:
         """
         glyph = ArrayGlyph(self._stack_3d())
         with pytest.raises(TypeError, match="colorbar must be a bool"):
-            glyph.facet(col="time", col_coords=[0, 1, 2], colorbar=object())
+            glyph.facet(col="time", labels=PanelLabels(col=[0, 1, 2]), colorbar=object())
 
     def test_facet_4d_accepts_colorbar_spec(self):
         """The `ColorBar` spec also works on a 4-D (`col` + `row`) facet.
@@ -3274,43 +2897,6 @@ class TestFacetColorbar:
             f"4-D facet shared cbar should read 'mm', got {result.cbar.ax.get_ylabel()!r}"
         )
 
-    @pytest.mark.parametrize(
-        "kwarg, value",
-        [
-            ("cbar_label", "mm"),
-            ("cbar_length", 0.5),
-            ("cbar_orientation", "horizontal"),
-            ("ticks_spacing", 5),
-        ],
-    )
-    def test_facet_loose_cbar_kwargs_deprecated(self, kwarg, value):
-        """Each loose `cbar_*` on `facet` emits a `DeprecationWarning`.
-
-        Args:
-            kwarg: The deprecated loose colorbar keyword under test.
-            value: A value to pass for that keyword.
-
-        Test scenario:
-            `facet` now calls `_warn_deprecated_cbar_kwargs`, so every loose
-            colorbar keyword deprecates on the faceted path exactly as on
-            `plot` / `animate`.
-        """
-        with pytest.warns(DeprecationWarning, match=kwarg):
-            ArrayGlyph(self._stack_3d()).facet(
-                col="time", col_coords=[0, 1, 2], **{kwarg: value}
-            )
-
-    def test_facet_without_colorbar_kwargs_does_not_warn(self):
-        """A plain `facet()` call emits no colorbar `DeprecationWarning`.
-
-        Test scenario:
-            The deprecation fires only for the loose keys, so an ordinary facet
-            (no `cbar_*`, no `colorbar`) stays quiet.
-        """
-        with warnings.catch_warnings():
-            warnings.simplefilter("error", DeprecationWarning)
-            ArrayGlyph(self._stack_3d()).facet(col="time", col_coords=[0, 1, 2])
-
     def test_facet_placement_colorbar_overrides_preset_swatch(self):
         """A placement-bearing `colorbar=` overrides a preset swatch on the facet path.
 
@@ -3324,7 +2910,7 @@ class TestFacetColorbar:
         """
         result = ArrayGlyph(self._stack_3d()).facet(
             col="time",
-            col_coords=[0, 1, 2],
+            labels=PanelLabels(col=[0, 1, 2]),
             data_style=DataStyle(style="flow_accumulation"),
             colorbar=ColorBar(location="right"),
         )
@@ -3346,7 +2932,7 @@ class TestFacetColorbar:
         """
         result = ArrayGlyph(self._stack_3d()).facet(
             col="time",
-            col_coords=[0, 1, 2],
+            labels=PanelLabels(col=[0, 1, 2]),
             data_style=DataStyle(style="flow_accumulation"),
         )
         assert self._colorbar_axes(result) == [], (
@@ -3355,24 +2941,6 @@ class TestFacetColorbar:
         swatches = sum(len(ax.child_axes) for ax in result.axes.ravel())
         assert swatches == 3, (
             f"each panel should keep its preset swatch, got {swatches}"
-        )
-
-    def test_facet_loose_cbar_warns_exactly_once(self):
-        """A loose `cbar_*` on `facet` deprecates exactly once, not once per panel.
-
-        Test scenario:
-            The single warning comes from `facet` itself; the per-panel sub-glyph
-            constructors fold the loose kwarg silently. This locks the invariant
-            that re-routing loose kwargs through `sub.plot` (which would warn per
-            panel) is not silently introduced.
-        """
-        with pytest.warns(DeprecationWarning) as record:
-            ArrayGlyph(self._stack_3d()).facet(
-                col="time", col_coords=[0, 1, 2], cbar_label="mm"
-            )
-        cbar_warnings = [w for w in record if "cbar_label" in str(w.message)]
-        assert len(cbar_warnings) == 1, (
-            f"expected exactly one cbar_label deprecation, got {len(cbar_warnings)}"
         )
 
 
@@ -3926,26 +3494,26 @@ class TestFacetingEdgeCases:
         with pytest.raises(ValueError, match="4-D array"):
             ArrayGlyph(stack).facet(col="t", row="lev")
 
-    def test_col_coords_length_mismatch_raises(self) -> None:
-        """`col_coords` whose length differs from N raises `ValueError`."""
+    def test_labels_col_length_mismatch_raises(self) -> None:
+        """`labels.col` whose length differs from N raises `ValueError`."""
         stack = self._stack(n=4)
-        with pytest.raises(ValueError, match="`col_coords` length"):
-            ArrayGlyph(stack).facet(col="t", col_coords=[0, 1, 2])
+        with pytest.raises(ValueError, match="`labels.col` length"):
+            ArrayGlyph(stack).facet(col="t", labels=PanelLabels(col=[0, 1, 2]))
 
-    def test_col_coords_length_mismatch_4d_raises(self) -> None:
-        """`col_coords` length wrong on a 4-D stack raises."""
+    def test_labels_col_length_mismatch_4d_raises(self) -> None:
+        """`labels.col` length wrong on a 4-D stack raises."""
         rng = np.random.default_rng(1337)
         stack = rng.uniform(0.0, 1.0, size=(2, 3, 4, 4))
-        with pytest.raises(ValueError, match="`col_coords` length"):
-            ArrayGlyph(stack).facet(col="t", row="lev", col_coords=[0])
+        with pytest.raises(ValueError, match="`labels.col` length"):
+            ArrayGlyph(stack).facet(col="t", row="lev", labels=PanelLabels(col=[0]))
 
-    def test_row_coords_length_mismatch_raises(self) -> None:
-        """`row_coords` whose length differs from Nrow raises."""
+    def test_labels_row_length_mismatch_raises(self) -> None:
+        """`labels.row` whose length differs from Nrow raises."""
         rng = np.random.default_rng(1337)
         stack = rng.uniform(0.0, 1.0, size=(2, 3, 4, 4))
-        with pytest.raises(ValueError, match="`row_coords` length"):
+        with pytest.raises(ValueError, match="`labels.row` length"):
             ArrayGlyph(stack).facet(
-                col="t", row="lev", col_coords=[0, 1], row_coords=[0]
+                col="t", row="lev", labels=PanelLabels(col=[0, 1], row=[0])
             )
 
     def test_shared_vmin_vmax_global_min_max(self) -> None:
@@ -3971,15 +3539,15 @@ class TestFacetingEdgeCases:
         finally:
             plt.close(result.fig)
 
-    def test_empty_col_coords_falls_back_to_index(self) -> None:
-        """`col_coords=None` titles use the integer panel index.
+    def test_empty_labels_col_falls_back_to_index(self) -> None:
+        """`labels.col=None` titles use the integer panel index.
 
         Test scenario:
             With no coord list, subplot titles encode the integer
             facet index (`t=0`, `t=1`, ...).
         """
         stack = self._stack(n=3)
-        result = ArrayGlyph(stack).facet(col="t", col_coords=None)
+        result = ArrayGlyph(stack).facet(col="t", labels=PanelLabels(col=None))
         try:
             titles = [ax.get_title() for ax in result.axes.ravel()]
             assert "t=0" in titles[0], f"expected 't=0'; got {titles[0]!r}"
@@ -3987,8 +3555,8 @@ class TestFacetingEdgeCases:
         finally:
             plt.close(result.fig)
 
-    def test_timestamp_col_coords(self) -> None:
-        """String / timestamp `col_coords` are forwarded into titles.
+    def test_timestamp_labels_col(self) -> None:
+        """String / timestamp `labels.col` are forwarded into titles.
 
         Test scenario:
             Time-axis coords often arrive as `str` (or
@@ -3997,7 +3565,7 @@ class TestFacetingEdgeCases:
         """
         stack = self._stack(n=3)
         coords = ["2024-01", "2024-02", "2024-03"]
-        result = ArrayGlyph(stack).facet(col="month", col_coords=coords)
+        result = ArrayGlyph(stack).facet(col="month", labels=PanelLabels(col=coords))
         try:
             titles = [ax.get_title() for ax in result.axes.ravel()]
             for want, title in zip(coords, titles):
@@ -4033,7 +3601,7 @@ class TestFacetingEdgeCases:
         rng = np.random.default_rng(1337)
         stack = rng.uniform(0.0, 1.0, size=(2, 2, 4, 4))
         result = ArrayGlyph(stack).facet(
-            col="t", row="lev", col_coords=["A", "B"], row_coords=[10, 20]
+            col="t", row="lev", labels=PanelLabels(col=["A", "B"], row=[10, 20])
         )
         try:
             assert len(result.name_dicts) == 4, (
@@ -4123,15 +3691,15 @@ class TestFacetingEdgeCases:
         finally:
             plt.close(result.fig)
 
-    def test_facet_explicit_figsize(self) -> None:
-        """An explicit `figsize` overrides the default panel-based sizing.
+    def test_facet_explicit_figure_size(self) -> None:
+        """An explicit `figure_size` overrides the default panel-based sizing.
 
         Test scenario:
-            `facet(figsize=(12, 4))` must produce a figure whose
+            `facet(figure_size=(12, 4))` must produce a figure whose
             dimensions reflect the caller's choice.
         """
         stack = self._stack(n=3)
-        result = ArrayGlyph(stack).facet(col="t", figsize=(12.0, 4.0))
+        result = ArrayGlyph(stack).facet(col="t", figure_size=(12.0, 4.0))
         try:
             w, h = result.fig.get_size_inches()
             assert w == pytest.approx(12.0), f"width must be 12; got {w}"
@@ -7023,16 +6591,15 @@ class TestColorbarPlacement:
         """An unset ColorBar caption leaves a loose `cbar_label` intact.
 
         Test scenario:
-            During the transition (before the loose kwargs are deprecated), a
-            `ColorBar` that sets no caption must not overwrite a loose `cbar_label`.
+            A `ColorBar` that sets no caption must not overwrite a loose
+            `cbar_label`.
         """
         g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
-        with pytest.warns(DeprecationWarning, match="cbar_label"):
-            g.plot(
-                cmap="viridis",
-                colorbar=ColorBar(location="right"),
-                cbar_label="Legacy caption",
-            )
+        g.plot(
+            cmap="viridis",
+            colorbar=ColorBar(location="right"),
+            cbar_label="Legacy caption",
+        )
         caption = g.cbar.ax.get_xlabel() or g.cbar.ax.get_ylabel()
         assert caption == "Legacy caption", (
             f"loose cbar_label was clobbered, got {caption!r}"
@@ -7069,14 +6636,13 @@ class TestColorbarPlacement:
             precedence, consistent with every other mapped `cbar_*` field.
         """
         g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 40.0, 20.0])
-        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
-            g.plot(
-                cmap="viridis",
-                vmin=0.0,
-                vmax=20.0,
-                ticks_spacing=2.0,
-                colorbar=ColorBar(location="right", ticks_spacing=5.0),
-            )
+        g.plot(
+            cmap="viridis",
+            vmin=0.0,
+            vmax=20.0,
+            ticks_spacing=2.0,
+            colorbar=ColorBar(location="right", ticks_spacing=5.0),
+        )
         resolved = g.default_options["ticks_spacing"]
         assert resolved == 5.0, (
             f"loose ticks_spacing should lose to the spec, got {resolved}"
@@ -7696,99 +7262,6 @@ class TestResolveColorbar:
         """
         with pytest.raises(TypeError, match="colorbar must be"):
             _resolve_colorbar(bad)
-
-
-class TestDeprecatedCbarKwargs:
-    """Deprecation of the loose `cbar_*` kwargs superseded by `ColorBar` (#234)."""
-
-    @staticmethod
-    def _field() -> np.ndarray:
-        """Return a small 2-D field for a single static plot."""
-        return np.arange(20 * 30, dtype=float).reshape(20, 30)
-
-    def test_helper_warns_for_a_deprecated_key(self):
-        """`_warn_deprecated_cbar_kwargs` warns and names the `ColorBar` field.
-
-        Test scenario:
-            A loose `cbar_label` triggers a DeprecationWarning pointing at
-            `colorbar=ColorBar(label=...)`.
-        """
-        with pytest.warns(DeprecationWarning, match=r"cbar_label.*ColorBar\(label="):
-            _warn_deprecated_cbar_kwargs({"cbar_label": "Depth"})
-
-    def test_helper_silent_without_deprecated_keys(self):
-        """No warning is emitted when no deprecated key is present.
-
-        Test scenario:
-            A kwargs dict free of loose cbar_* keys warns nothing.
-        """
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            _warn_deprecated_cbar_kwargs({"cmap": "viridis", "vmin": 0})
-
-    def test_plot_loose_cbar_label_warns_but_still_works(self):
-        """A loose `cbar_label` on `plot` warns yet still renders the caption.
-
-        Test scenario:
-            During the deprecation window the kwarg keeps working (caption
-            rendered) while steering the caller toward `ColorBar`.
-        """
-        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 30.0, 20.0])
-        with pytest.warns(DeprecationWarning, match="cbar_label"):
-            g.plot(cmap="viridis", cbar_label="Rainfall mm/day")
-        caption = g.cbar.ax.get_xlabel() or g.cbar.ax.get_ylabel()
-        assert caption == "Rainfall mm/day", (
-            f"deprecated kwarg should still work, got {caption!r}"
-        )
-        plt.close("all")
-
-    def test_typed_colorbar_does_not_warn(self):
-        """Configuring the caption through `ColorBar` emits no cbar deprecation.
-
-        Test scenario:
-            The typed `colorbar=ColorBar(label=...)` path is the recommended
-            replacement and must not raise the loose-kwarg deprecation.
-        """
-        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 30.0, 20.0])
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            g.plot(cmap="viridis", colorbar=ColorBar(label="Rainfall mm/day"))
-        assert not any(
-            "deprecated" in str(x.message) and "cbar" in str(x.message) for x in caught
-        ), "typed ColorBar should not trigger the loose-kwarg deprecation"
-        plt.close("all")
-
-    def test_cbar_orientation_is_deprecated(self):
-        """A loose `cbar_orientation` warns, steering to `ColorBar(orientation=...)` (#235).
-
-        Test scenario:
-            The last colorbar kwarg folded into the spec now emits the
-            deprecation like the rest, while still taking effect.
-        """
-        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 30.0, 20.0])
-        with pytest.warns(
-            DeprecationWarning, match=r"cbar_orientation.*ColorBar\(orientation="
-        ):
-            g.plot(cmap="viridis", cbar_orientation="horizontal")
-        assert g.cbar.orientation == "horizontal", (
-            f"deprecated kwarg should still work, got {g.cbar.orientation}"
-        )
-        plt.close("all")
-
-    def test_invalid_loose_cbar_orientation_raises(self):
-        """A loose `cbar_orientation` typo raises a clear error at render (#235).
-
-        Test scenario:
-            The deprecated path is validated in `create_color_bar` too, so a bad
-            value surfaces as an actionable cleopatra error, not a matplotlib one.
-        """
-        g = ArrayGlyph(self._field(), extent=[0.0, 0.0, 30.0, 20.0])
-        with pytest.warns(DeprecationWarning, match="cbar_orientation"):
-            with pytest.raises(
-                ValueError, match="cbar_orientation must be 'vertical' or 'horizontal'"
-            ):
-                g.plot(cmap="viridis", cbar_orientation="horizontl")
-        plt.close("all")
 
 
 class TestStylePrecedence:

--- a/tests/test_colorbar_glyphs.py
+++ b/tests/test_colorbar_glyphs.py
@@ -166,22 +166,6 @@ def test_colorbar_false_suppresses(name):
 
 
 @pytest.mark.parametrize("name", list(GLYPHS))
-def test_loose_cbar_kwarg_is_deprecated(name):
-    """A loose `cbar_label` warns on every glyph, steering to `ColorBar` (#239).
-
-    Args:
-        name: The glyph type under test.
-
-    Test scenario:
-        The deprecation fires wherever the loose kwarg lands (construction for
-        the add_colorbar glyphs, plot for MeshGlyph).
-    """
-    _, _, _, loose = GLYPHS[name]
-    with pytest.warns(DeprecationWarning, match=r"cbar_label.*ColorBar\(label="):
-        loose()
-
-
-@pytest.mark.parametrize("name", list(GLYPHS))
 def test_colorbar_spec_ticks_spacing_reaches_render(name):
     """`colorbar=ColorBar(ticks_spacing=...)` is honored on every glyph (#239).
 

--- a/tests/test_mesh_glyph.py
+++ b/tests/test_mesh_glyph.py
@@ -1237,8 +1237,7 @@ class TestPlotReuse:
             data range) rather than `(vmax - vmin) / 10`.
         """
         mg = _make_tri_mg()
-        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
-            fig, ax = mg.plot(np.array([0.0, 10.0]), ticks_spacing=2.5)
+        fig, ax = mg.plot(np.array([0.0, 10.0]), ticks_spacing=2.5)
         assert mg.ticks_spacing == 2.5, (
             f"Expected explicit ticks_spacing=2.5, got {mg.ticks_spacing}"
         )
@@ -1560,16 +1559,15 @@ class TestAnimate:
         """
         mg = _make_tri_mg()
         frames = np.array([[1.0, 2.0], [3.0, 4.0]])
-        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
-            anim = mg.animate(
-                frames,
-                time=["t0", "t1"],
-                text_loc=[0.5, 0.5],
-                vmin=0.0,
-                vmax=10.0,
-                ticks_spacing=2.0,
-                title="My Animation",
-            )
+        anim = mg.animate(
+            frames,
+            time=["t0", "t1"],
+            text_loc=[0.5, 0.5],
+            vmin=0.0,
+            vmax=10.0,
+            ticks_spacing=2.0,
+            title="My Animation",
+        )
         assert anim is not None, "Should return a FuncAnimation"
         assert mg.vmin == 0.0, f"Expected explicit vmin=0.0, got {mg.vmin}"
         assert mg.vmax == 10.0, f"Expected explicit vmax=10.0, got {mg.vmax}"

--- a/tests/test_polygon_glyph.py
+++ b/tests/test_polygon_glyph.py
@@ -209,10 +209,9 @@ class TestPolygonGlyphPlot:
             With a spacing that divides the range, the clim equals the
             value range.
         """
-        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
-            glyph = PolygonGlyph(
-                polygons, values=np.array([0.0, 40.0]), ticks_spacing=10.0
-            )
+        glyph = PolygonGlyph(
+            polygons, values=np.array([0.0, 40.0]), ticks_spacing=10.0
+        )
         _, _, pc = glyph.plot()
         assert pc.get_clim() == (
             0.0,

--- a/tests/test_scatter_glyph.py
+++ b/tests/test_scatter_glyph.py
@@ -177,10 +177,9 @@ class TestScatterGlyphPlot:
             contract shared with ArrayGlyph); an evenly-dividing spacing
             keeps the top tick at exactly vmax.
         """
-        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
-            glyph = ScatterGlyph(
-                *xy, values=values, vmin=0.0, vmax=40.0, ticks_spacing=10.0
-            )
+        glyph = ScatterGlyph(
+            *xy, values=values, vmin=0.0, vmax=40.0, ticks_spacing=10.0
+        )
         _, _, paths = glyph.plot()
         assert paths.get_clim() == (
             0.0,

--- a/tests/test_vector_glyph.py
+++ b/tests/test_vector_glyph.py
@@ -156,8 +156,7 @@ class TestVectorGlyphPlot:
         y, x = np.mgrid[0:5, 0:5].astype(float)
         u = np.full_like(x, 3.0)
         v = np.full_like(y, 4.0)
-        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
-            glyph = VectorGlyph(x, y, u, v, vmin=0.0, vmax=10.0, ticks_spacing=2.0)
+        glyph = VectorGlyph(x, y, u, v, vmin=0.0, vmax=10.0, ticks_spacing=2.0)
         _, _, im = glyph.plot(kind="streamplot")
         ticks = glyph.get_ticks()
         assert im.get_clim() == (
@@ -175,8 +174,7 @@ class TestVectorGlyphPlot:
         x, y = np.meshgrid(np.arange(3.0), np.arange(3.0))
         u = np.full_like(x, 3.0)
         v = np.full_like(y, 4.0)
-        with pytest.warns(DeprecationWarning, match="ticks_spacing"):
-            glyph = VectorGlyph(x, y, u, v, vmin=0.0, vmax=10.0, ticks_spacing=2.0)
+        glyph = VectorGlyph(x, y, u, v, vmin=0.0, vmax=10.0, ticks_spacing=2.0)
         _, _, im = glyph.plot(kind="quiver")
         ticks = glyph.get_ticks()
         assert im.get_clim() == (


### PR DESCRIPTION
# Description

Follow-up to the grouped render-parameter refactor (#274). Now that the group objects exist, this removes the
temporary backward-compatible shims that kept the old loose keywords working, finishes grouping the `facet`
parameters, and documents the migration.

- Remove every deprecation shim: `_resolve_point_overlay`, `_resolve_frame_label`, `_resolve_renamed_kwarg`,
  `_pop_first` (array_glyph) and `_warn_deprecated_cbar_kwargs` / `_DEPRECATED_CBAR_KWARGS` (colorbar, imported by
  six other glyphs). Removed keywords now raise the ordinary `TypeError`; a bare `(N, 3)` array passed as `points`
  raises `AttributeError` instead of being auto-wrapped.
- Rename `ArrayGlyph.no_elem` -> `num_domain_cells` (the alias is gone) and `text_colors` ->
  `cell_value_text_colors` (now a normal parameter with a real default).
- Group `ArrayGlyph.facet`'s `col_coords` / `row_coords` into a new `PanelLabels` object (`labels=`), and rename
  `facet`'s `figsize` -> `figure_size` (drops `facet` back under SonarCloud's `python:S107` parameter cap).
- Add a "Grouped render-parameter objects" section to `docs/migration.md` and wire the migration guide into the
  mkdocs nav.
- Test surface: delete the deprecation test classes, unwrap the still-functional `cbar_*` / `ticks_spacing` tests
  (those loose keys still work — only the warning is gone), and convert the bare-array `points` tests to
  `PointOverlay`.

The loose `cbar_*` / `ticks_spacing` keywords are intentionally **not** removed — they remain valid options and
keep working; only their deprecation warning is dropped, with `colorbar=ColorBar(...)` still preferred.

**Dependencies:** none.

# Issues

- Closes #281 — group facet parameters (`PanelLabels` + `figure_size`)
- Closes #283 — remove legacy-kwarg shims and rename attributes
- Closes #285 — migration guide for the grouped render-parameter API

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Run against the external uv environment (`VIRTUAL_ENV=C:/python-environments/uv/cleopatra`, `uv run --active`).

- [x] Full test suite green: `pytest -q` -> **2190 passed** (excluding one pre-existing broken untracked scratch
      file, `tests/test_subplot_visual.py`, which imports the old flat `cleopatra.array_glyph` path unrelated to
      this change).
- [x] `tests/test_array_glyph.py` -> **505 passed**; the other glyph suites
      (colorbar/mesh/vector/polygon/scatter/kde/flow) -> **338 passed**.
- [x] Doctests green across every changed module: `pytest --doctest-modules` -> **60 passed**.
- [x] Rejection paths covered: removed keywords raise the natural error, and the deprecation tests were removed
      rather than left asserting a warning that no longer fires.
- [x] `mkdocs build` renders the migration guide page.

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
