### PR TITLE
fix(styling): drop pandas null sentinels (pd.NA/pd.NaT) in categorize

### DIFF
--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1798,6 +1798,64 @@ def classify(
     return edges, norm
 
 
+def _categorical_is_null(value: Any, pd_isna) -> bool:
+    """Return whether a scalar `value` is a missing/null entry `categorize` drops.
+
+    Recognises every null flavour a categorical column can carry -- ``None``,
+    ``float('nan')`` / ``np.nan`` (via ``np.isnan``), ``np.datetime64('NaT')``
+    (via ``np.isnan``, or ``pd.isna`` / ``np.isnat`` on numpy builds whose
+    ``np.isnan`` rejects datetime dtypes -- ``pd.isna`` when pandas is present,
+    ``np.isnat`` when it is absent), and pandas' own ``pd.NA`` / ``pd.NaT``
+    sentinels (via `pd_isna`) -- so the category set never depends on the source
+    dtype.
+
+    Args:
+        value: A single (already-flattened) scalar from `categorize`'s input.
+        pd_isna: ``pandas.isna`` resolved once by the caller, or ``None`` when
+            pandas is unavailable (its sentinels then cannot occur).
+
+    Returns:
+        bool: ``True`` if `value` is null and should be dropped; ``False``
+        otherwise. A container argument (list/tuple/dict/set/ndarray) or a
+        string/bytes label also returns ``False`` -- neither is treated as null
+        -- though a container is not itself colourable and would fail later in
+        deduplication.
+    """
+    if value is None:
+        return True
+    if isinstance(value, (list, tuple, dict, set, np.ndarray)):
+        return False
+    # A string/bytes label -- the most common categorical value -- is never
+    # null, so short-circuit before the `np.isnan` TypeError + `pd.isna`
+    # dispatch that every non-numeric scalar would otherwise pay per element.
+    if isinstance(value, (str, bytes)):
+        return False
+    try:
+        return bool(np.isnan(value))
+    except (TypeError, ValueError):
+        # TypeError: not a float/datetime scalar (pd.NA, ...). ValueError: an
+        # array-like element (e.g. `range`) made `np.isnan` return an array, so
+        # `bool(...)` is ambiguous -- fall through to the guarded checks below.
+        pass
+    # pandas' own sentinels (`pd.NA` / `pd.NaT`) raise under `np.isnan`; catch
+    # them with the once-resolved `pd_isna` when pandas is available. Guard the
+    # call (as `np.isnat` below): an array-like element makes `pd.isna` return
+    # an array and `bool(array)` raises `ValueError` -- such an element is
+    # simply not null (carried through, as base does).
+    if pd_isna is not None:
+        try:
+            return bool(pd_isna(value))
+        except (TypeError, ValueError):
+            return False
+    # pandas absent: a `datetime64`/`timedelta64` NaT still reaches here on numpy
+    # builds whose `np.isnan` rejects datetime dtypes; `np.isnat` drops it
+    # robustly. Any other unrecognised scalar is a real, colourable value.
+    try:
+        return bool(np.isnat(value))
+    except (TypeError, ValueError):
+        return False
+
+
 def categorize(
     values: np.ndarray | Sequence,
     cmap: str | colors.Colormap = "tab10",
@@ -1919,67 +1977,7 @@ def categorize(
     except ImportError:
         _pd_isna = None
 
-    def _is_null(value: Any) -> bool:
-        """Return whether a scalar `value` is a missing/null entry to drop.
-
-        Recognises every null flavour a categorical column can carry -- ``None``,
-        ``float('nan')`` / ``np.nan`` (via ``np.isnan``), ``np.datetime64('NaT')``
-        (via ``np.isnan``, or ``pd.isna`` / ``np.isnat`` on numpy builds whose
-        ``np.isnan`` rejects datetime dtypes -- ``pd.isna`` when pandas is
-        present, ``np.isnat`` when it is absent), and pandas' own ``pd.NA`` /
-        ``pd.NaT`` sentinels (via the once-resolved ``pd.isna``) -- so the
-        category set never depends on the source dtype.
-
-        Args:
-            value: A single (already-flattened) scalar from ``values``.
-
-        Returns:
-            bool: ``True`` if `value` is null and should be dropped; ``False``
-            otherwise. A container argument (list/tuple/dict/set/ndarray) also
-            returns ``False`` -- it is never treated as null, via an early
-            short-circuit that keeps it away from the scalar ``np.isnan`` check
-            -- though a container is not itself colourable and would fail later
-            in deduplication.
-        """
-        if value is None:
-            return True
-        if isinstance(value, (list, tuple, dict, set, np.ndarray)):
-            return False
-        # A string/bytes label -- the most common categorical value -- is never
-        # null, so short-circuit before the `np.isnan` TypeError + `pd.isna`
-        # dispatch that every non-numeric scalar would otherwise pay per element.
-        if isinstance(value, (str, bytes)):
-            return False
-        try:
-            return bool(np.isnan(value))
-        except (TypeError, ValueError):
-            # TypeError: not a float/datetime scalar (str, pd.NA, ...).
-            # ValueError: an array-like element (e.g. `range`) made `np.isnan`
-            # return an array, so `bool(...)` is ambiguous -- fall through and
-            # let the guarded pandas/`np.isnat` checks classify it as non-null.
-            pass
-        # pandas' own sentinels (`pd.NA` / `pd.NaT`) raise under `np.isnan`
-        # ("boolean value of NA is ambiguous"); catch them with the
-        # once-resolved `pd.isna` when pandas is available. Guard the call the
-        # same way as `np.isnat` below: an array-like element not caught by the
-        # container short-circuit (e.g. a `range` or nested `Series`) makes
-        # `pd.isna` return an array, and `bool(array)` raises `ValueError` --
-        # such an odd element is simply not null (carried through as base does).
-        if _pd_isna is not None:
-            try:
-                return bool(_pd_isna(value))
-            except (TypeError, ValueError):
-                return False
-        # pandas absent: a `datetime64`/`timedelta64` NaT still reaches here on
-        # numpy builds whose `np.isnan` rejects datetime dtypes; `np.isnat`
-        # drops it robustly (version-independent) so NaT never leaks in as a
-        # class. Any other unrecognised scalar is a real, colourable value.
-        try:
-            return bool(np.isnat(value))
-        except (TypeError, ValueError):
-            return False
-
-    seen = list(dict.fromkeys(v for v in raw if not _is_null(v)))
+    seen = list(dict.fromkeys(v for v in raw if not _categorical_is_null(v, _pd_isna)))
     if not seen:
         raise ValueError("Cannot categorize: `values` has no non-null entries.")
     try:

--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1908,14 +1908,25 @@ def categorize(
     """
     raw = np.asarray(values, dtype=object).ravel().tolist()
 
+    # Resolve pandas' scalar null check once (not per element). pandas is an
+    # undeclared soft dependency of cleopatra, so bind `pd.isna` when it is
+    # importable and fall back to the numpy-only path otherwise -- `pd.NA` /
+    # `pd.NaT` cannot exist unless pandas is installed. `except ImportError`
+    # (broader than `ModuleNotFoundError`) also degrades gracefully on a
+    # broken/partial pandas install rather than crashing categorisation.
+    try:
+        from pandas import isna as _pd_isna
+    except ImportError:
+        _pd_isna = None
+
     def _is_null(value: Any) -> bool:
         """Return whether a scalar `value` is a missing/null entry to drop.
 
         Recognises every null flavour a categorical column can carry -- ``None``,
-        ``float('nan')`` / ``np.nan``, ``np.datetime64('NaT')`` (all via
-        ``np.isnan``), and pandas' own ``pd.NA`` / ``pd.NaT`` sentinels (via a
-        lazily-imported ``pd.isna`` fallback) -- so the category set never
-        depends on the source dtype.
+        ``float('nan')`` / ``np.nan``, ``np.datetime64('NaT')`` (via ``np.isnan``),
+        and pandas' own ``pd.NA`` / ``pd.NaT`` sentinels (via the once-resolved
+        ``pd.isna`` fallback) -- so the category set never depends on the source
+        dtype.
 
         Args:
             value: A single (already-flattened) scalar from ``values``.
@@ -1933,17 +1944,13 @@ def categorize(
             return bool(np.isnan(value))
         except TypeError:
             pass
-        # pandas' own null sentinels (`pd.NA` / `pd.NaT`) raise under
-        # `np.isnan` (`bool(np.isnan(pd.NA))` -> "boolean value of NA is
-        # ambiguous"), so they fall through to here. They can only exist when
-        # pandas is installed -- an undeclared soft dependency -- so import it
-        # lazily and treat the value as non-null when pandas is absent (the
-        # sentinels cannot occur in that case).
-        try:
-            import pandas as pd
-        except ModuleNotFoundError:
+        # pandas' own sentinels (`pd.NA` / `pd.NaT`) raise under `np.isnan`
+        # ("boolean value of NA is ambiguous"); catch them with the
+        # once-resolved `pd.isna` when pandas is available, else treat the
+        # value as non-null (the sentinels cannot occur without pandas).
+        if _pd_isna is None:
             return False
-        return bool(pd.isna(value))
+        return bool(_pd_isna(value))
 
     seen = list(dict.fromkeys(v for v in raw if not _is_null(v)))
     if not seen:

--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1933,8 +1933,11 @@ def categorize(
 
         Returns:
             bool: ``True`` if `value` is null and should be dropped; ``False``
-            for a real, colourable value (including any container argument,
-            which short-circuits before the scalar null checks).
+            otherwise. A container argument (list/tuple/dict/set/ndarray) also
+            returns ``False`` -- it is never treated as null, via an early
+            short-circuit that keeps it away from the scalar ``np.isnan`` check
+            -- though a container is not itself colourable and would fail later
+            in deduplication.
         """
         if value is None:
             return True

--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1809,7 +1809,11 @@ def categorize(
     the auto-derived equivalent of a hand-authored `colors.DATA_STYLES`
     categorical preset. Values are sorted when they support `<` (numbers,
     strings); otherwise first-encounter order is kept. Null entries
-    (`None` / `NaN`) never become a category. Deduplication is by Python
+    (`None`, `NaN`, and pandas' own `pd.NA` / `pd.NaT` sentinels) never
+    become a category, so categorisation is dtype-independent: the same
+    data yields the same categories whether a missing value arrives as
+    `None`, `float('nan')`, or a pandas nullable-dtype sentinel.
+    Deduplication is by Python
     `hash`/`==`, so values that are *equal but differently typed* collapse
     into one category, same as any other Python `dict`/`set`: `1`, `1.0`,
     and `True` are indistinguishable class codes here (`1 == True` and
@@ -1905,6 +1909,22 @@ def categorize(
     raw = np.asarray(values, dtype=object).ravel().tolist()
 
     def _is_null(value: Any) -> bool:
+        """Return whether a scalar `value` is a missing/null entry to drop.
+
+        Recognises every null flavour a categorical column can carry -- ``None``,
+        ``float('nan')`` / ``np.nan``, ``np.datetime64('NaT')`` (all via
+        ``np.isnan``), and pandas' own ``pd.NA`` / ``pd.NaT`` sentinels (via a
+        lazily-imported ``pd.isna`` fallback) -- so the category set never
+        depends on the source dtype.
+
+        Args:
+            value: A single (already-flattened) scalar from ``values``.
+
+        Returns:
+            bool: ``True`` if `value` is null and should be dropped; ``False``
+            for a real, colourable value (including any container argument,
+            which short-circuits before the scalar null checks).
+        """
         if value is None:
             return True
         if isinstance(value, (list, tuple, dict, set, np.ndarray)):

--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1949,9 +1949,16 @@ def categorize(
             pass
         # pandas' own sentinels (`pd.NA` / `pd.NaT`) raise under `np.isnan`
         # ("boolean value of NA is ambiguous"); catch them with the
-        # once-resolved `pd.isna` when pandas is available.
+        # once-resolved `pd.isna` when pandas is available. Guard the call the
+        # same way as `np.isnat` below: an array-like element not caught by the
+        # container short-circuit (e.g. a `range` or nested `Series`) makes
+        # `pd.isna` return an array, and `bool(array)` raises `ValueError` --
+        # such an odd element is simply not null (carried through as base does).
         if _pd_isna is not None:
-            return bool(_pd_isna(value))
+            try:
+                return bool(_pd_isna(value))
+            except (TypeError, ValueError):
+                return False
         # pandas absent: a `datetime64`/`timedelta64` NaT still reaches here on
         # numpy builds whose `np.isnan` rejects datetime dtypes; `np.isnat`
         # drops it robustly (version-independent) so NaT never leaks in as a

--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1945,7 +1945,11 @@ def categorize(
             return False
         try:
             return bool(np.isnan(value))
-        except TypeError:
+        except (TypeError, ValueError):
+            # TypeError: not a float/datetime scalar (str, pd.NA, ...).
+            # ValueError: an array-like element (e.g. `range`) made `np.isnan`
+            # return an array, so `bool(...)` is ambiguous -- fall through and
+            # let the guarded pandas/`np.isnat` checks classify it as non-null.
             pass
         # pandas' own sentinels (`pd.NA` / `pd.NaT`) raise under `np.isnan`
         # ("boolean value of NA is ambiguous"); catch them with the

--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1923,10 +1923,10 @@ def categorize(
         """Return whether a scalar `value` is a missing/null entry to drop.
 
         Recognises every null flavour a categorical column can carry -- ``None``,
-        ``float('nan')`` / ``np.nan``, ``np.datetime64('NaT')`` (via ``np.isnan``),
-        and pandas' own ``pd.NA`` / ``pd.NaT`` sentinels (via the once-resolved
-        ``pd.isna`` fallback) -- so the category set never depends on the source
-        dtype.
+        ``float('nan')`` / ``np.nan`` (via ``np.isnan``), ``np.datetime64('NaT')``
+        (via ``np.isnan`` or, when pandas is absent, ``np.isnat``), and pandas'
+        own ``pd.NA`` / ``pd.NaT`` sentinels (via the once-resolved ``pd.isna``)
+        -- so the category set never depends on the source dtype.
 
         Args:
             value: A single (already-flattened) scalar from ``values``.
@@ -1946,11 +1946,17 @@ def categorize(
             pass
         # pandas' own sentinels (`pd.NA` / `pd.NaT`) raise under `np.isnan`
         # ("boolean value of NA is ambiguous"); catch them with the
-        # once-resolved `pd.isna` when pandas is available, else treat the
-        # value as non-null (the sentinels cannot occur without pandas).
-        if _pd_isna is None:
+        # once-resolved `pd.isna` when pandas is available.
+        if _pd_isna is not None:
+            return bool(_pd_isna(value))
+        # pandas absent: a `datetime64`/`timedelta64` NaT still reaches here on
+        # numpy builds whose `np.isnan` rejects datetime dtypes; `np.isnat`
+        # drops it robustly (version-independent) so NaT never leaks in as a
+        # class. Any other unrecognised scalar is a real, colourable value.
+        try:
+            return bool(np.isnat(value))
+        except (TypeError, ValueError):
             return False
-        return bool(_pd_isna(value))
 
     seen = list(dict.fromkeys(v for v in raw if not _is_null(v)))
     if not seen:

--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1943,6 +1943,11 @@ def categorize(
             return True
         if isinstance(value, (list, tuple, dict, set, np.ndarray)):
             return False
+        # A string/bytes label -- the most common categorical value -- is never
+        # null, so short-circuit before the `np.isnan` TypeError + `pd.isna`
+        # dispatch that every non-numeric scalar would otherwise pay per element.
+        if isinstance(value, (str, bytes)):
+            return False
         try:
             return bool(np.isnan(value))
         except (TypeError, ValueError):

--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1912,7 +1912,18 @@ def categorize(
         try:
             return bool(np.isnan(value))
         except TypeError:
+            pass
+        # pandas' own null sentinels (`pd.NA` / `pd.NaT`) raise under
+        # `np.isnan` (`bool(np.isnan(pd.NA))` -> "boolean value of NA is
+        # ambiguous"), so they fall through to here. They can only exist when
+        # pandas is installed -- an undeclared soft dependency -- so import it
+        # lazily and treat the value as non-null when pandas is absent (the
+        # sentinels cannot occur in that case).
+        try:
+            import pandas as pd
+        except ModuleNotFoundError:
             return False
+        return bool(pd.isna(value))
 
     seen = list(dict.fromkeys(v for v in raw if not _is_null(v)))
     if not seen:

--- a/src/cleopatra/styling/styles.py
+++ b/src/cleopatra/styling/styles.py
@@ -1924,9 +1924,11 @@ def categorize(
 
         Recognises every null flavour a categorical column can carry -- ``None``,
         ``float('nan')`` / ``np.nan`` (via ``np.isnan``), ``np.datetime64('NaT')``
-        (via ``np.isnan`` or, when pandas is absent, ``np.isnat``), and pandas'
-        own ``pd.NA`` / ``pd.NaT`` sentinels (via the once-resolved ``pd.isna``)
-        -- so the category set never depends on the source dtype.
+        (via ``np.isnan``, or ``pd.isna`` / ``np.isnat`` on numpy builds whose
+        ``np.isnan`` rejects datetime dtypes -- ``pd.isna`` when pandas is
+        present, ``np.isnat`` when it is absent), and pandas' own ``pd.NA`` /
+        ``pd.NaT`` sentinels (via the once-resolved ``pd.isna``) -- so the
+        category set never depends on the source dtype.
 
         Args:
             value: A single (already-flattened) scalar from ``values``.

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -249,7 +249,8 @@ class TestCategorize:
         """
         categories, _ = categorize(np.array(["a", "b", range(3)], dtype=object))
         cats = list(categories)
-        assert "a" in cats and "b" in cats, f"real labels lost: {cats}"
+        assert "a" in cats, f"real label 'a' lost: {cats}"
+        assert "b" in cats, f"real label 'b' lost: {cats}"
         assert len(cats) == 3, f"array-like element not carried through: {cats}"
 
     def test_colors_aligned_with_categories(self):

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -220,6 +220,23 @@ class TestCategorize:
         categories, _ = categorize(np.array(real + [np.datetime64("NaT")], dtype=object))
         assert len(categories) == 2, f"NaT leaked via isnat fallback: {categories}"
 
+    def test_pandas_nullable_dtype_missing_dropped(self):
+        """A genuine pandas nullable dtype's missing entry is dropped (issue #302).
+
+        Test scenario:
+            Build the input from real nullable dtypes -- an `Int64` array and a
+            `string` Series -- whose missing entries materialise as `pd.NA`
+            rather than being hand-placed in an object array. Categorisation
+            must yield only the distinct real values, proving genuine
+            dtype-independence through the actual pandas conversion path.
+        """
+        pd = pytest.importorskip("pandas")
+        int_cats, _ = categorize(pd.array([1, 2, pd.NA, 1], dtype="Int64"))
+        assert list(int_cats) == [1, 2], f"Int64 pd.NA leaked into categories: {int_cats}"
+
+        str_cats, _ = categorize(pd.Series(["a", "b", None, "a"], dtype="string"))
+        assert list(str_cats) == ["a", "b"], f"string-dtype null leaked into categories: {str_cats}"
+
     def test_colors_aligned_with_categories(self):
         """Colours and categories have the same length, one-to-one.
 

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -179,6 +179,47 @@ class TestCategorize:
         )
         assert list(categories) == ["a", "b"], f"Mixed null kinds leaked: {categories}"
 
+    def test_numpy_datetime_nat_dropped(self):
+        """A pure-numpy `datetime64('NaT')` is dropped, not coloured (issue #302).
+
+        Test scenario:
+            NaT arrives as a numpy datetime (no pandas sentinel involved). It
+            must be dropped so a numpy datetime categorical never gains a
+            spurious NaT class alongside its real timestamps.
+        """
+        real = [np.datetime64("2020-01-01"), np.datetime64("2021-01-01")]
+        categories, _ = categorize(np.array(real + [np.datetime64("NaT")], dtype=object))
+        assert len(categories) == 2, f"numpy NaT leaked into categories: {categories}"
+
+    def test_datetime_nat_dropped_via_isnat_without_pandas(self, monkeypatch):
+        """`datetime64('NaT')` is dropped by `np.isnat` when pandas is absent (M2).
+
+        Test scenario:
+            Reproduce the silent-regression edge: a numpy whose `np.isnan`
+            rejects `datetime64` (patched to raise), with pandas unavailable.
+            The `np.isnat` fallback must still drop NaT so it never becomes a
+            colour class, while real timestamps survive.
+        """
+        real_np_isnan = np.isnan
+
+        def isnan_no_datetime(value):
+            if isinstance(value, np.datetime64):
+                raise TypeError("simulated: np.isnan rejects datetime64")
+            return real_np_isnan(value)
+
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name == "pandas" or name.startswith("pandas."):
+                raise ModuleNotFoundError("No module named 'pandas'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(np, "isnan", isnan_no_datetime)
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        real = [np.datetime64("2020-01-01"), np.datetime64("2021-01-01")]
+        categories, _ = categorize(np.array(real + [np.datetime64("NaT")], dtype=object))
+        assert len(categories) == 2, f"NaT leaked via isnat fallback: {categories}"
+
     def test_colors_aligned_with_categories(self):
         """Colours and categories have the same length, one-to-one.
 

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -519,8 +519,10 @@ class TestGlyphPrepareCategoricalMapping:
             `color_scale` is ignored -- and a warning says so.
         """
         glyph = ScatterGlyph(np.arange(4.0), np.zeros(4), values=np.array(["a", "b", "a", "b"]))
+        classify = Classify(scheme="categorical")
+        color = ColorScaling.midpoint()
         with pytest.warns(UserWarning, match="color_scale"):
-            glyph.plot(classify=Classify(scheme="categorical"), color=ColorScaling.midpoint())
+            glyph.plot(classify=classify, color=color)
 
     def test_warns_on_conflicting_levels(self):
         """`scheme="categorical"` together with `levels` warns.
@@ -530,8 +532,10 @@ class TestGlyphPrepareCategoricalMapping:
             ignored -- and a warning says so.
         """
         glyph = ScatterGlyph(np.arange(4.0), np.zeros(4), values=np.array(["a", "b", "a", "b"]))
+        classify = Classify(scheme="categorical")
+        contour = Contour(levels=3)
         with pytest.warns(UserWarning, match="levels"):
-            glyph.plot(classify=Classify(scheme="categorical"), contour=Contour(levels=3))
+            glyph.plot(classify=classify, contour=contour)
 
 
 class TestPolygonGlyphCategorical:

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -237,6 +237,21 @@ class TestCategorize:
         str_cats, _ = categorize(pd.Series(["a", "b", None, "a"], dtype="string"))
         assert list(str_cats) == ["a", "b"], f"string-dtype null leaked into categories: {str_cats}"
 
+    def test_arraylike_object_element_does_not_crash(self):
+        """An array-like object element is carried through, not crashed on.
+
+        Test scenario:
+            A non-container array-like (e.g. `range`) stored in an object array
+            is not a null sentinel, but `pd.isna` returns an array for it and
+            `bool(array)` would raise `ValueError`. `categorize` must guard that
+            and keep the element as a (non-null) value, matching base behaviour,
+            rather than crashing.
+        """
+        categories, _ = categorize(np.array(["a", "b", range(3)], dtype=object))
+        cats = list(categories)
+        assert "a" in cats and "b" in cats, f"real labels lost: {cats}"
+        assert len(cats) == 3, f"array-like element not carried through: {cats}"
+
     def test_colors_aligned_with_categories(self):
         """Colours and categories have the same length, one-to-one.
 

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -18,6 +18,8 @@ Covers:
 
 from __future__ import annotations
 
+import builtins
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -101,6 +103,54 @@ class TestCategorize:
             "urban",
             "water",
         ], f"Null entries leaked into categories: {categories}"
+
+    def test_pandas_null_sentinels_dropped(self):
+        """pandas' `pd.NA` / `pd.NaT` are dropped, not coloured (issue #302).
+
+        Test scenario:
+            `categorize` must be dtype-independent: identical categorical data
+            yields the same categories whether a missing value is `None`,
+            `np.nan`, or a pandas sentinel. `pd.NA`/`pd.NaT` raise "boolean
+            value of NA is ambiguous" under `np.isnan`, so without the
+            `pd.isna` fallback they slip past the null test and become an extra
+            coloured class.
+        """
+        pd = pytest.importorskip("pandas")
+        na_cats, _ = categorize(np.array(["a", "b", pd.NA, "a"], dtype=object))
+        assert list(na_cats) == ["a", "b"], f"pd.NA leaked into categories: {na_cats}"
+
+        nat_cats, _ = categorize(
+            np.array(
+                [pd.Timestamp("2020-01-01"), pd.Timestamp("2021-01-01"), pd.NaT],
+                dtype=object,
+            )
+        )
+        assert len(nat_cats) == 2, f"pd.NaT leaked into categories: {nat_cats}"
+
+    def test_categorize_without_pandas(self, monkeypatch):
+        """Categorisation still works when pandas is not installed (no hard dep).
+
+        Test scenario:
+            Non-null strings raise `TypeError` under `np.isnan`, so they reach
+            the lazy `import pandas` in the null check. Simulate pandas being
+            absent: the import raises `ModuleNotFoundError`, the value falls
+            back to non-null, and categorisation succeeds -- proving pandas
+            stays an optional soft dependency rather than a runtime requirement.
+        """
+        real_import = builtins.__import__
+
+        def blocked_import(name, *args, **kwargs):
+            if name == "pandas" or name.startswith("pandas."):
+                raise ModuleNotFoundError("No module named 'pandas'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", blocked_import)
+        categories, _ = categorize(["urban", "water", None, "forest", np.nan])
+        assert list(categories) == [
+            "forest",
+            "urban",
+            "water",
+        ], f"categorize must not require pandas: {categories}"
 
     def test_colors_aligned_with_categories(self):
         """Colours and categories have the same length, one-to-one.

--- a/tests/test_categorize.py
+++ b/tests/test_categorize.py
@@ -152,6 +152,33 @@ class TestCategorize:
             "water",
         ], f"categorize must not require pandas: {categories}"
 
+    def test_all_pandas_null_raises(self):
+        """An all-`pd.NA` input has no category to assign (issue #302).
+
+        Test scenario:
+            Every entry is a pandas null sentinel, so after dropping there is
+            nothing to categorize -- the same `ValueError` as the all-`None`/
+            `NaN` case, not a silent empty result.
+        """
+        pd = pytest.importorskip("pandas")
+        with pytest.raises(ValueError, match="no non-null entries"):
+            categorize(np.array([pd.NA, pd.NA], dtype=object))
+
+    def test_mixed_null_kinds_dtype_independent(self):
+        """`None`, `np.nan`, and `pd.NA` mixed drop to the same categories.
+
+        Test scenario:
+            A single array carrying every null flavour yields only the two
+            real categories -- categorisation depends on the distinct real
+            values, never on which null sentinel (or column dtype) produced
+            the missing entries.
+        """
+        pd = pytest.importorskip("pandas")
+        categories, _ = categorize(
+            np.array(["a", None, "b", np.nan, pd.NA, "a"], dtype=object)
+        )
+        assert list(categories) == ["a", "b"], f"Mixed null kinds leaked: {categories}"
+
     def test_colors_aligned_with_categories(self):
         """Colours and categories have the same length, one-to-one.
 


### PR DESCRIPTION
# Description

`cleopatra.styling.styles.categorize` assigns one colour per distinct non-null value and drops nulls. Its inner
`_is_null` check recognised only `None` and `np.nan`: pandas' own null sentinels (`pd.NA` / `pd.NaT`) raise
`TypeError: boolean value of NA is ambiguous` under `np.isnan` and fell through to the *not-null* branch, so they
became their own coloured category.

The effect was a silent, **dtype-dependent** inconsistency — the same categorical data rendered with a different
number of colours depending only on the column dtype (`object`/`None` vs a pandas nullable `string`/`Int64`/
`datetime64[NaT]`), and a genuinely-missing value could render as a labelled `<NA>` class.

**Fix:** when `np.isnan` raises, fall back to pandas' scalar `pd.isna`, which uniformly recognises `None`,
`np.nan`, `pd.NA`, and `pd.NaT`. pandas is **not** a declared dependency of cleopatra (deps are numpy / matplotlib /
pillow / imageio-ffmpeg / hpc-utils, and pandas is unused in `src/`), so it is imported **lazily** inside the null
check and the code falls back to "non-null" when pandas is absent — the sentinels cannot occur without pandas
installed. No new runtime dependency; stays within scope (matplotlib-only over in-memory NumPy).

The in-glyph categorical path (`Glyph._prepare_categorical_mapping`, used by `scheme="categorical"`) delegates to
`categorize`, so it is fixed by the same change — no duplicate null logic exists.

**Not in scope of the report:** `np.datetime64('NaT')` was already handled (it satisfies `np.isnan`); the only real
gaps were `pd.NA` and `pd.NaT`.

# Issues
- Closes #302 — categorize treats pandas nulls (pd.NA/pd.NaT) as a category

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

Two new tests in `tests/test_categorize.py`:

- [x] `test_pandas_null_sentinels_dropped` — `pd.NA` in a string array and `pd.NaT` in a timestamp array are dropped
  (categories match the identical `None`/`np.nan` data). Skips cleanly via `importorskip` if pandas is unavailable.
- [x] `test_categorize_without_pandas` — monkeypatches the import so `import pandas` raises `ModuleNotFoundError`;
  string categorisation still succeeds, proving pandas stays an optional soft dependency (no hard requirement).
- [x] Full `test_categorize.py` (46) + categorical consumers (`test_styles`, `test_colors`, `test_polygon_glyph`,
  `test_scatter_glyph`) — **322 passed**; `styles.py` doctests — 23 passed.

Repro before the fix:
```python
import numpy as np, pandas as pd
from cleopatra.styling.styles import categorize
len(categorize(np.array(["a","b",np.nan,"a"], dtype=object), "tab10")[1])  # 2  ✓
len(categorize(np.array(["a","b",pd.NA, "a"], dtype=object), "tab10")[1])  # 3 -> now 2  ✓
```

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes