### PR TITLE
perf(array_glyph): count domain cells without materialising a per-cell index list

### DIFF
--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -981,12 +981,13 @@ class ArrayGlyph(GeoMixin, Glyph):
         extent (List): The extent of the array [xmin, xmax, ymin, ymax].
         rgb (bool): Whether the array is an RGB array.
         num_domain_cells (int): Number of cells in the data domain — cells
-            that are neither masked (via `exclude_value`) nor NaN. Counted on
-            the first frame of a 3-D `(n, h, w)` stack. For a single-band frame
-            it equals the number of per-cell value labels drawn when
-            `display_cell_value=True`. For a 4-D `(n, h, w, 3)` RGB stack it is
-            counted over the first frame's elements and is informational (RGB
-            renders draw no per-cell labels).
+            that are neither masked (via `exclude_value`) nor NaN. A stack
+            (3-D `(n, h, w)` grey or 4-D `(n, h, w, 3)`) is counted on its first
+            frame; a single frame (2-D, or an `(h, w, 3)` RGB image from
+            `rgb_bands`) is counted whole. For a single-band frame it equals the
+            number of per-cell value labels drawn when `display_cell_value=True`;
+            for multi-channel RGB data it counts elements and is informational
+            (RGB renders draw no per-cell labels).
         anim (matplotlib.animation.FuncAnimation): The animation object if created.
         im (matplotlib.cm.ScalarMappable): The colour-mapped artist produced by
             the most recent `plot`/`animate` call (e.g. the `AxesImage` for
@@ -1325,10 +1326,13 @@ class ArrayGlyph(GeoMixin, Glyph):
         # Count in-domain cells (neither `exclude_value`-masked nor NaN) with a
         # pure-numpy reduction. The old `len(get_indices2(first_frame, [np.nan]))`
         # allocated one Python tuple per cell -- O(n) objects that raised a
-        # MemoryError on a large RGB animation stack -- and its `len(shape) == 3`
-        # frame pick selected the whole 4-D `(n, h, w, 3)` stack instead of one
-        # frame. `array` is always an `ma.array` by here, so honour its mask too.
-        first_frame = array[0] if array.ndim >= 3 else array
+        # MemoryError on a large true-colour animation stack -- and its
+        # `len(shape) == 3` frame pick selected the whole 4-D `(n, h, w, 3)`
+        # stack instead of one frame. Count a stack (3-D `(n, h, w)` grey or 4-D
+        # `(n, h, w, 3)`) on frame 0; count a single frame -- 2-D, or an
+        # `(h, w, 3)` RGB image from `rgb_bands` (also 3-D) -- whole. `array` is
+        # always an `ma.array` by here, so honour its mask too.
+        first_frame = array if (self.rgb or array.ndim < 3) else array[0]
         in_domain = ~(
             ma.getmaskarray(first_frame) | np.isnan(ma.getdata(first_frame))
         )

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -1041,6 +1041,29 @@ class ArrayGlyph(GeoMixin, Glyph):
     #: Option keys this glyph accepts (see `Glyph.option_keys`/`filter_kwargs`).
     DEFAULT_OPTIONS = ARRAY_DEFAULT_OPTIONS
 
+    @staticmethod
+    def _count_domain_cells(array: np.ndarray, is_rgb: bool) -> int:
+        """Count the in-domain cells -- neither `exclude_value`-masked nor NaN.
+
+        Replaces the old `len(get_indices2(frame, [np.nan]))`, which allocated
+        one Python tuple per cell (O(n) objects that raised `MemoryError` on a
+        large animation stack). A stack (3-D `(n, h, w)` grey or 4-D
+        `(n, h, w, 3)`) is counted on frame 0; a single frame -- 2-D, or an
+        `(h, w, 3)` RGB image from `rgb_bands` (also 3-D) -- is counted whole.
+
+        Args:
+            array: The already-masked input array (an `ma.array`).
+            is_rgb: Whether `array` is a single band-last RGB image.
+
+        Returns:
+            int: The number of in-domain cells on the counted frame.
+        """
+        first_frame = array if (is_rgb or array.ndim < 3) else array[0]
+        in_domain = ~(
+            ma.getmaskarray(first_frame) | np.isnan(ma.getdata(first_frame))
+        )
+        return int(np.count_nonzero(in_domain))
+
     def __init__(
         self,
         array: np.ndarray,
@@ -1323,20 +1346,7 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         self._arr = array
         self.ticks_spacing = (self._vmax - self._vmin) / 10 or 1.0
-        # Count in-domain cells (neither `exclude_value`-masked nor NaN) with a
-        # pure-numpy reduction. The old `len(get_indices2(first_frame, [np.nan]))`
-        # allocated one Python tuple per cell -- O(n) objects that raised a
-        # MemoryError on a large true-colour animation stack -- and its
-        # `len(shape) == 3` frame pick selected the whole 4-D `(n, h, w, 3)`
-        # stack instead of one frame. Count a stack (3-D `(n, h, w)` grey or 4-D
-        # `(n, h, w, 3)`) on frame 0; count a single frame -- 2-D, or an
-        # `(h, w, 3)` RGB image from `rgb_bands` (also 3-D) -- whole. `array` is
-        # always an `ma.array` by here, so honour its mask too.
-        first_frame = array if (self.rgb or array.ndim < 3) else array[0]
-        in_domain = ~(
-            ma.getmaskarray(first_frame) | np.isnan(ma.getdata(first_frame))
-        )
-        self.num_domain_cells = int(np.count_nonzero(in_domain))
+        self.num_domain_cells = self._count_domain_cells(array, self.rgb)
         self.im: Any = None
         self.cbar: Colorbar | None = None
         self._day_text: Any = None

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -981,10 +981,12 @@ class ArrayGlyph(GeoMixin, Glyph):
         extent (List): The extent of the array [xmin, xmax, ymin, ymax].
         rgb (bool): Whether the array is an RGB array.
         num_domain_cells (int): Number of cells in the data domain — cells
-            that are neither masked (via `exclude_value`) nor NaN. For a
-            3-D `(n, h, w)` or 4-D `(n, h, w, 3)` stack this is counted on the
-            first frame. Equals the number of per-cell value labels drawn when
-            `display_cell_value=True`.
+            that are neither masked (via `exclude_value`) nor NaN. Counted on
+            the first frame of a 3-D `(n, h, w)` stack. For a single-band frame
+            it equals the number of per-cell value labels drawn when
+            `display_cell_value=True`. For a 4-D `(n, h, w, 3)` RGB stack it is
+            counted over the first frame's elements and is informational (RGB
+            renders draw no per-cell labels).
         anim (matplotlib.animation.FuncAnimation): The animation object if created.
         im (matplotlib.cm.ScalarMappable): The colour-mapped artist produced by
             the most recent `plot`/`animate` call (e.g. the `AxesImage` for

--- a/src/cleopatra/glyphs/gridded/array_glyph.py
+++ b/src/cleopatra/glyphs/gridded/array_glyph.py
@@ -982,8 +982,9 @@ class ArrayGlyph(GeoMixin, Glyph):
         rgb (bool): Whether the array is an RGB array.
         num_domain_cells (int): Number of cells in the data domain — cells
             that are neither masked (via `exclude_value`) nor NaN. For a
-            3-D stack this is counted on the first frame. Equals the number
-            of per-cell value labels drawn when `display_cell_value=True`.
+            3-D `(n, h, w)` or 4-D `(n, h, w, 3)` stack this is counted on the
+            first frame. Equals the number of per-cell value labels drawn when
+            `display_cell_value=True`.
         anim (matplotlib.animation.FuncAnimation): The animation object if created.
         im (matplotlib.cm.ScalarMappable): The colour-mapped artist produced by
             the most recent `plot`/`animate` call (e.g. the `AxesImage` for
@@ -1319,9 +1320,17 @@ class ArrayGlyph(GeoMixin, Glyph):
 
         self._arr = array
         self.ticks_spacing = (self._vmax - self._vmin) / 10 or 1.0
-        shape = array.shape
-        first_frame = array[0, :, :] if len(shape) == 3 else array
-        self.num_domain_cells = len(get_indices2(first_frame, [np.nan]))
+        # Count in-domain cells (neither `exclude_value`-masked nor NaN) with a
+        # pure-numpy reduction. The old `len(get_indices2(first_frame, [np.nan]))`
+        # allocated one Python tuple per cell -- O(n) objects that raised a
+        # MemoryError on a large RGB animation stack -- and its `len(shape) == 3`
+        # frame pick selected the whole 4-D `(n, h, w, 3)` stack instead of one
+        # frame. `array` is always an `ma.array` by here, so honour its mask too.
+        first_frame = array[0] if array.ndim >= 3 else array
+        in_domain = ~(
+            ma.getmaskarray(first_frame) | np.isnan(ma.getdata(first_frame))
+        )
+        self.num_domain_cells = int(np.count_nonzero(in_domain))
         self.im: Any = None
         self.cbar: Colorbar | None = None
         self._day_text: Any = None

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2188,6 +2188,18 @@ class TestNanNoDataConvention:
             f"{glyph.num_domain_cells}"
         )
 
+    def test_num_domain_cells_counts_whole_single_rgb_image(self):
+        """A single RGB image from `rgb_bands` is 3-D `(h, w, 3)` -- a lone
+        frame, so the count is the whole image (`h*w*3`), not one row: `rgb`
+        distinguishes it from an `(n, h, w)` grey stack."""
+        band_first = np.random.default_rng(0).random((3, 4, 5))
+        glyph = ArrayGlyph(band_first, rgb_bands=RgbBands([0, 1, 2]))
+        assert glyph.rgb is True, "rgb_bands input should set rgb=True"
+        assert glyph.num_domain_cells == 4 * 5 * 3, (
+            f"a single (4, 5, 3) RGB image has {4 * 5 * 3} in-domain elements, "
+            f"got {glyph.num_domain_cells}"
+        )
+
     def test_animate_display_cell_value_true_with_nan_nodata(self):
         """`animate(display_cell_value=True)` on a NaN-nodata stack runs
         without `IndexError` (the cell-update loop iterates the artist list,

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2149,6 +2149,17 @@ class TestNanNoDataConvention:
             f"all cells are in-domain; got {glyph.num_domain_cells}"
         )
 
+    def test_num_domain_cells_integer_array_counts_all_cells(self):
+        """On an integer array every cell is in-domain: `np.isnan` on integer
+        data is all-False, so the mask-aware reduction returns the full size
+        (guards the non-float dtype path of the count)."""
+        arr = np.arange(20, dtype=int).reshape(4, 5)
+        glyph = ArrayGlyph(arr)
+        assert glyph.num_domain_cells == arr.size, (
+            f"all {arr.size} integer cells are in-domain, got "
+            f"{glyph.num_domain_cells}"
+        )
+
     def test_animate_display_cell_value_true_with_nan_nodata(self):
         """`animate(display_cell_value=True)` on a NaN-nodata stack runs
         without `IndexError` (the cell-update loop iterates the artist list,

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2110,6 +2110,45 @@ class TestNanNoDataConvention:
             f"(expected {expected}), got {glyph.num_domain_cells}"
         )
 
+    def test_num_domain_cells_counts_first_frame_of_4d_rgb_stack(self):
+        """On a 4-D `(n, h, w, 3)` RGB stack the count is taken on the first
+        *frame* (`array[0]`), not the whole stack -- the old `len(shape) == 3`
+        check selected the entire `(n, h, w, 3)` array (issue #304)."""
+        stack = np.random.default_rng(0).random((3, 4, 5, 3))  # 3 RGB frames
+        stack[0, 0, 0, 0] = np.nan  # one NaN in frame 0
+        glyph = ArrayGlyph(stack)
+        expected = int(np.count_nonzero(~np.isnan(stack[0])))  # frame 0 only
+        assert glyph.num_domain_cells == expected, (
+            f"expected the first-frame domain count {expected}, got "
+            f"{glyph.num_domain_cells}"
+        )
+        assert glyph.num_domain_cells < stack.size, (
+            "count must be per-frame, not over the whole 4-D stack"
+        )
+
+    def test_num_domain_cells_excludes_exclude_value_masked_cells(self):
+        """`num_domain_cells` also excludes `exclude_value`-masked cells, not
+        only NaN -- the mask-aware count matches the old `get_indices2`
+        behaviour (a plain `~isnan` would over-count the masked cell)."""
+        arr = np.arange(25, dtype=float).reshape(5, 5)
+        arr[0, 0] = -9999.0  # a no-data cell to mask via exclude_value
+        arr[1, 1] = np.nan  # plus a NaN cell
+        glyph = ArrayGlyph(arr, exclude_value=[-9999.0])
+        assert glyph.num_domain_cells == 23, (
+            f"count should exclude both the masked and the NaN cell "
+            f"(expected 23), got {glyph.num_domain_cells}"
+        )
+
+    def test_large_rgb_stack_constructs_without_materialising_index_list(self):
+        """A large-per-frame 4-D RGB stack constructs without the old per-cell
+        tuple-list allocation that raised `MemoryError`; ~3M cells per frame,
+        counted on one frame so it stays cheap (issue #304)."""
+        stack = np.ones((2, 1000, 1000, 3), dtype="float32")
+        glyph = ArrayGlyph(stack)
+        assert glyph.num_domain_cells == 1000 * 1000 * 3, (
+            f"all cells are in-domain; got {glyph.num_domain_cells}"
+        )
+
     def test_animate_display_cell_value_true_with_nan_nodata(self):
         """`animate(display_cell_value=True)` on a NaN-nodata stack runs
         without `IndexError` (the cell-update loop iterates the artist list,

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2110,11 +2110,12 @@ class TestNanNoDataConvention:
             f"(expected {expected}), got {glyph.num_domain_cells}"
         )
 
-    def test_num_domain_cells_counts_first_frame_of_4d_rgb_stack(self):
-        """On a 4-D `(n, h, w, 3)` RGB stack the count is taken on the first
-        *frame* (`array[0]`), not the whole stack -- the old `len(shape) == 3`
-        check selected the entire `(n, h, w, 3)` array (issue #304)."""
-        stack = np.random.default_rng(0).random((3, 4, 5, 3))  # 3 RGB frames
+    def test_num_domain_cells_counts_first_frame_of_4d_stack(self):
+        """On a 4-D `(n, h, w, 3)` stack the count is taken on the first frame
+        (`array[0]`), not the whole stack -- the old `len(shape) == 3` check
+        selected the entire `(n, h, w, 3)` array (issue #304). Uses a bare 4-D
+        array (no `rgb_bands`); only the count logic is under test."""
+        stack = np.random.default_rng(0).random((3, 4, 5, 3))  # 3 frames
         stack[0, 0, 0, 0] = np.nan  # one NaN in frame 0
         glyph = ArrayGlyph(stack)
         expected = int(np.count_nonzero(~np.isnan(stack[0])))  # frame 0 only
@@ -2139,14 +2140,16 @@ class TestNanNoDataConvention:
             f"(expected 23), got {glyph.num_domain_cells}"
         )
 
-    def test_large_rgb_stack_constructs_without_materialising_index_list(self):
-        """A large-per-frame 4-D RGB stack constructs without the old per-cell
-        tuple-list allocation that raised `MemoryError`; ~3M cells per frame,
-        counted on one frame so it stays cheap (issue #304)."""
+    def test_large_4d_stack_uses_cheap_per_frame_count(self):
+        """A large-per-frame 4-D `(n, h, w, 3)` stack constructs and the count
+        is over one frame (~3M elements), not the whole stack -- a
+        clean-construction / per-frame-count guard for the numpy reduction that
+        replaced the old per-cell index list (issue #304)."""
         stack = np.ones((2, 1000, 1000, 3), dtype="float32")
         glyph = ArrayGlyph(stack)
         assert glyph.num_domain_cells == 1000 * 1000 * 3, (
-            f"all cells are in-domain; got {glyph.num_domain_cells}"
+            f"count is over one (1000, 1000, 3) frame; got "
+            f"{glyph.num_domain_cells}"
         )
 
     def test_num_domain_cells_integer_array_counts_all_cells(self):

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2160,6 +2160,31 @@ class TestNanNoDataConvention:
             f"{glyph.num_domain_cells}"
         )
 
+    def test_num_domain_cells_counts_first_frame_of_3d_stack(self):
+        """On a multi-frame 3-D `(n, h, w)` stack the count is on frame 0 only:
+        NaNs placed in a later frame (none in frame 0) leave the count at the
+        full frame size."""
+        stack = np.random.default_rng(1).random((3, 4, 5)) * 100.0
+        stack[2, 0, 0] = np.nan  # NaN only in frame 2, not frame 0
+        stack[2, 1, 1] = np.nan
+        glyph = ArrayGlyph(stack)
+        assert glyph.num_domain_cells == 4 * 5, (
+            f"frame 0 has no NaN, so all {4 * 5} cells are in-domain; got "
+            f"{glyph.num_domain_cells}"
+        )
+
+    def test_num_domain_cells_zero_when_first_frame_all_nan(self):
+        """`num_domain_cells` is 0 when frame 0 is entirely NaN, even though a
+        later frame carries data (which keeps the colour range valid) — the
+        count is on frame 0 and its domain is empty."""
+        stack = np.ones((2, 4, 5))
+        stack[0] = np.nan  # frame 0 all-NaN; frame 1 has data (no ValueError)
+        glyph = ArrayGlyph(stack)
+        assert glyph.num_domain_cells == 0, (
+            f"frame 0 is all-NaN so its domain is empty, got "
+            f"{glyph.num_domain_cells}"
+        )
+
     def test_animate_display_cell_value_true_with_nan_nodata(self):
         """`animate(display_cell_value=True)` on a NaN-nodata stack runs
         without `IndexError` (the cell-update loop iterates the artist list,

--- a/tests/test_array_glyph.py
+++ b/tests/test_array_glyph.py
@@ -2200,6 +2200,19 @@ class TestNanNoDataConvention:
             f"got {glyph.num_domain_cells}"
         )
 
+    def test_num_domain_cells_masked_stack_counts_first_frame_only(self):
+        """`exclude_value` masking on a 3-D stack is honoured but only on frame
+        0: a no-data value in frame 0 and in a later frame excludes just the
+        frame-0 occurrence from the count."""
+        stack = np.arange(2 * 4 * 5, dtype=float).reshape(2, 4, 5)
+        stack[0, 0, 0] = -9999.0  # masked cell in frame 0
+        stack[1, 2, 2] = -9999.0  # masked cell in a later frame (ignored)
+        glyph = ArrayGlyph(stack, exclude_value=[-9999.0])
+        assert glyph.num_domain_cells == 4 * 5 - 1, (
+            f"only the frame-0 masked cell should be excluded, got "
+            f"{glyph.num_domain_cells}"
+        )
+
     def test_animate_display_cell_value_true_with_nan_nodata(self):
         """`animate(display_cell_value=True)` on a NaN-nodata stack runs
         without `IndexError` (the cell-update loop iterates the artist list,


### PR DESCRIPTION
# Description

`ArrayGlyph.__init__` computed `num_domain_cells` as `len(get_indices2(first_frame, [np.nan]))`, which builds one
Python tuple per cell (O(n) objects), and its `len(shape) == 3` check picked the whole 4-D `(n, h, w, 3)` stack
instead of a single frame. On a large RGB animation stack that raised `MemoryError` — the animation could not be
built at all — and on large single frames it was thousands of times slower and ~71× more memory than needed
(measurements in #304). The attribute is never read elsewhere in the package, so the whole cost bought an unused
value.

Replace it with a pure-numpy, mask-aware reduction, extracted into a small helper:

```python
@staticmethod
def _count_domain_cells(array: np.ndarray, is_rgb: bool) -> int:
    first_frame = array if (is_rgb or array.ndim < 3) else array[0]
    in_domain = ~(ma.getmaskarray(first_frame) | np.isnan(ma.getdata(first_frame)))
    return int(np.count_nonzero(in_domain))
```

- **O(1) in Python objects** → no `MemoryError`, and ~3000× faster on large frames.
- **Correct frame selection.** A stack (3-D `(n, h, w)` grey or 4-D `(n, h, w, 3)`) is counted on frame 0; a single
  frame — 2-D, or an `(h, w, 3)` RGB image from `rgb_bands` — is counted whole. Using `self.rgb` distinguishes a lone
  `(h, w, 3)` RGB image from an `(n, h, w)` grey stack (both 3-D), fixing a latent miscount where such an image
  counted only its first row.
- **Mask-aware:** by this point `array` is always an `ma.array`, so the count excludes both `exclude_value`-masked
  and NaN cells — byte-equivalent to the old `get_indices2`.
- Extracted into `ArrayGlyph._count_domain_cells` (keeps `__init__` under the cognitive-complexity threshold and
  makes the logic directly testable).

**Deviation from the issue's proposed fix:** #304 suggested `np.count_nonzero(~np.isnan(first_frame))`. That would
regress the `exclude_value` case — `get_indices2` also excludes *masked* cells (`masked_no_nan`: old 24 vs plain
`~isnan` 25), so the fix keeps the mask term. Equivalence to the old count was confirmed across float / int /
masked / 3-D / 4-D inputs.

No change to the public meaning of `num_domain_cells` — identical counts for the previously-correct shapes, plus a
corrected count for 4-D stacks and single RGB images.

# Issues

- Closes #304 — count domain cells without materialising a per-cell index list

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

- **Regression tests** in `TestNanNoDataConvention`: 4-D first-frame count; 3-D multi-frame first-frame selection;
  zero-domain (frame-0 all-NaN); `exclude_value` masking on a 2-D array and on a multi-frame stack; a single
  `(h, w, 3)` RGB image counted whole; a large 4-D stack; and an integer array.
- **Existing contracts hold** — `num_domain_cells == 89` and `test_num_domain_cells_excludes_nan_cells`.
- Equivalence to the old `get_indices2` count verified across float / int / masked / masked-and-NaN / 3-D / 4-D
  inputs.
- Reviewed with two independent adversarial rounds (`/review-rounds`); all findings resolved.
- [x] Full non-e2e suite: **2291 passed**; ruff clean; **SonarCloud: 0 open issues**.

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
