### PR TITLE
feat(basemap): add world_texture() and mercator_to_equirectangular

### DIFF
--- a/src/cleopatra/basemap/tiles.py
+++ b/src/cleopatra/basemap/tiles.py
@@ -35,11 +35,13 @@ Examples:
 
 from __future__ import annotations
 
+import hashlib
 import html
 import importlib.util
 import io
 import logging
 import math
+import os
 import re
 import urllib.error
 import urllib.parse
@@ -51,6 +53,7 @@ import numpy as np
 
 from cleopatra import __version__
 from cleopatra.basemap._net import urlopen_http
+from cleopatra.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +156,13 @@ _EARTH_RADIUS = 6378137.0
 #: Circumference of the Web Mercator sphere (metres): the width and height,
 #: in projected metres, of the whole world at any zoom level.
 _CIRCUMFERENCE = 2 * math.pi * _EARTH_RADIUS
+
+#: Half the Web Mercator circumference (metres): the projected x/y extent from
+#: the origin to the antimeridian / pole clamp, i.e. `pi * _EARTH_RADIUS`
+#: (~20 037 508 m). The `(west, south, east, north)` extent `stitch_tiles`
+#: returns is in these units, and `mercator_to_equirectangular` maps lon/lat
+#: edges onto them.
+_MERC_MAX = _CIRCUMFERENCE / 2.0
 
 #: The maximum (and, negated, minimum) latitude Web Mercator can represent --
 #: beyond this the projection's `y` coordinate diverges to infinity. XYZ tile
@@ -1152,3 +1162,221 @@ def add_tiles(
         )
 
     return ax
+
+
+def mercator_to_equirectangular(
+    mosaic: np.ndarray,
+    bounds: tuple[float, float, float, float],
+    n_lon: int = 2880,
+    n_lat: int = 1440,
+) -> np.ndarray:
+    """Resample a Web Mercator image onto an equirectangular lon/lat grid.
+
+    XYZ tiles -- and the mosaic `stitch_tiles` builds from them -- are in Web
+    Mercator (EPSG:3857), where a degree of latitude occupies more pixels near
+    the poles. A globe, or a plain lon/lat (EPSG:4326) axis, is textured in
+    equirectangular longitude and latitude, so the mosaic must be resampled
+    from its Mercator rows onto evenly spaced latitude rows.
+
+    Each output cell area-averages the whole contiguous block of source pixels
+    that falls inside it, found from the cell's **edges** -- not a fixed number
+    of point samples, which over-reads the compressed equatorial rows and skips
+    source rows near the poles, exactly where Mercator's stretch makes aliasing
+    worst. Latitudes beyond the Mercator limit (`+/-85.051` deg) clamp onto the
+    edge rows; a cell thinner than one source pixel keeps that single row.
+
+    Args:
+        mosaic: The Web Mercator image, `(H, W)` or `(H, W, C)`, north-up
+            (row 0 = north), as returned by `stitch_tiles`.
+        bounds: `(west, south, east, north)` of `mosaic` in EPSG:3857 metres,
+            as returned by `stitch_tiles`. Read from the mosaic rather than
+            assumed global, so a partial mosaic reprojects correctly.
+        n_lon: Width of the output grid, spanning -180..180 degrees.
+        n_lat: Height of the output grid, spanning 90..-90 degrees.
+
+    Returns:
+        numpy.ndarray: The `(n_lat, n_lon)` or `(n_lat, n_lon, C)`
+        equirectangular resample as `float32`, in the same value scale as
+        `mosaic` (a `uint8` 0..255 mosaic yields 0..255 floats -- averaging is
+        inherently fractional; `world_texture` normalises to 0..1).
+
+    Raises:
+        ValueError: If `mosaic` is not 2-D or 3-D, `n_lon`/`n_lat` are not
+            positive, or `bounds` is degenerate (`east <= west` or
+            `north <= south`).
+
+    Examples:
+        - A west-blue / east-red Mercator mosaic keeps its longitudinal order
+            after resampling (Web Mercator x is linear in longitude):
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.basemap.tiles import mercator_to_equirectangular
+            >>> m = np.zeros((4, 8, 3), dtype="uint8")
+            >>> m[:, :4] = (0, 0, 255)
+            >>> m[:, 4:] = (255, 0, 0)
+            >>> world = (-20037508.34, -20037508.34, 20037508.34, 20037508.34)
+            >>> tex = mercator_to_equirectangular(m, world, n_lon=8, n_lat=4)
+            >>> tex.shape
+            (4, 8, 3)
+            >>> bool(tex[0, 0, 2] > tex[0, 0, 0])  # west stays blue
+            True
+            >>> bool(tex[0, -1, 0] > tex[0, -1, 2])  # east stays red
+            True
+
+            ```
+    """
+    mosaic = np.asarray(mosaic)
+    if mosaic.ndim not in (2, 3):
+        raise ValueError(f"mosaic must be a 2-D or 3-D array, got {mosaic.ndim}-D")
+    if n_lon < 1 or n_lat < 1:
+        raise ValueError(
+            f"n_lon and n_lat must be positive, got n_lon={n_lon}, n_lat={n_lat}"
+        )
+    west, south, east, north = (float(v) for v in bounds)
+    if not (east > west and north > south):
+        raise ValueError(
+            "bounds must be (west, south, east, north) with east > west and "
+            f"north > south, got {bounds!r}"
+        )
+    h, w = mosaic.shape[:2]
+
+    lat_edges = np.clip(
+        np.linspace(90.0, -90.0, n_lat + 1), -_MAX_LATITUDE, _MAX_LATITUDE
+    )
+    y_edges = np.log(np.tan(np.pi / 4 + np.deg2rad(lat_edges) / 2)) * _MERC_MAX / np.pi
+    row_edges = np.clip(
+        np.round((north - y_edges) / (north - south) * h).astype(int), 0, h
+    )
+    x_edges = np.linspace(-180.0, 180.0, n_lon + 1) / 180.0 * _MERC_MAX
+    col_edges = np.clip(
+        np.round((x_edges - west) / (east - west) * w).astype(int), 0, w
+    )
+
+    # reduceat sums each [start[i]:start[i+1]] block; the edge-derived widths
+    # (min 1) turn the sums into means and keep a collapsed polar row on its own.
+    row_start = np.minimum(row_edges[:-1], h - 1)
+    col_start = np.minimum(col_edges[:-1], w - 1)
+    row_w = np.maximum(np.diff(row_edges), 1)[:, None].astype("float32")
+    col_w = np.maximum(np.diff(col_edges), 1)[None, :].astype("float32")
+
+    flat = mosaic.reshape(h, w, -1)  # (H, W, C), C == 1 for a 2-D mosaic
+    bands = []
+    for band_index in range(flat.shape[2]):
+        # One band at a time: the float32 copy of a large mosaic is heavy, and
+        # converting every band at once multiplies the transient peak.
+        band = flat[..., band_index].astype("float32")
+        band = np.add.reduceat(band, row_start, axis=0) / row_w
+        bands.append(np.add.reduceat(band, col_start, axis=1) / col_w)
+    grid = np.stack(bands, axis=-1)
+    return grid[..., 0] if mosaic.ndim == 2 else grid
+
+
+def world_texture(
+    provider: str | None = None,
+    *,
+    zoom: int = 5,
+    n_lon: int = 2880,
+    n_lat: int = 1440,
+    cache: bool = True,
+    max_workers: int = 8,
+    timeout: int = 10,
+    retries: int = 2,
+    user_agent: str = USER_AGENT,
+) -> np.ndarray:
+    """Fetch a whole-world XYZ tile basemap as an equirectangular texture.
+
+    The XYZ-provider analogue of `cleopatra.basemap.reference.relief`: it
+    fetches every tile of the `zoom`-level world grid, stitches them into a Web
+    Mercator mosaic, and resamples that onto an equirectangular lon/lat grid
+    (`mercator_to_equirectangular`), so the result can texture a globe or back
+    an EPSG:4326 axis. Unlike `relief` (a fixed re-hosted asset), this pulls
+    live tiles from any `xyzservices` provider.
+
+    The grid is `2**zoom` tiles per side (`4**zoom` total -- 1024 at the default
+    zoom 5), so the texture is cached on disk and fetched once per
+    `(provider, zoom, n_lon, n_lat)`.
+
+    Args:
+        provider: An `xyzservices` provider name (e.g. `"Esri.WorldImagery"`);
+            `None` uses the default (`OpenStreetMap.Mapnik`). Resolved by
+            `get_provider`.
+        zoom: Tile zoom level; the world grid is `2**zoom` tiles per side.
+        n_lon: Width of the returned texture, spanning -180..180 degrees.
+        n_lat: Height of the returned texture, spanning 90..-90 degrees.
+        cache: When `True` (default), read/write the texture under
+            `Config.get_cache_dir()/"world-textures"` so the tiles are fetched
+            once. `False` always refetches.
+        max_workers: Maximum concurrent tile HTTP connections.
+        timeout: Per-tile HTTP request timeout in seconds.
+        retries: Per-tile retry count on failure.
+        user_agent: `User-Agent` header sent on every tile request.
+
+    Returns:
+        numpy.ndarray: The `(n_lat, n_lon, 3)` texture as `float32` in `[0, 1]`
+        (RGB; the tiles' alpha is dropped). This differs from
+        `reference.relief`, which returns `uint8` 0..255.
+
+    Raises:
+        ImportError: If the `[tiles]` extra (xyzservices, Pillow, pyproj) is
+            not installed.
+        ValueError: If `zoom` is negative or `n_lon`/`n_lat` are not positive.
+        ConnectionError: If any tile cannot be fetched after all retries.
+
+    Examples:
+        - Fetch a coarse world texture (network-dependent, hence skipped under
+            doctest):
+            ```python
+            >>> from cleopatra.basemap.tiles import world_texture
+            >>> tex = world_texture("Esri.WorldImagery", zoom=2)  # doctest: +SKIP
+            >>> tex.shape, tex.dtype.name  # doctest: +SKIP
+            ((1440, 2880, 3), 'float32')
+
+            ```
+    """
+    _require_tiles_extra()
+    if zoom < 0:
+        raise ValueError(f"zoom must be non-negative, got {zoom}")
+    if n_lon < 1 or n_lat < 1:
+        raise ValueError(
+            f"n_lon and n_lat must be positive, got n_lon={n_lon}, n_lat={n_lat}"
+        )
+    resolved = get_provider(provider)
+
+    cache_path = None
+    if cache:
+        name = re.sub(r"[^0-9A-Za-z]+", "_", str(resolved.get("name", "default")))
+        digest = hashlib.blake2s(
+            repr((name, zoom, n_lon, n_lat)).encode(), digest_size=8
+        ).hexdigest()
+        cache_dir = Config.get_cache_dir() / "world-textures"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = cache_dir / f"{name}_z{zoom}_{digest}.npy"
+        if cache_path.exists():
+            return np.load(cache_path)
+
+    side = 2**zoom
+    tiles = [Tile(x, y, zoom) for x in range(side) for y in range(side)]
+    mosaic, bounds = stitch_tiles(
+        fetch_tiles(
+            tiles,
+            resolved,
+            max_workers=max_workers,
+            timeout=timeout,
+            retries=retries,
+            user_agent=user_agent,
+        ),
+        tiles,
+        zoom,
+    )
+    rgb = np.asarray(mosaic)[..., :3]
+    texture = mercator_to_equirectangular(rgb, bounds, n_lon=n_lon, n_lat=n_lat)
+    texture = np.clip(texture / 255.0, 0.0, 1.0).astype("float32")
+
+    if cache_path is not None:
+        # Write aside and rename: np.save straight onto the final path leaves a
+        # truncated array under the name the next run trusts if it is interrupted.
+        tmp = cache_path.with_name(cache_path.name + ".tmp")
+        with open(tmp, "wb") as fh:
+            np.save(fh, texture)
+        os.replace(tmp, cache_path)
+    return texture

--- a/src/cleopatra/basemap/tiles.py
+++ b/src/cleopatra/basemap/tiles.py
@@ -1286,7 +1286,7 @@ def mercator_to_equirectangular(
 
 
 def world_texture(
-    provider: str | None = None,
+    provider: Any = None,
     *,
     zoom: int = 5,
     n_lon: int = 2880,
@@ -1317,9 +1317,10 @@ def world_texture(
         whole-world textures.
 
     Args:
-        provider: An `xyzservices` provider name (e.g. `"Esri.WorldImagery"`);
-            `None` uses the default (`OpenStreetMap.Mapnik`). Resolved by
-            `get_provider`.
+        provider: An `xyzservices` provider name (e.g. `"Esri.WorldImagery"`) or
+            a resolved `xyzservices.TileProvider` (as `add_tiles` accepts);
+            `None` uses the default (`OpenStreetMap.Mapnik`). A name is resolved
+            by `get_provider`.
         zoom: Tile zoom level (0..6); the world grid is `2**zoom` tiles per side.
         n_lon: Width of the returned texture, spanning -180..180 degrees.
         n_lat: Height of the returned texture, spanning 90..-90 degrees.
@@ -1364,7 +1365,11 @@ def world_texture(
         raise ValueError(
             f"n_lon and n_lat must be positive, got n_lon={n_lon}, n_lat={n_lat}"
         )
-    resolved = get_provider(provider)
+    # Accept a name string or a resolved TileProvider, matching add_tiles.
+    if isinstance(provider, str) or provider is None:
+        resolved = get_provider(provider)
+    else:
+        resolved = provider
 
     cache_path = None
     if cache:

--- a/src/cleopatra/basemap/tiles.py
+++ b/src/cleopatra/basemap/tiles.py
@@ -1189,8 +1189,10 @@ def mercator_to_equirectangular(
         mosaic: The Web Mercator image, `(H, W)` or `(H, W, C)`, north-up
             (row 0 = north), as returned by `stitch_tiles`.
         bounds: `(west, south, east, north)` of `mosaic` in EPSG:3857 metres,
-            as returned by `stitch_tiles`. Read from the mosaic rather than
-            assumed global, so a partial mosaic reprojects correctly.
+            as returned by `stitch_tiles`. The output always spans the whole
+            globe (-180..180, 90..-90); latitudes and longitudes outside the
+            mosaic's coverage clamp onto its edge rows/columns rather than
+            being cropped, so a partial mosaic is placed within a full frame.
         n_lon: Width of the output grid, spanning -180..180 degrees.
         n_lat: Height of the output grid, spanning 90..-90 degrees.
 
@@ -1252,12 +1254,18 @@ def mercator_to_equirectangular(
         np.round((x_edges - west) / (east - west) * w).astype(int), 0, w
     )
 
-    # reduceat sums each [start[i]:start[i+1]] block; the edge-derived widths
-    # (min 1) turn the sums into means and keep a collapsed polar row on its own.
+    # reduceat sums each block band[start[i]:start[i+1]] (the last runs to the
+    # array end). The block END is the next *capped* start, not the raw edge, so
+    # size the mean's divisor from the actual block widths: otherwise the south
+    # clamp (row_edges == h collapses start to h-1) sums one row fewer than it
+    # divides by, darkening the row near -85 deg S. max(.,1) keeps a collapsed
+    # polar row (next start == start) on its own.
     row_start = np.minimum(row_edges[:-1], h - 1)
     col_start = np.minimum(col_edges[:-1], w - 1)
-    row_w = np.maximum(np.diff(row_edges), 1)[:, None].astype("float32")
-    col_w = np.maximum(np.diff(col_edges), 1)[None, :].astype("float32")
+    row_next = np.concatenate([row_start[1:], [h]])
+    col_next = np.concatenate([col_start[1:], [w]])
+    row_w = np.maximum(row_next - row_start, 1)[:, None].astype("float32")
+    col_w = np.maximum(col_next - col_start, 1)[None, :].astype("float32")
 
     flat = mosaic.reshape(h, w, -1)  # (H, W, C), C == 1 for a 2-D mosaic
     bands = []

--- a/src/cleopatra/basemap/tiles.py
+++ b/src/cleopatra/basemap/tiles.py
@@ -35,6 +35,7 @@ Examples:
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import html
 import importlib.util
@@ -1418,7 +1419,7 @@ def world_texture(
                 np.save(fh, texture)
             os.replace(tmp_name, cache_path)
         except BaseException:
-            if os.path.exists(tmp_name):
+            with contextlib.suppress(FileNotFoundError):
                 os.remove(tmp_name)
             raise
     return texture

--- a/src/cleopatra/basemap/tiles.py
+++ b/src/cleopatra/basemap/tiles.py
@@ -43,6 +43,7 @@ import logging
 import math
 import os
 import re
+import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -1381,7 +1382,12 @@ def world_texture(
         cache_dir.mkdir(parents=True, exist_ok=True)
         cache_path = cache_dir / f"{name}_z{zoom}_{digest}.npy"
         if cache_path.exists():
-            return np.load(cache_path)
+            try:
+                return np.load(cache_path)
+            except (OSError, ValueError, EOFError):
+                # A truncated / foreign / pre-atomic .npy: drop it and rebuild
+                # (as reference.relief does with a poisoned cached asset).
+                cache_path.unlink(missing_ok=True)
 
     side = 2**zoom
     tiles = [Tile(x, y, zoom) for x in range(side) for y in range(side)]
@@ -1402,10 +1408,17 @@ def world_texture(
     texture = np.clip(texture / 255.0, 0.0, 1.0).astype("float32")
 
     if cache_path is not None:
-        # Write aside and rename: np.save straight onto the final path leaves a
-        # truncated array under the name the next run trusts if it is interrupted.
-        tmp = cache_path.with_name(cache_path.name + ".tmp")
-        with open(tmp, "wb") as fh:
-            np.save(fh, texture)
-        os.replace(tmp, cache_path)
+        # Write to a unique temp file, then rename: np.save straight onto the
+        # final path leaves a truncated array under the name the next run trusts
+        # if it is interrupted, and a fixed .tmp name lets concurrent same-key
+        # writes clobber each other. Remove the temp if the write fails.
+        fd, tmp_name = tempfile.mkstemp(dir=cache_path.parent, suffix=".npy.tmp")
+        try:
+            with os.fdopen(fd, "wb") as fh:
+                np.save(fh, texture)
+            os.replace(tmp_name, cache_path)
+        except BaseException:
+            if os.path.exists(tmp_name):
+                os.remove(tmp_name)
+            raise
     return texture

--- a/src/cleopatra/basemap/tiles.py
+++ b/src/cleopatra/basemap/tiles.py
@@ -164,6 +164,12 @@ _CIRCUMFERENCE = 2 * math.pi * _EARTH_RADIUS
 #: edges onto them.
 _MERC_MAX = _CIRCUMFERENCE / 2.0
 
+#: Highest zoom `world_texture` will fetch. A world grid is `2**zoom` tiles per
+#: side, i.e. `4**zoom` tiles; zoom 6 already pulls 4096 tiles and stitches a
+#: ~16k x 16k (~1 GB) mosaic. Higher zooms would exhaust memory, so they are
+#: rejected rather than attempted.
+_MAX_WORLD_ZOOM = 6
+
 #: The maximum (and, negated, minimum) latitude Web Mercator can represent --
 #: beyond this the projection's `y` coordinate diverges to infinity. XYZ tile
 #: grids clip to this band and simply do not cover the poles.
@@ -1301,14 +1307,20 @@ def world_texture(
     live tiles from any `xyzservices` provider.
 
     The grid is `2**zoom` tiles per side (`4**zoom` total -- 1024 at the default
-    zoom 5), so the texture is cached on disk and fetched once per
-    `(provider, zoom, n_lon, n_lat)`.
+    zoom 5, capped at zoom 6 / 4096 tiles), so the texture is cached on disk and
+    fetched once per `(provider, zoom, n_lon, n_lat)`.
+
+    Note:
+        A whole-world fetch pulls thousands of tiles. The default provider,
+        `OpenStreetMap.Mapnik`, prohibits bulk downloading in its usage policy;
+        pass a bulk-permitting imagery provider (e.g. `"Esri.WorldImagery"`) for
+        whole-world textures.
 
     Args:
         provider: An `xyzservices` provider name (e.g. `"Esri.WorldImagery"`);
             `None` uses the default (`OpenStreetMap.Mapnik`). Resolved by
             `get_provider`.
-        zoom: Tile zoom level; the world grid is `2**zoom` tiles per side.
+        zoom: Tile zoom level (0..6); the world grid is `2**zoom` tiles per side.
         n_lon: Width of the returned texture, spanning -180..180 degrees.
         n_lat: Height of the returned texture, spanning 90..-90 degrees.
         cache: When `True` (default), read/write the texture under
@@ -1327,7 +1339,8 @@ def world_texture(
     Raises:
         ImportError: If the `[tiles]` extra (xyzservices, Pillow, pyproj) is
             not installed.
-        ValueError: If `zoom` is negative or `n_lon`/`n_lat` are not positive.
+        ValueError: If `zoom` is outside `0..6`, or `n_lon`/`n_lat` are not
+            positive.
         ConnectionError: If any tile cannot be fetched after all retries.
 
     Examples:
@@ -1342,8 +1355,11 @@ def world_texture(
             ```
     """
     _require_tiles_extra()
-    if zoom < 0:
-        raise ValueError(f"zoom must be non-negative, got {zoom}")
+    if not 0 <= zoom <= _MAX_WORLD_ZOOM:
+        raise ValueError(
+            f"zoom must be between 0 and {_MAX_WORLD_ZOOM} (a world grid is "
+            f"4**zoom tiles; a higher zoom would exhaust memory), got {zoom}"
+        )
     if n_lon < 1 or n_lat < 1:
         raise ValueError(
             f"n_lon and n_lat must be positive, got n_lon={n_lon}, n_lat={n_lat}"

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -42,7 +42,9 @@ from cleopatra.basemap.tiles import (  # noqa: E402
     fetch_single_tile,
     fetch_tiles,
     get_provider,
+    mercator_to_equirectangular,
     stitch_tiles,
+    world_texture,
 )
 
 
@@ -1386,3 +1388,144 @@ class TestAddTilesNearGlobalExtent:
         assert max(xs) >= 2**3 - 1, (
             "should include tiles from the eastern half of the split (x near the grid edge)"
         )
+
+
+def _world_bounds() -> tuple[float, float, float, float]:
+    """The full-world EPSG:3857 extent `(west, south, east, north)` in metres."""
+    m = tiles_mod._MERC_MAX
+    return (-m, -m, m, m)
+
+
+def _fetch_split_by_x():
+    """A `fetch_tiles` stand-in: west tiles solid blue, east tiles solid red."""
+
+    def fake(tile_list, provider, **kwargs):
+        out = {}
+        for tile in tile_list:
+            half = 2**tile.z // 2
+            colour = (0, 0, 255, 255) if tile.x < half else (255, 0, 0, 255)
+            buf = io.BytesIO()
+            Image.new("RGBA", (256, 256), colour).save(buf, "PNG")
+            out[tile] = buf.getvalue()
+        return out
+
+    return fake
+
+
+class TestMercatorToEquirectangular:
+    """Tests for `cleopatra.basemap.tiles.mercator_to_equirectangular`."""
+
+    def test_returns_equirectangular_shape_and_float32(self):
+        """A 3-band mosaic resamples to an `(n_lat, n_lon, 3)` float32 grid."""
+        tex = mercator_to_equirectangular(
+            np.zeros((16, 16, 3), "uint8"), _world_bounds(), n_lon=8, n_lat=6
+        )
+        assert tex.shape == (6, 8, 3), f"unexpected shape {tex.shape}"
+        assert tex.dtype == np.float32, f"expected float32, got {tex.dtype}"
+
+    def test_two_dimensional_mosaic_stays_2d(self):
+        """A single-band (2-D) mosaic returns a 2-D `(n_lat, n_lon)` grid."""
+        tex = mercator_to_equirectangular(
+            np.zeros((16, 16), "uint8"), _world_bounds(), n_lon=8, n_lat=6
+        )
+        assert tex.shape == (6, 8), f"unexpected shape {tex.shape}"
+
+    def test_preserves_west_east_longitude_order(self):
+        """West-blue / east-red survives the resample (x is linear in longitude)."""
+        m = np.zeros((8, 8, 3), "uint8")
+        m[:, :4] = (0, 0, 255)
+        m[:, 4:] = (255, 0, 0)
+        tex = mercator_to_equirectangular(m, _world_bounds(), n_lon=8, n_lat=6)
+        assert (tex[:, 0, 2] > tex[:, 0, 0]).all(), "west column should stay blue"
+        assert (tex[:, -1, 0] > tex[:, -1, 2]).all(), "east column should stay red"
+
+    def test_preserves_north_south_latitude_order(self):
+        """North-red / south-blue keeps red at the top (north-up, origin upper)."""
+        m = np.zeros((8, 8, 3), "uint8")
+        m[:4] = (255, 0, 0)
+        m[4:] = (0, 0, 255)
+        tex = mercator_to_equirectangular(m, _world_bounds(), n_lon=8, n_lat=8)
+        assert tex[0, 0, 0] > tex[0, 0, 2], "north row should stay red"
+        assert tex[-1, 0, 2] > tex[-1, 0, 0], "south row should stay blue"
+
+    def test_value_scale_preserved_and_averaged(self):
+        """A constant uint8 mosaic yields that same value as float32 (0..255)."""
+        tex = mercator_to_equirectangular(
+            np.full((8, 8, 1), 200, "uint8"), _world_bounds(), n_lon=4, n_lat=4
+        )
+        assert tex.dtype == np.float32, f"expected float32, got {tex.dtype}"
+        assert np.allclose(tex, 200.0), "a constant mosaic stays at its value"
+
+    @pytest.mark.parametrize("bad", [np.zeros((2,)), np.zeros((2, 2, 2, 2))])
+    def test_rejects_non_2d_3d_mosaic(self, bad):
+        """A 1-D or 4-D mosaic raises `ValueError`."""
+        with pytest.raises(ValueError, match="2-D or 3-D"):
+            mercator_to_equirectangular(bad, _world_bounds())
+
+    @pytest.mark.parametrize("n_lon,n_lat", [(0, 4), (4, 0), (-1, 4)])
+    def test_rejects_non_positive_grid(self, n_lon, n_lat):
+        """A non-positive `n_lon`/`n_lat` raises `ValueError`."""
+        with pytest.raises(ValueError, match="must be positive"):
+            mercator_to_equirectangular(
+                np.zeros((4, 4, 3)), _world_bounds(), n_lon=n_lon, n_lat=n_lat
+            )
+
+    @pytest.mark.parametrize("bounds", [(1.0, 1.0, 0.0, 2.0), (0.0, 2.0, 2.0, 1.0)])
+    def test_rejects_degenerate_bounds(self, bounds):
+        """Bounds with `east <= west` or `north <= south` raise `ValueError`."""
+        with pytest.raises(ValueError, match="east > west"):
+            mercator_to_equirectangular(np.zeros((4, 4, 3)), bounds)
+
+
+class TestWorldTexture:
+    """Tests for `cleopatra.basemap.tiles.world_texture`."""
+
+    def test_returns_float32_texture_in_unit_range(self, tmp_path, monkeypatch):
+        """A whole-world fetch resamples to an `(n_lat, n_lon, 3)` float32 in [0, 1]."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(tiles_mod, "fetch_tiles", _fetch_split_by_x())
+        tex = world_texture(zoom=1, n_lon=16, n_lat=8)
+        assert tex.shape == (8, 16, 3), f"unexpected shape {tex.shape}"
+        assert tex.dtype == np.float32, f"expected float32, got {tex.dtype}"
+        assert 0.0 <= float(tex.min()) and float(tex.max()) <= 1.0, "not in [0, 1]"
+
+    def test_preserves_longitude_order(self, tmp_path, monkeypatch):
+        """West tiles (blue) stay west end-to-end through fetch/stitch/reproject."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(tiles_mod, "fetch_tiles", _fetch_split_by_x())
+        tex = world_texture(zoom=1, n_lon=16, n_lat=8)
+        assert tex[4, 0, 2] > tex[4, 0, 0], "west should be blue"
+        assert tex[4, -1, 0] > tex[4, -1, 2], "east should be red"
+
+    def test_caches_texture_and_skips_refetch(self, tmp_path, monkeypatch):
+        """A second call reads the on-disk cache instead of refetching tiles."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        fetch = MagicMock(side_effect=_fetch_split_by_x())
+        monkeypatch.setattr(tiles_mod, "fetch_tiles", fetch)
+        first = world_texture(zoom=1, n_lon=8, n_lat=4)
+        second = world_texture(zoom=1, n_lon=8, n_lat=4)
+        assert fetch.call_count == 1, "the second call should hit the cache"
+        assert np.array_equal(first, second), "cached texture should match"
+
+    def test_cache_false_always_refetches(self, tmp_path, monkeypatch):
+        """`cache=False` refetches on every call."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        fetch = MagicMock(side_effect=_fetch_split_by_x())
+        monkeypatch.setattr(tiles_mod, "fetch_tiles", fetch)
+        world_texture(zoom=1, n_lon=8, n_lat=4, cache=False)
+        world_texture(zoom=1, n_lon=8, n_lat=4, cache=False)
+        assert fetch.call_count == 2, "cache=False must not reuse a cached texture"
+
+    def test_missing_extra_raises_import_error(self, monkeypatch):
+        """Without the `[tiles]` extra, `world_texture` raises `ImportError`."""
+        monkeypatch.setattr(tiles_mod, "_TILES_AVAILABLE", False)
+        with pytest.raises(ImportError, match=r"cleopatra\[tiles\]"):
+            world_texture(zoom=0)
+
+    @pytest.mark.parametrize(
+        "kwargs", [{"zoom": -1}, {"zoom": 1, "n_lon": 0}, {"zoom": 1, "n_lat": 0}]
+    )
+    def test_rejects_invalid_params(self, kwargs):
+        """A negative zoom or non-positive grid dimension raises `ValueError`."""
+        with pytest.raises(ValueError):
+            world_texture(**kwargs)

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1530,9 +1530,15 @@ class TestWorldTexture:
             world_texture(zoom=0)
 
     @pytest.mark.parametrize(
-        "kwargs", [{"zoom": -1}, {"zoom": 1, "n_lon": 0}, {"zoom": 1, "n_lat": 0}]
+        "kwargs",
+        [
+            {"zoom": -1},
+            {"zoom": 7},
+            {"zoom": 1, "n_lon": 0},
+            {"zoom": 1, "n_lat": 0},
+        ],
     )
     def test_rejects_invalid_params(self, kwargs):
-        """A negative zoom or non-positive grid dimension raises `ValueError`."""
+        """A zoom outside 0..6 or a non-positive grid dimension raises `ValueError`."""
         with pytest.raises(ValueError):
             world_texture(**kwargs)

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1531,6 +1531,26 @@ class TestWorldTexture:
         world_texture(zoom=1, n_lon=8, n_lat=4, cache=False)
         assert fetch.call_count == 2, "cache=False must not reuse a cached texture"
 
+    def test_recovers_from_a_corrupt_cache_file(self, tmp_path, monkeypatch):
+        """A truncated/foreign cache file is dropped and the texture recomputed."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(tiles_mod, "fetch_tiles", _fetch_split_by_x())
+        world_texture(zoom=1, n_lon=8, n_lat=4)
+        cache_files = list((tmp_path / "world-textures").glob("*.npy"))
+        assert len(cache_files) == 1, f"expected one cache file, got {cache_files}"
+        cache_files[0].write_bytes(b"not a valid npy")
+        tex = world_texture(zoom=1, n_lon=8, n_lat=4)
+        assert tex.shape == (4, 8, 3), "a poisoned cache must be rebuilt, not raise"
+
+    def test_cache_key_discriminates_params(self, tmp_path, monkeypatch):
+        """A different `n_lon` yields a distinct cache entry (the key discriminates)."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(tiles_mod, "fetch_tiles", _fetch_split_by_x())
+        world_texture(zoom=1, n_lon=8, n_lat=4)
+        world_texture(zoom=1, n_lon=16, n_lat=4)
+        cache_files = list((tmp_path / "world-textures").glob("*.npy"))
+        assert len(cache_files) == 2, f"expected two distinct cache files, got {cache_files}"
+
     def test_missing_extra_raises_import_error(self, monkeypatch):
         """Without the `[tiles]` extra, `world_texture` raises `ImportError`."""
         monkeypatch.setattr(tiles_mod, "_TILES_AVAILABLE", False)

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1551,6 +1551,18 @@ class TestWorldTexture:
         cache_files = list((tmp_path / "world-textures").glob("*.npy"))
         assert len(cache_files) == 2, f"expected two distinct cache files, got {cache_files}"
 
+    def test_cache_write_failure_removes_temp(self, tmp_path, monkeypatch):
+        """A failed texture save leaves no temp file behind and re-raises."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(tiles_mod, "fetch_tiles", _fetch_split_by_x())
+        monkeypatch.setattr(
+            tiles_mod.np, "save", MagicMock(side_effect=OSError("disk full"))
+        )
+        with pytest.raises(OSError, match="disk full"):
+            world_texture(zoom=1, n_lon=8, n_lat=4)
+        leftovers = list((tmp_path / "world-textures").glob("*.tmp"))
+        assert leftovers == [], f"temp file left behind: {leftovers}"
+
     def test_missing_extra_raises_import_error(self, monkeypatch):
         """Without the `[tiles]` extra, `world_texture` raises `ImportError`."""
         monkeypatch.setattr(tiles_mod, "_TILES_AVAILABLE", False)

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1549,7 +1549,9 @@ class TestWorldTexture:
         world_texture(zoom=1, n_lon=8, n_lat=4)
         world_texture(zoom=1, n_lon=16, n_lat=4)
         cache_files = list((tmp_path / "world-textures").glob("*.npy"))
-        assert len(cache_files) == 2, f"expected two distinct cache files, got {cache_files}"
+        assert len(cache_files) == 2, (
+            f"expected two distinct cache files, got {cache_files}"
+        )
 
     def test_cache_write_failure_removes_temp(self, tmp_path, monkeypatch):
         """A failed texture save leaves no temp file behind and re-raises."""

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1484,6 +1484,33 @@ class TestMercatorToEquirectangular:
         with pytest.raises(ValueError, match="east > west"):
             mercator_to_equirectangular(mosaic, bounds)
 
+    def test_rejects_nan_bounds(self):
+        """Non-finite (NaN) bounds fail the `east > west` finiteness guard."""
+        mosaic = np.zeros((4, 4, 3))
+        with pytest.raises(ValueError, match="east > west"):
+            mercator_to_equirectangular(mosaic, (float("nan"), -1.0, 1.0, 1.0))
+
+    def test_single_output_cell_averages_whole_mosaic(self):
+        """`n_lon = n_lat = 1` averages the entire mosaic into one cell."""
+        tex = mercator_to_equirectangular(
+            np.full((8, 8, 3), 100, "uint8"), _world_bounds(), n_lon=1, n_lat=1
+        )
+        assert tex.shape == (1, 1, 3), f"unexpected shape {tex.shape}"
+        assert np.allclose(tex, 100.0), "a constant mosaic averages to its value"
+
+    def test_sub_region_bounds_clamp_to_edges(self):
+        """A mosaic covering only a mid-latitude band still fills the whole
+        output frame; the poles clamp onto the mosaic's edge rows."""
+        m = np.zeros((8, 8, 3), "uint8")
+        m[0] = (255, 0, 0)
+        m[-1] = (0, 0, 255)
+        merc = _world_bounds()[3]
+        bounds = (-merc, -merc / 2.0, merc, merc / 2.0)
+        tex = mercator_to_equirectangular(m, bounds, n_lon=4, n_lat=8)
+        assert tex.shape == (8, 4, 3), f"output must span the frame, got {tex.shape}"
+        assert tex[0, 0, 0] > tex[0, 0, 2], "north pole clamps to the red top row"
+        assert tex[-1, 0, 2] > tex[-1, 0, 0], "south pole clamps to the blue bottom row"
+
 
 class TestWorldTexture:
     """Tests for `cleopatra.basemap.tiles.world_texture`."""
@@ -1497,6 +1524,14 @@ class TestWorldTexture:
         assert tex.dtype == np.float32, f"expected float32, got {tex.dtype}"
         assert float(tex.min()) >= 0.0, f"min below 0: {float(tex.min())}"
         assert float(tex.max()) <= 1.0, f"max above 1: {float(tex.max())}"
+
+    def test_zoom_zero_single_tile(self, tmp_path, monkeypatch):
+        """`zoom=0` (a single world tile) produces a valid float32 texture."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(tiles_mod, "fetch_tiles", _fetch_split_by_x())
+        tex = world_texture(zoom=0, n_lon=8, n_lat=4)
+        assert tex.shape == (4, 8, 3), f"unexpected shape {tex.shape}"
+        assert tex.dtype == np.float32, f"expected float32, got {tex.dtype}"
 
     def test_preserves_longitude_order(self, tmp_path, monkeypatch):
         """West tiles (blue) stay west end-to-end through fetch/stitch/reproject."""

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1466,22 +1466,23 @@ class TestMercatorToEquirectangular:
     @pytest.mark.parametrize("bad", [np.zeros((2,)), np.zeros((2, 2, 2, 2))])
     def test_rejects_non_2d_3d_mosaic(self, bad):
         """A 1-D or 4-D mosaic raises `ValueError`."""
+        bounds = _world_bounds()
         with pytest.raises(ValueError, match="2-D or 3-D"):
-            mercator_to_equirectangular(bad, _world_bounds())
+            mercator_to_equirectangular(bad, bounds)
 
     @pytest.mark.parametrize("n_lon,n_lat", [(0, 4), (4, 0), (-1, 4)])
     def test_rejects_non_positive_grid(self, n_lon, n_lat):
         """A non-positive `n_lon`/`n_lat` raises `ValueError`."""
+        mosaic, bounds = np.zeros((4, 4, 3)), _world_bounds()
         with pytest.raises(ValueError, match="must be positive"):
-            mercator_to_equirectangular(
-                np.zeros((4, 4, 3)), _world_bounds(), n_lon=n_lon, n_lat=n_lat
-            )
+            mercator_to_equirectangular(mosaic, bounds, n_lon=n_lon, n_lat=n_lat)
 
     @pytest.mark.parametrize("bounds", [(1.0, 1.0, 0.0, 2.0), (0.0, 2.0, 2.0, 1.0)])
     def test_rejects_degenerate_bounds(self, bounds):
         """Bounds with `east <= west` or `north <= south` raise `ValueError`."""
+        mosaic = np.zeros((4, 4, 3))
         with pytest.raises(ValueError, match="east > west"):
-            mercator_to_equirectangular(np.zeros((4, 4, 3)), bounds)
+            mercator_to_equirectangular(mosaic, bounds)
 
 
 class TestWorldTexture:
@@ -1494,7 +1495,8 @@ class TestWorldTexture:
         tex = world_texture(zoom=1, n_lon=16, n_lat=8)
         assert tex.shape == (8, 16, 3), f"unexpected shape {tex.shape}"
         assert tex.dtype == np.float32, f"expected float32, got {tex.dtype}"
-        assert 0.0 <= float(tex.min()) and float(tex.max()) <= 1.0, "not in [0, 1]"
+        assert float(tex.min()) >= 0.0, f"min below 0: {float(tex.min())}"
+        assert float(tex.max()) <= 1.0, f"max above 1: {float(tex.max())}"
 
     def test_preserves_longitude_order(self, tmp_path, monkeypatch):
         """West tiles (blue) stay west end-to-end through fetch/stitch/reproject."""

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1456,6 +1456,13 @@ class TestMercatorToEquirectangular:
         assert tex.dtype == np.float32, f"expected float32, got {tex.dtype}"
         assert np.allclose(tex, 200.0), "a constant mosaic stays at its value"
 
+    def test_no_south_seam_at_realistic_height(self):
+        """A tall constant mosaic stays flat at the default `n_lat`, guarding the
+        south-clamp divisor bug that darkened the output row near -85 deg S."""
+        m = np.full((8192, 8, 3), 255, "uint8")
+        tex = mercator_to_equirectangular(m, _world_bounds(), n_lon=8, n_lat=1440)
+        assert np.allclose(tex, 255.0), f"seam near -85S: min {float(tex.min())}"
+
     @pytest.mark.parametrize("bad", [np.zeros((2,)), np.zeros((2, 2, 2, 2))])
     def test_rejects_non_2d_3d_mosaic(self, bad):
         """A 1-D or 4-D mosaic raises `ValueError`."""

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1504,6 +1504,14 @@ class TestWorldTexture:
         assert tex[4, 0, 2] > tex[4, 0, 0], "west should be blue"
         assert tex[4, -1, 0] > tex[4, -1, 2], "east should be red"
 
+    def test_accepts_a_tileprovider_object(self, tmp_path, monkeypatch):
+        """A resolved `TileProvider` object is accepted, not only a name string."""
+        monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))
+        monkeypatch.setattr(tiles_mod, "fetch_tiles", _fetch_split_by_x())
+        provider = get_provider("OpenStreetMap.Mapnik")
+        tex = world_texture(provider, zoom=1, n_lon=8, n_lat=4)
+        assert tex.shape == (4, 8, 3), f"unexpected shape {tex.shape}"
+
     def test_caches_texture_and_skips_refetch(self, tmp_path, monkeypatch):
         """A second call reads the on-disk cache instead of refetching tiles."""
         monkeypatch.setenv("CLEOPATRA_CACHE_DIR", str(tmp_path))


### PR DESCRIPTION
# Description

Ports the two generic basemap helpers from the earthlens satellite showcase notebook's inline `basemap_texture`
into `cleopatra.basemap.tiles` (tracked in serapeum-org/earthlens#1104). Both are extracted from the same inline
helper; #310 builds on #309.

- **`mercator_to_equirectangular(mosaic, bounds, n_lon=2880, n_lat=1440)`** — a **pure-NumPy** area-averaging
  resample of a Web Mercator (EPSG:3857) tile mosaic onto an equirectangular lon/lat grid. It reads the mosaic's
  own EPSG:3857 bounds (exactly what `stitch_tiles` returns), area-averages each output cell from its edges (via
  `np.add.reduceat`), sizing the divisor from the actual block widths so the poles do not seam, and clamps
  out-of-coverage latitudes onto the edge rows. Returns `float32` in the input value scale. Needs **no** network,
  Pillow, or pyproj.
- **`world_texture(provider=None, *, zoom=5, n_lon=2880, n_lat=1440, cache=True, ...)`** — the XYZ analogue of
  `reference.relief`: fetches the whole `2**zoom` world tile grid (zoom capped at 6), stitches, reprojects, and
  returns an `(n_lat, n_lon, 3)` `float32` texture in `[0, 1]`. Accepts a provider name **or** a resolved
  `xyzservices.TileProvider` (as `add_tiles` does). Caches the texture under `Config.get_cache_dir()/"world-textures"`
  (guarded read that rebuilds a corrupt file, atomic `mkstemp` + `os.replace` write) so the ~1024 tiles are fetched
  once. Requires the `cleopatra[tiles]` extra.

The earthlens-specific two-tone / ocean-land recolour stays in the notebook (out of scope). No new dependencies —
reuses the existing `fetch_tiles`/`stitch_tiles`/`get_provider` machinery and the `_EARTH_RADIUS`/`_CIRCUMFERENCE`/
`_MAX_LATITUDE` constants; no GDAL.

# Issues
- Closes #309 — Web Mercator → equirectangular reprojection
- Closes #310 — `world_texture()` for XYZ providers alongside `relief()`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

`tests/test_tiles.py` (run with `VIRTUAL_ENV=…/uv/cleopatra uv run --active python -m pytest`):

- **`TestMercatorToEquirectangular`** — RGB and single-band shapes; west/east longitude and north/south latitude
  order preserved; constant-mosaic value-scale preservation; a **tall (h=8192) constant-mosaic seam guard** (would
  darken ≈−85°S before the divisor fix); validation (`ValueError` on non-2-D/3-D mosaic, non-positive `n_lon`/`n_lat`,
  degenerate bounds).
- **`TestWorldTexture`** (offline, `fetch_tiles` monkeypatched) — `(n_lat,n_lon,3)` float32 in `[0,1]`; longitude
  order preserved end-to-end; a `TileProvider` object is accepted; on-disk cache hit and `cache=False` refetch; the
  cache key discriminates params; a **corrupt cache is rebuilt** and a **failed write leaves no temp behind**; the
  `[tiles]`-extra gate raises `ImportError`; invalid params (incl. `zoom > 6`) raise `ValueError`.
- Two independent `/review-rounds` passes (all findings resolved — including a real south-of-−85° reprojection seam,
  a zoom/tile-count OOM cap, `TileProvider`-object acceptance, and cache read/write hardening). Full suite
  **2317 passed**; `tiles.py` doctests pass; the two new functions are at **100% line + branch** coverage;
  SonarCloud gate **OK** with **0** issues.

- [x] Reprojection unit tests (shape, longitude/latitude order, value scale, realistic-height seam guard, validation)
- [x] `world_texture` tests (float32/[0,1], alignment, provider object, caching + corrupt/failed-write, extra gate,
  validation incl. zoom cap)

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
