### PR TITLE
feat(styling): add stamp_mark figure watermark / brand-mark helper

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -88,7 +88,10 @@ colorbars, ticks, classification, and animation.
   not here. The deliberate exception is the `tiles` / `reference` basemap
   helpers, which fetch a handful of *fixed public* reference datasets (never
   user data) that cleopatra re-hosts as dependency-light artifacts — see
-  "Supporting utilities".
+  "Supporting utilities". Reading a **presentation asset** — a logo / watermark
+  image for `styling.watermark.stamp_mark` — is likewise allowed: it is
+  decoration on the rendered figure, not user data, and it loads via Pillow (an
+  existing dependency), never GDAL/geopandas.
 - **GIS / geoprocessing:** reprojection of user data, clipping, resampling,
   zonal stats, CRS management beyond what the optional `tiles` basemap needs.
 - **Interactive / GUI apps:** dashboards, widget servers, event callbacks,

--- a/docs/reference/watermark.md
+++ b/docs/reference/watermark.md
@@ -1,0 +1,57 @@
+# Watermark — Stamp a Logo / Brand-Mark on a Figure
+
+The `cleopatra.styling.watermark` module places a logo or watermark image onto a finished
+matplotlib `Figure` with a single call, so anything you publish or share can carry a mark
+without re-rolling the same inset-axes glue in every notebook.
+
+The one entry point is `stamp_mark(fig, path, *, frac=0.11, corner="lower right", margin=0.025,
+shadow=True)`. Two things make it more than a one-liner over `imshow`:
+
+- **Fraction-of-figure sizing.** The mark is drawn on a frameless inset axes in
+  *figure-fraction* coordinates, so it stays the same proportion (and corner offset) no
+  matter what dpi the figure is later saved at — the MP4 master, the smaller web copy, and
+  the GIF all get a mark of the same relative size. `frac` sets the width relative to the
+  figure width; the height is derived from the image and figure aspect ratios, so the image
+  is never stretched. (This is the dpi-independent counterpart of `Figure.figimage`, which is
+  pixel-based.)
+- **Optional drop shadow.** With `shadow=True` (the default) a gaussian-blurred, black,
+  slightly-offset copy of the mark's alpha is drawn beneath it so the mark separates from a
+  busy or dark canvas. The blur uses Pillow (already a cleopatra dependency), so no new
+  dependency — and no SciPy — is pulled in.
+
+It is a presentation helper, not a glyph: it takes whatever `Figure` you hand it and draws on
+top. Single-image, corner-anchored marks only — text watermarks, tiled / repeated marks, and
+any licensing / provenance semantics are out of scope.
+
+`stamp_mark` accepts the mark either as a **file path** (any format Pillow can open, read as
+RGBA) or as an in-memory `(H, W, 3)` / `(H, W, 4)` NumPy array (`uint8` `0-255` or float
+`0-1`; RGB gains an opaque alpha). It returns the frameless inset `Axes` it drew on, so you
+can adjust it further.
+
+## Usage
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from cleopatra.styling.watermark import stamp_mark
+
+fig = plt.figure(figsize=(12, 8))
+fig.add_subplot(111).imshow(np.random.default_rng(0).random((60, 90)), cmap="magma")
+
+# a file on disk...
+stamp_mark(fig, "brand/logo.png", frac=0.12, corner="lower right")
+
+# ...or an in-memory RGBA array, in a different corner, without the shadow
+logo = np.zeros((80, 160, 4), dtype=np.uint8)
+logo[..., :3] = 255
+logo[..., 3] = 255
+stamp_mark(fig, logo, frac=0.09, corner="upper left", shadow=False)
+
+fig.savefig("figure.png", dpi=200)  # the mark keeps its proportion at any dpi
+```
+
+`corner` is one of `"lower right"` (default), `"lower left"`, `"upper right"`, or
+`"upper left"`; anything else raises a `ValueError` naming the bad value. `margin` is the gap
+to the figure edges as a fraction of the figure.
+
+::: cleopatra.styling.watermark.stamp_mark

--- a/docs/reference/watermark.md
+++ b/docs/reference/watermark.md
@@ -54,4 +54,13 @@ fig.savefig("figure.png", dpi=200)  # the mark keeps its proportion at any dpi
 `"upper left"`; anything else raises a `ValueError` naming the bad value. `margin` is the gap
 to the figure edges as a fraction of the figure.
 
+!!! note "Call `stamp_mark` last, and save the whole figure"
+
+    The mark is baked at stamp time from the figure's current size, so stamp **after** any
+    `tight_layout()` / layout finalization and after the final `set_size_inches` (stamping first
+    then calling `tight_layout()` emits a `UserWarning`). The fraction-of-figure sizing assumes the
+    **whole** figure is saved: a plain `dpi=` save keeps the mark proportional, but
+    `savefig(bbox_inches="tight")` crops surrounding whitespace and so changes the mark's relative
+    margin and size.
+
 ::: cleopatra.styling.watermark.stamp_mark

--- a/docs/reference/watermark.md
+++ b/docs/reference/watermark.md
@@ -5,7 +5,7 @@ matplotlib `Figure` with a single call, so anything you publish or share can car
 without re-rolling the same inset-axes glue in every notebook.
 
 The one entry point is `stamp_mark(fig, path, *, frac=0.11, corner="lower right", margin=0.025,
-shadow=True)`. Two things make it more than a one-liner over `imshow`:
+shadow=True, blur=0.065)`. Two things make it more than a one-liner over `imshow`:
 
 - **Fraction-of-figure sizing.** The mark is drawn on a frameless inset axes in
   *figure-fraction* coordinates, so it stays the same proportion (and corner offset) no
@@ -14,10 +14,15 @@ shadow=True)`. Two things make it more than a one-liner over `imshow`:
   figure width; the height is derived from the image and figure aspect ratios, so the image
   is never stretched. (This is the dpi-independent counterpart of `Figure.figimage`, which is
   pixel-based.)
-- **Optional drop shadow.** With `shadow=True` (the default) a gaussian-blurred, black,
-  slightly-offset copy of the mark's alpha is drawn beneath it so the mark separates from a
-  busy or dark canvas. The blur uses Pillow (already a cleopatra dependency), so no new
-  dependency — and no SciPy — is pulled in.
+- **Optional halo.** With `shadow=True` (the default) a gaussian-blurred black copy of the
+  mark's alpha is composited *behind* it so the mark separates from a busy or dark canvas.
+  The blur uses Pillow (already a cleopatra dependency), so no new dependency — and no
+  SciPy — is pulled in.
+
+  The halo is **centred, not offset**. A mark is composited over arbitrary imagery — night
+  ocean, sunlit cloud, a bright limb — and a symmetric halo reads the same whichever way the
+  background falls, where a down-right drop shadow implies a light direction nothing else in
+  the frame has. `blur` is the halo's sigma as a fraction of the mark's own width.
 
 It is a presentation helper, not a glyph: it takes whatever `Figure` you hand it and draws on
 top. Single-image, corner-anchored marks only — text watermarks, tiled / repeated marks, and
@@ -52,7 +57,13 @@ fig.savefig("figure.png", dpi=200)  # the mark keeps its proportion at any dpi
 
 `corner` is one of `"lower right"` (default), `"lower left"`, `"upper right"`, or
 `"upper left"`; anything else raises a `ValueError` naming the bad value. `margin` is the gap
-to the figure edges as a fraction of the figure.
+between the **mark** and the figure edges as a fraction of the figure — either a scalar for
+both axes or an `(x, y)` pair. The pair matters when a mark has to tuck hard into a corner on
+one axis while keeping a gap on the other:
+
+```python
+stamp_mark(fig, "brand/logo.png", margin=(0.025, 0.0))  # flush with the bottom, inset from the right
+```
 
 !!! note "Call `stamp_mark` last, and save the whole figure"
 
@@ -62,5 +73,16 @@ to the figure edges as a fraction of the figure.
     **whole** figure is saved: a plain `dpi=` save keeps the mark proportional, but
     `savefig(bbox_inches="tight")` crops surrounding whitespace and so changes the mark's relative
     margin and size.
+
+!!! note "`frac` sizes the mark, not the halo canvas"
+
+    The halo needs a transparent pad of three sigmas on each side to hold its own tail, which
+    makes the composited canvas about 1.39x the mark's width at the default `blur`. `stamp_mark`
+    grows the inset axes by exactly that factor, so the **visible mark** still measures `frac`.
+    Sizing the padded canvas to `frac` instead would render the mark at roughly 72 % of the
+    requested size — easy to miss, because the axes bounding box still looks correct. With
+    `shadow=True` the returned axes' bbox therefore covers mark *and* halo, and is larger than
+    `frac`; `margin` is still measured to the mark, so a halo beside a small margin is clipped at
+    the figure edge (which is what you want when tucking a mark into a corner).
 
 ::: cleopatra.styling.watermark.stamp_mark

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
     - Geo basemap methods (glyphs): reference/geo.md
     - Projection (globe frames): reference/projection.md
     - Animations (save/embed): reference/animation.md
+    - Watermark (figure mark): reference/watermark.md
     - Colors: reference/colors-glyph.md
     - Styles: reference/styles-glyph.md
     - Perceptual colour toolkit: reference/perceptual.md

--- a/src/cleopatra/styling/__init__.py
+++ b/src/cleopatra/styling/__init__.py
@@ -4,5 +4,5 @@ Deliberately re-exports nothing, matching the package root: import from the
 submodule, e.g. `from cleopatra.styling.colors import DATA_STYLES`,
 `from cleopatra.styling.styles import swatch_legend`.
 
-Submodules: `styles`, `colors`, `colorbar`, `palettes`, `perceptual`.
+Submodules: `styles`, `colors`, `colorbar`, `palettes`, `perceptual`, `watermark`.
 """

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -69,8 +69,10 @@ def stamp_mark(
         path: The mark image. A file path (any format `PIL` can open, read as
             RGBA) or an in-memory ``(H, W, 3)`` / ``(H, W, 4)`` array -- either
             ``uint8`` ``0-255`` or float ``0-1``; RGB gains an opaque alpha.
-        frac: The mark's width as a fraction of the figure width, in ``(0, 1]``.
-            Defaults to ``0.11``.
+        frac: The size of the mark's *longer* on-figure side as a fraction of
+            the corresponding figure side, in ``(0, 1]`` -- the width for a
+            landscape mark, the height for a portrait one -- so the mark always
+            fits and is never distorted. Defaults to ``0.11``.
         corner: Which corner to anchor to -- ``"lower right"`` (default),
             ``"lower left"``, ``"upper right"``, or ``"upper left"``.
         margin: The gap between the mark and the figure edges, as a fraction of
@@ -123,6 +125,15 @@ def stamp_mark(
     # image aspect and corrected for the figure's own aspect, because a unit of
     # figure-fraction height spans fewer inches than a unit of width (or more).
     height = width * (img_h / img_w) * (fig_w_in / fig_h_in)
+    # `frac` sizes the mark's *longer* on-figure side: for a landscape mark that
+    # is the width (unchanged), but a portrait mark whose derived height exceeds
+    # `frac` is scaled down so its height is `frac` instead -- otherwise a tall
+    # logo would silently overflow the figure. Aspect is preserved either way.
+    longest = max(width, height)
+    if longest > frac:
+        scale = frac / longest
+        width *= scale
+        height *= scale
     x0, y0 = _corner_origin(corner, width, height, margin)
 
     if shadow:

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -226,7 +226,15 @@ def _as_rgba(path: "str | os.PathLike | np.ndarray") -> np.ndarray:
         if np.issubdtype(arr.dtype, np.floating):
             # A float image is the ``0-1`` contract; reject clearly out-of-range
             # values rather than silently clipping (e.g. a ``0-255`` float array
-            # would otherwise flatten to all-white).
+            # would otherwise flatten to all-white). Reject non-finite values
+            # first: a NaN makes `min()`/`max()` NaN, whose comparisons are all
+            # False, so it would otherwise slip past the range check and cast to
+            # 0 with a RuntimeWarning -- the very silent garbling this guards.
+            if arr.size and not np.all(np.isfinite(arr)):
+                raise ValueError(
+                    "a float image array must hold finite values in [0, 1]; "
+                    "it contains NaN or inf."
+                )
             if arr.size and (arr.min() < -1e-6 or arr.max() > 1.0 + 1e-6):
                 raise ValueError(
                     "a float image array must hold values in [0, 1]; got range "

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -185,7 +185,9 @@ def stamp_mark(
     # by the same ratio (about the mark's centre) or the mark would render at
     # 1/grow of the requested `frac`.
     drawn, grow_w, grow_h = (image, 1.0, 1.0)
-    if shadow:
+    # `blur == 0` yields an invisible halo but still pads the canvas (min 1 px),
+    # so skip the composite entirely -- it only wastes work and inflates the bbox.
+    if shadow and blur > 0.0:
         drawn, grow_w, grow_h = _composite_halo(image, blur)
     rect_w = width * grow_w
     rect_h = height * grow_h

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -178,6 +178,15 @@ def stamp_mark(
         scale = frac / longest
         width *= scale
         height *= scale
+    # `frac` and `margin` are each in range on their own, but their sum must
+    # still leave the mark on the figure: `margin + size > 1` would place the
+    # mark off the opposite edge (`x0 = 1 - margin - width < 0`).
+    if margin_x + width > 1.0 or margin_y + height > 1.0:
+        raise ValueError(
+            f"margin + mark size exceeds the figure: margin={(margin_x, margin_y)} "
+            f"leaves no room for a {width:.3g}x{height:.3g} (figure-fraction) mark. "
+            "Reduce frac or margin."
+        )
     x0, y0 = _corner_origin(corner, width, height, margin_x, margin_y)
 
     # `width`/`height` are the MARK's rect. When a halo is composited in, the

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -222,6 +222,40 @@ def stamp_mark(
     return ax
 
 
+def _float_to_uint8(arr: np.ndarray) -> np.ndarray:
+    """Validate a float ``0-1`` image array and scale it to ``uint8`` ``0-255``.
+
+    A float image is the ``0-1`` contract; reject out-of-range or non-finite
+    values rather than silently clipping (a ``0-255`` float array would
+    otherwise flatten to white, and a ``NaN`` -- whose ``min``/``max``
+    comparisons are all ``False`` -- would slip past a plain range check and
+    cast to 0 with a ``RuntimeWarning``).
+
+    Args:
+        arr: A floating-dtype image array expected to hold finite values in
+            ``[0, 1]``.
+
+    Returns:
+        np.ndarray: The array scaled to ``uint8`` ``0-255``.
+
+    Raises:
+        ValueError: If `arr` holds non-finite values (NaN/inf) or values
+            outside ``[0, 1]``.
+    """
+    if arr.size and not np.all(np.isfinite(arr)):
+        raise ValueError(
+            "a float image array must hold finite values in [0, 1]; "
+            "it contains NaN or inf."
+        )
+    if arr.size and (arr.min() < -1e-6 or arr.max() > 1.0 + 1e-6):
+        raise ValueError(
+            "a float image array must hold values in [0, 1]; got range "
+            f"[{float(arr.min()):.4g}, {float(arr.max()):.4g}]. "
+            "For 0-255 data pass a uint8 array."
+        )
+    return (np.clip(arr, 0.0, 1.0) * 255).round().astype(np.uint8)
+
+
 def _as_rgba(path: "str | os.PathLike | np.ndarray") -> np.ndarray:
     """Return the mark as an ``(H, W, 4)`` ``uint8`` RGBA array.
 
@@ -246,24 +280,7 @@ def _as_rgba(path: "str | os.PathLike | np.ndarray") -> np.ndarray:
                 f"an image array must be (H, W, 3) or (H, W, 4); got shape {arr.shape}."
             )
         if np.issubdtype(arr.dtype, np.floating):
-            # A float image is the ``0-1`` contract; reject clearly out-of-range
-            # values rather than silently clipping (e.g. a ``0-255`` float array
-            # would otherwise flatten to all-white). Reject non-finite values
-            # first: a NaN makes `min()`/`max()` NaN, whose comparisons are all
-            # False, so it would otherwise slip past the range check and cast to
-            # 0 with a RuntimeWarning -- the very silent garbling this guards.
-            if arr.size and not np.all(np.isfinite(arr)):
-                raise ValueError(
-                    "a float image array must hold finite values in [0, 1]; "
-                    "it contains NaN or inf."
-                )
-            if arr.size and (arr.min() < -1e-6 or arr.max() > 1.0 + 1e-6):
-                raise ValueError(
-                    "a float image array must hold values in [0, 1]; got range "
-                    f"[{float(arr.min()):.4g}, {float(arr.max()):.4g}]. "
-                    "For 0-255 data pass a uint8 array."
-                )
-            arr = (np.clip(arr, 0.0, 1.0) * 255).round().astype(np.uint8)
+            arr = _float_to_uint8(arr)
         elif arr.dtype != np.uint8:
             # Any other non-float dtype (uint16, int32, bool, ...) would truncate
             # mod 256 under a bare uint8 cast and silently garble the mark.

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -4,7 +4,12 @@
 sized as a *fraction of the figure* (so it stays proportional across the
 several dpis a figure is often exported at -- an MP4 master, a smaller web
 copy, a GIF) and anchored in one of the four corners, with an optional
-gaussian-blurred drop shadow so the mark reads on a busy or dark canvas.
+gaussian-blurred *halo* so the mark reads on a busy or dark canvas.
+
+The halo is centred, not offset: the mark is composited over arbitrary
+imagery -- night-side ocean, sunlit cloud, a bright limb -- and a symmetric
+halo reads the same whichever way the background falls, where an offset drop
+shadow would imply a light direction nothing else in the frame has.
 
 This is a presentation helper, not a glyph: it takes a finished `Figure` and
 draws on top of it via a frameless inset axes in figure-fraction coordinates
@@ -13,7 +18,7 @@ It covers only single-image, corner-anchored marks -- text watermarks,
 tiled / repeated marks, and any licensing / provenance semantics are
 deliberately out of scope.
 
-The gaussian blur for the shadow uses `PIL` (Pillow), already a hard cleopatra
+The gaussian blur for the halo uses `PIL` (Pillow), already a hard cleopatra
 dependency, so no new dependency (and no SciPy) is pulled in.
 """
 
@@ -35,14 +40,18 @@ __all__ = ["stamp_mark"]
 #: The four corner anchors `stamp_mark` accepts.
 _CORNERS = ("lower right", "lower left", "upper right", "upper left")
 
-#: Drop-shadow tuning, all as fractions of the mark's own size / alpha.
-_SHADOW_PAD = 0.14  #: transparent border added around the mark before blurring
-_SHADOW_BLUR_FRAC = 0.5  #: gaussian blur radius, as a fraction of the pad
-_SHADOW_OFFSET = 0.045  #: shadow shift down-and-right, as a fraction of the mark
-_SHADOW_ALPHA = 0.5  #: peak shadow opacity
+#: Default halo blur sigma, as a fraction of the mark's own (unpadded) width.
+DEFAULT_BLUR = 0.065
 
-#: Inset zorders: both marks sit above ordinary figure content, shadow under mark.
-_SHADOW_ZORDER = 1_000_000
+#: Transparent border added around the mark before blurring, in sigmas. Three
+#: sigmas hold ~99.7% of the kernel, so the halo's tail is not clipped by the
+#: canvas it is drawn on -- the pad exists precisely to contain that tail.
+_HALO_SIGMAS = 3.0
+
+#: Peak halo opacity.
+_HALO_ALPHA = 0.5
+
+#: Inset zorder: the mark sits above ordinary figure content.
 _MARK_ZORDER = 1_000_001
 
 
@@ -52,8 +61,9 @@ def stamp_mark(
     *,
     frac: float = 0.11,
     corner: str = "lower right",
-    margin: float = 0.025,
+    margin: "float | tuple[float, float]" = 0.025,
     shadow: bool = True,
+    blur: float = DEFAULT_BLUR,
 ) -> "Axes":
     """Stamp a logo / watermark image onto a figure, sized as a fraction of it.
 
@@ -75,19 +85,26 @@ def stamp_mark(
             fits and is never distorted. Defaults to ``0.11``.
         corner: Which corner to anchor to -- ``"lower right"`` (default),
             ``"lower left"``, ``"upper right"``, or ``"upper left"``.
-        margin: The gap between the mark and the figure edges, as a fraction of
-            the figure, in ``[0, 1)``. Defaults to ``0.025``.
-        shadow: Whether to draw a gaussian-blurred drop shadow beneath the mark
-            so it separates from a busy or dark canvas. Defaults to ``True``.
+        margin: The gap between the **mark** and the figure edges, as a fraction
+            of the figure, each in ``[0, 1)``. Either a scalar applied to both
+            axes or an ``(x, y)`` pair -- a pair is what lets a mark tuck hard
+            into a corner on one axis (``margin=(0.025, 0.0)``) while keeping a
+            gap on the other. Defaults to ``0.025``.
+        shadow: Whether to composite a gaussian-blurred halo behind the mark so
+            it separates from a busy or dark canvas. Defaults to ``True``.
+        blur: Halo blur sigma, as a fraction of the mark's own **unpadded**
+            width. Defaults to `DEFAULT_BLUR`. Ignored when ``shadow=False``.
 
     Returns:
         Axes: The frameless inset axes the mark was drawn on, so the caller can
-        further adjust it (e.g. ``ax.set_zorder(...)``). The optional shadow is
-        drawn on its own separate axes beneath this one.
+        further adjust it (e.g. ``ax.set_zorder(...)``). With ``shadow=True``
+        that axes holds the mark *and* its halo, so its bbox is larger than the
+        mark by the halo pad -- see the sizing note below.
 
     Raises:
         ValueError: If `corner` is not one of the four accepted anchors, if
-            `frac` is not in ``(0, 1]``, if `margin` is not in ``[0, 1)``, or if
+            `frac` is not in ``(0, 1]``, if `margin` is not a scalar or
+            ``(x, y)`` pair in ``[0, 1)``, if `blur` is negative, or if
             an image array is out of contract (wrong shape, a non-``uint8``
             integer dtype, or a float outside ``[0, 1]`` -- see `_as_rgba`).
         FileNotFoundError: If `path` is a file path that does not exist.
@@ -101,9 +118,20 @@ def stamp_mark(
         after the final `set_size_inches`. Placement holds across dpi but not
         across a later figure-size change. Saving with `bbox_inches="tight"`
         crops surrounding whitespace and so changes the mark's relative margin /
-        size; a plain ``dpi=`` save preserves them. Leave enough `margin` for
-        the drop shadow (the default does) or its soft outer edge is clipped in
-        the corner.
+        size; a plain ``dpi=`` save preserves them.
+
+        `frac` always sizes the **mark itself**, never the canvas it is
+        composited on. The halo needs a transparent pad of
+        ``_HALO_SIGMAS * blur`` on each side to hold its own tail, which makes
+        that canvas ``1 + 2 * _HALO_SIGMAS * blur`` times the mark's width
+        (1.39x at the defaults). The axes rect is grown by exactly that factor
+        so the visible mark still measures `frac`; sizing the padded canvas to
+        `frac` instead would silently render the mark at ~72% of the requested
+        size, which is easy to miss because the axes bbox looks right.
+
+        `margin` is measured to the mark, so a halo next to a small margin is
+        clipped at the figure edge -- which is what you want when tucking a
+        mark hard into a corner.
 
     Examples:
         - Stamp a logo array in the lower-right corner at 11 % of the width:
@@ -128,8 +156,9 @@ def stamp_mark(
         raise ValueError(f"corner must be one of {list(_CORNERS)}, got {corner!r}.")
     if not 0.0 < frac <= 1.0:
         raise ValueError(f"frac must be in (0, 1], got {frac!r}.")
-    if not 0.0 <= margin < 1.0:
-        raise ValueError(f"margin must be in [0, 1), got {margin!r}.")
+    margin_x, margin_y = _as_margins(margin)
+    if blur < 0.0:
+        raise ValueError(f"blur must be non-negative, got {blur!r}.")
 
     image = _as_rgba(path)
     img_h, img_w = image.shape[:2]
@@ -149,13 +178,24 @@ def stamp_mark(
         scale = frac / longest
         width *= scale
         height *= scale
-    x0, y0 = _corner_origin(corner, width, height, margin)
+    x0, y0 = _corner_origin(corner, width, height, margin_x, margin_y)
 
+    # `width`/`height` are the MARK's rect. When a halo is composited in, the
+    # image handed to `imshow` is the padded canvas, so the axes rect has to grow
+    # by the same ratio (about the mark's centre) or the mark would render at
+    # 1/grow of the requested `frac`.
+    drawn, grow_w, grow_h = (image, 1.0, 1.0)
     if shadow:
-        _stamp_shadow(fig, image, x0, y0, width, height)
+        drawn, grow_w, grow_h = _composite_halo(image, blur)
+    rect_w = width * grow_w
+    rect_h = height * grow_h
+    rect_x = x0 - (rect_w - width) / 2.0
+    rect_y = y0 - (rect_h - height) / 2.0
 
-    ax = fig.add_axes((x0, y0, width, height), frameon=False, zorder=_MARK_ZORDER)
-    ax.imshow(image, aspect="auto", interpolation="antialiased")
+    ax = fig.add_axes(
+        (rect_x, rect_y, rect_w, rect_h), frameon=False, zorder=_MARK_ZORDER
+    )
+    ax.imshow(drawn, aspect="auto", interpolation="antialiased")
     ax.axis("off")
     ax.set_in_layout(False)
     return ax
@@ -209,68 +249,129 @@ def _as_rgba(path: "str | os.PathLike | np.ndarray") -> np.ndarray:
         return np.asarray(im.convert("RGBA"))
 
 
-def _corner_origin(corner: str, width: float, height: float, margin: float) -> tuple[float, float]:
+def _as_margins(margin: "float | tuple[float, float]") -> tuple[float, float]:
+    """Normalise `margin` to an ``(x, y)`` pair of figure fractions.
+
+    Args:
+        margin: A scalar applied to both axes, or an ``(x, y)`` pair. A pair is
+            needed when a mark must tuck hard into a corner on one axis while
+            keeping a gap on the other.
+
+    Returns:
+        tuple[float, float]: The ``(x, y)`` margins.
+
+    Raises:
+        ValueError: If `margin` is not a scalar or a 2-sequence, or if either
+            component is outside ``[0, 1)``.
+    """
+    if isinstance(margin, (int, float)) and not isinstance(margin, bool):
+        pair = (float(margin), float(margin))
+    else:
+        try:
+            values = tuple(margin)  # type: ignore[arg-type]
+        except TypeError:
+            raise ValueError(
+                f"margin must be a number or an (x, y) pair, got {margin!r}."
+            ) from None
+        if len(values) != 2:
+            raise ValueError(
+                f"margin must be a number or an (x, y) pair, got {margin!r}."
+            )
+        pair = (float(values[0]), float(values[1]))
+    for name, value in zip(("x", "y"), pair):
+        if not 0.0 <= value < 1.0:
+            raise ValueError(f"margin must be in [0, 1), got {name}={value!r}.")
+    return pair
+
+
+def _corner_origin(
+    corner: str, width: float, height: float, margin_x: float, margin_y: float
+) -> tuple[float, float]:
     """Return the ``(x0, y0)`` figure-fraction origin for a corner-anchored rect.
 
     Args:
         corner: One of the `_CORNERS` anchors.
         width: The mark width in figure fraction.
         height: The mark height in figure fraction.
-        margin: The edge gap in figure fraction.
+        margin_x: The horizontal edge gap in figure fraction.
+        margin_y: The vertical edge gap in figure fraction.
 
     Returns:
-        tuple[float, float]: The bottom-left ``(x0, y0)`` of the mark's axes.
+        tuple[float, float]: The bottom-left ``(x0, y0)`` of the mark's rect.
     """
     at_right = corner.endswith("right")
     at_top = corner.startswith("upper")
-    x0 = (1.0 - margin - width) if at_right else margin
-    y0 = (1.0 - margin - height) if at_top else margin
+    x0 = (1.0 - margin_x - width) if at_right else margin_x
+    y0 = (1.0 - margin_y - height) if at_top else margin_y
     return x0, y0
 
 
-def _stamp_shadow(
-    fig: "Figure", image: np.ndarray, x0: float, y0: float, width: float, height: float
-) -> "Axes":
-    """Draw a gaussian-blurred drop shadow beneath a mark on its own axes.
+def _alpha_over(foreground: np.ndarray, background: np.ndarray) -> np.ndarray:
+    """Composite RGBA over RGBA (Porter-Duff "over"), un-premultiplied.
 
-    Builds the shadow from the mark's alpha channel: pad it (to give the blur
-    room), gaussian-blur it, tint it black, and place it in a slightly larger,
-    down-and-right-offset frameless axes under the mark so the mark separates
-    from a busy / dark canvas.
+    The colour a pixel ends up with is the foreground's, weighted by its own
+    alpha, plus the background's weighted by whatever coverage the foreground
+    left over -- so the halo contributes black only where the mark does not
+    already cover, including partially across a soft edge.
 
     Args:
-        fig: The figure to draw on.
-        image: The RGBA ``uint8`` mark (its alpha drives the shadow shape).
-        x0: The mark's figure-fraction left edge.
-        y0: The mark's figure-fraction bottom edge.
-        width: The mark's figure-fraction width.
-        height: The mark's figure-fraction height.
+        foreground: An ``(H, W, 4)`` float array in ``[0, 1]``.
+        background: An ``(H, W, 4)`` float array in ``[0, 1]``, same shape.
 
     Returns:
-        Axes: The frameless axes the shadow was drawn on.
+        np.ndarray: The composited ``(H, W, 4)`` float array in ``[0, 1]``.
+
+    Notes:
+        This is the same operator issue #306 proposes to centralise as
+        `glyphs.base.compositing.alpha_over`; swap this private helper for it
+        once that lands rather than keeping two copies.
+    """
+    fg_a = foreground[..., 3:4]
+    bg_a = background[..., 3:4]
+    out_a = fg_a + bg_a * (1.0 - fg_a)
+    # Guard the un-premultiply where nothing covers at all; those pixels are
+    # fully transparent, so their colour is arbitrary -- keep it at zero.
+    safe = np.where(out_a > 0.0, out_a, 1.0)
+    rgb = (
+        foreground[..., :3] * fg_a + background[..., :3] * bg_a * (1.0 - fg_a)
+    ) / safe
+    return np.concatenate([np.where(out_a > 0.0, rgb, 0.0), out_a], axis=2)
+
+
+def _composite_halo(image: np.ndarray, blur: float) -> tuple[np.ndarray, float, float]:
+    """Composite a mark over its own blurred halo, returning the growth factors.
+
+    Pads the mark symmetrically so the blur's tail has room, blurs a black copy
+    of its alpha to make the halo, and composites the mark back over it. The
+    halo is *centred* on the mark rather than offset: the mark goes over
+    arbitrary imagery, and a symmetric halo reads the same whichever way the
+    background falls.
+
+    Args:
+        image: The RGBA ``uint8`` mark; its alpha channel drives the halo shape.
+        blur: The blur sigma as a fraction of the mark's own unpadded width.
+
+    Returns:
+        tuple[np.ndarray, float, float]: The composited RGBA ``uint8`` canvas,
+        and the factors by which it is wider and taller than the mark. The
+        caller grows the axes rect by these so the *mark* still measures `frac`.
     """
     img_h, img_w = image.shape[:2]
-    pad = max(1, int(round(_SHADOW_PAD * max(img_h, img_w))))
+    # Sigma comes off the mark's own width, so `blur` means what it says; taking
+    # it off the padded width instead would inflate the effective blur and leave
+    # the pad too small for the tail it was sized to contain.
+    sigma = blur * img_w
+    pad = max(1, int(round(_HALO_SIGMAS * sigma)))
+
     alpha = np.pad(image[..., 3], pad, mode="constant", constant_values=0)
-    blurred = np.asarray(
-        Image.fromarray(alpha).filter(ImageFilter.GaussianBlur(pad * _SHADOW_BLUR_FRAC))
-    )
-    shadow = np.zeros(blurred.shape + (4,), dtype=np.uint8)
-    shadow[..., 3] = (blurred.astype(np.float64) * _SHADOW_ALPHA).astype(np.uint8)
+    blurred = np.asarray(Image.fromarray(alpha).filter(ImageFilter.GaussianBlur(sigma)))
 
-    # The mark occupies (img_w, img_h) centred within the padded (pad_w, pad_h),
-    # so scale the mark's rect by the same ratio to keep the shadow aligned, then
-    # nudge it down-and-right for the drop-shadow offset.
-    pad_h, pad_w = shadow.shape[:2]
-    shadow_w = width * pad_w / img_w
-    shadow_h = height * pad_h / img_h
-    shadow_x = x0 - (shadow_w - width) / 2.0 + _SHADOW_OFFSET * width
-    shadow_y = y0 - (shadow_h - height) / 2.0 - _SHADOW_OFFSET * height
+    halo = np.zeros(blurred.shape + (4,), dtype=np.float64)  # black, alpha-only
+    halo[..., 3] = blurred / 255.0 * _HALO_ALPHA
 
-    sax = fig.add_axes(
-        (shadow_x, shadow_y, shadow_w, shadow_h), frameon=False, zorder=_SHADOW_ZORDER
-    )
-    sax.imshow(shadow, aspect="auto", interpolation="antialiased")
-    sax.axis("off")
-    sax.set_in_layout(False)
-    return sax
+    mark = np.zeros_like(halo)
+    mark[pad : pad + img_h, pad : pad + img_w] = image / 255.0
+
+    out = _alpha_over(mark, halo)
+    pad_h, pad_w = out.shape[:2]
+    return (out * 255).round().astype(np.uint8), pad_w / img_w, pad_h / img_h

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -106,9 +106,10 @@ def stamp_mark(
     Raises:
         ValueError: If `corner` is not one of the four accepted anchors, if
             `frac` is not in ``(0, 1]``, if `margin` is not a scalar or
-            ``(x, y)`` pair in ``[0, 1)``, if `blur` is negative, or if
-            an image array is out of contract (wrong shape, a non-``uint8``
-            integer dtype, or a float outside ``[0, 1]`` -- see `_as_rgba`).
+            ``(x, y)`` pair in ``[0, 1)``, if `margin + mark size` exceeds the
+            figure, if `blur` is negative, or if an image array is out of
+            contract (wrong shape, a non-``uint8`` non-float dtype, or a float
+            outside ``[0, 1]`` or containing NaN/inf -- see `_as_rgba`).
         FileNotFoundError: If `path` is a file path that does not exist.
         PIL.UnidentifiedImageError: If `path` is a file that is not an image
             `PIL` can decode.
@@ -229,8 +230,9 @@ def _as_rgba(path: "str | os.PathLike | np.ndarray") -> np.ndarray:
 
     Raises:
         ValueError: If an array input is not ``(H, W, 3)`` / ``(H, W, 4)``, is a
-            non-``uint8`` integer array, or is a float array with values outside
-            ``[0, 1]``.
+            non-``uint8`` non-float array (e.g. ``uint16``, ``int32``, ``bool``),
+            or is a float array with values outside ``[0, 1]`` or containing
+            NaN/inf.
     """
     if isinstance(path, np.ndarray):
         arr = np.asarray(path)

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -254,10 +254,10 @@ def _as_rgba(path: "str | os.PathLike | np.ndarray") -> np.ndarray:
                 )
             arr = (np.clip(arr, 0.0, 1.0) * 255).round().astype(np.uint8)
         elif arr.dtype != np.uint8:
-            # Any other integer dtype (uint16, int32, bool, ...) would truncate
+            # Any other non-float dtype (uint16, int32, bool, ...) would truncate
             # mod 256 under a bare uint8 cast and silently garble the mark.
             raise ValueError(
-                f"an integer image array must be uint8 (0-255); got dtype {arr.dtype}. "
+                f"a non-float image array must be uint8 (0-255); got dtype {arr.dtype}. "
                 "Convert / rescale it to uint8 (or pass a float 0-1 array) first."
             )
         if arr.shape[2] == 3:

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -87,8 +87,23 @@ def stamp_mark(
 
     Raises:
         ValueError: If `corner` is not one of the four accepted anchors, if
-            `frac` is not in ``(0, 1]``, if `margin` is not in ``[0, 1)``, or
-            if an image array does not have shape ``(H, W, 3)`` / ``(H, W, 4)``.
+            `frac` is not in ``(0, 1]``, if `margin` is not in ``[0, 1)``, or if
+            an image array is out of contract (wrong shape, a non-``uint8``
+            integer dtype, or a float outside ``[0, 1]`` -- see `_as_rgba`).
+        FileNotFoundError: If `path` is a file path that does not exist.
+        PIL.UnidentifiedImageError: If `path` is a file that is not an image
+            `PIL` can decode.
+
+    Notes:
+        The mark is baked at stamp time from the figure's current size, so call
+        `stamp_mark` **last** -- after any `tight_layout()` / layout
+        finalization (stamping first then calling `tight_layout()` warns), and
+        after the final `set_size_inches`. Placement holds across dpi but not
+        across a later figure-size change. Saving with `bbox_inches="tight"`
+        crops surrounding whitespace and so changes the mark's relative margin /
+        size; a plain ``dpi=`` save preserves them. Leave enough `margin` for
+        the drop shadow (the default does) or its soft outer edge is clipped in
+        the corner.
 
     Examples:
         - Stamp a logo array in the lower-right corner at 11 % of the width:

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -1,0 +1,234 @@
+"""Figure watermark / brand-mark helper.
+
+`stamp_mark` places a logo or watermark image onto a matplotlib `Figure`,
+sized as a *fraction of the figure* (so it stays proportional across the
+several dpis a figure is often exported at -- an MP4 master, a smaller web
+copy, a GIF) and anchored in one of the four corners, with an optional
+gaussian-blurred drop shadow so the mark reads on a busy or dark canvas.
+
+This is a presentation helper, not a glyph: it takes a finished `Figure` and
+draws on top of it via a frameless inset axes in figure-fraction coordinates
+(the dpi-independent counterpart of `Figure.figimage`, which is pixel-based).
+It covers only single-image, corner-anchored marks -- text watermarks,
+tiled / repeated marks, and any licensing / provenance semantics are
+deliberately out of scope.
+
+The gaussian blur for the shadow uses `PIL` (Pillow), already a hard cleopatra
+dependency, so no new dependency (and no SciPy) is pulled in.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from PIL import Image, ImageFilter
+
+if TYPE_CHECKING:
+    import os
+
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+
+__all__ = ["stamp_mark"]
+
+#: The four corner anchors `stamp_mark` accepts.
+_CORNERS = ("lower right", "lower left", "upper right", "upper left")
+
+#: Drop-shadow tuning, all as fractions of the mark's own size / alpha.
+_SHADOW_PAD = 0.14  #: transparent border added around the mark before blurring
+_SHADOW_BLUR_FRAC = 0.5  #: gaussian blur radius, as a fraction of the pad
+_SHADOW_OFFSET = 0.045  #: shadow shift down-and-right, as a fraction of the mark
+_SHADOW_ALPHA = 0.5  #: peak shadow opacity
+
+#: Inset zorders: both marks sit above ordinary figure content, shadow under mark.
+_SHADOW_ZORDER = 1_000_000
+_MARK_ZORDER = 1_000_001
+
+
+def stamp_mark(
+    fig: "Figure",
+    path: "str | os.PathLike | np.ndarray",
+    *,
+    frac: float = 0.11,
+    corner: str = "lower right",
+    margin: float = 0.025,
+    shadow: bool = True,
+) -> "Axes":
+    """Stamp a logo / watermark image onto a figure, sized as a fraction of it.
+
+    Places `path` in one corner of `fig` on a frameless inset axes in
+    figure-fraction coordinates, so the mark keeps the same proportion (and
+    corner offset) no matter what dpi the figure is later saved at. The image
+    is drawn undistorted: `frac` sets its width relative to the figure width
+    and the height is derived from the image and figure aspect ratios.
+
+    Args:
+        fig: The matplotlib `Figure` to stamp. The mark is drawn on top of
+            whatever the figure already contains.
+        path: The mark image. A file path (any format `PIL` can open, read as
+            RGBA) or an in-memory ``(H, W, 3)`` / ``(H, W, 4)`` array -- either
+            ``uint8`` ``0-255`` or float ``0-1``; RGB gains an opaque alpha.
+        frac: The mark's width as a fraction of the figure width, in ``(0, 1]``.
+            Defaults to ``0.11``.
+        corner: Which corner to anchor to -- ``"lower right"`` (default),
+            ``"lower left"``, ``"upper right"``, or ``"upper left"``.
+        margin: The gap between the mark and the figure edges, as a fraction of
+            the figure, in ``[0, 1)``. Defaults to ``0.025``.
+        shadow: Whether to draw a gaussian-blurred drop shadow beneath the mark
+            so it separates from a busy or dark canvas. Defaults to ``True``.
+
+    Returns:
+        Axes: The frameless inset axes the mark was drawn on, so the caller can
+        further adjust it (e.g. ``ax.set_zorder(...)``). The optional shadow is
+        drawn on its own separate axes beneath this one.
+
+    Raises:
+        ValueError: If `corner` is not one of the four accepted anchors, if
+            `frac` is not in ``(0, 1]``, if `margin` is not in ``[0, 1)``, or
+            if an image array does not have shape ``(H, W, 3)`` / ``(H, W, 4)``.
+
+    Examples:
+        - Stamp a logo array in the lower-right corner at 11 % of the width:
+            ```python
+            >>> import matplotlib
+            >>> matplotlib.use("Agg")
+            >>> import numpy as np
+            >>> import matplotlib.pyplot as plt
+            >>> from cleopatra.styling.watermark import stamp_mark
+            >>> fig = plt.figure(figsize=(8, 6))
+            >>> logo = np.zeros((40, 80, 4), dtype=np.uint8)
+            >>> logo[..., :3] = 255  # white
+            >>> logo[..., 3] = 255   # opaque
+            >>> ax = stamp_mark(fig, logo, frac=0.2, shadow=False)
+            >>> [round(float(v), 3) for v in ax.get_position().bounds]
+            [0.775, 0.025, 0.2, 0.133]
+            >>> plt.close(fig)
+
+            ```
+    """
+    if corner not in _CORNERS:
+        raise ValueError(f"corner must be one of {list(_CORNERS)}, got {corner!r}.")
+    if not 0.0 < frac <= 1.0:
+        raise ValueError(f"frac must be in (0, 1], got {frac!r}.")
+    if not 0.0 <= margin < 1.0:
+        raise ValueError(f"margin must be in [0, 1), got {margin!r}.")
+
+    image = _as_rgba(path)
+    img_h, img_w = image.shape[:2]
+    fig_w_in, fig_h_in = fig.get_size_inches()
+
+    width = float(frac)
+    # Keep the image undistorted: its on-figure height is its width scaled by the
+    # image aspect and corrected for the figure's own aspect, because a unit of
+    # figure-fraction height spans fewer inches than a unit of width (or more).
+    height = width * (img_h / img_w) * (fig_w_in / fig_h_in)
+    x0, y0 = _corner_origin(corner, width, height, margin)
+
+    if shadow:
+        _stamp_shadow(fig, image, x0, y0, width, height)
+
+    ax = fig.add_axes((x0, y0, width, height), frameon=False, zorder=_MARK_ZORDER)
+    ax.imshow(image, aspect="auto", interpolation="antialiased")
+    ax.axis("off")
+    ax.set_in_layout(False)
+    return ax
+
+
+def _as_rgba(path: "str | os.PathLike | np.ndarray") -> np.ndarray:
+    """Return the mark as an ``(H, W, 4)`` ``uint8`` RGBA array.
+
+    Args:
+        path: A file path `PIL` can open, or an ``(H, W, 3)`` / ``(H, W, 4)``
+            array (``uint8`` ``0-255`` or float ``0-1``).
+
+    Returns:
+        np.ndarray: The image as ``uint8`` RGBA, with an opaque alpha added
+        when the input is RGB.
+
+    Raises:
+        ValueError: If an array input is not ``(H, W, 3)`` or ``(H, W, 4)``.
+    """
+    if isinstance(path, np.ndarray):
+        arr = np.asarray(path)
+        if arr.ndim != 3 or arr.shape[2] not in (3, 4):
+            raise ValueError(
+                f"an image array must be (H, W, 3) or (H, W, 4); got shape {arr.shape}."
+            )
+        if np.issubdtype(arr.dtype, np.floating):
+            arr = (np.clip(arr, 0.0, 1.0) * 255).round().astype(np.uint8)
+        else:
+            arr = arr.astype(np.uint8, copy=False)
+        if arr.shape[2] == 3:
+            opaque = np.full(arr.shape[:2] + (1,), 255, dtype=np.uint8)
+            arr = np.concatenate([arr, opaque], axis=2)
+        return arr
+    with Image.open(path) as im:
+        return np.asarray(im.convert("RGBA"))
+
+
+def _corner_origin(corner: str, width: float, height: float, margin: float) -> tuple[float, float]:
+    """Return the ``(x0, y0)`` figure-fraction origin for a corner-anchored rect.
+
+    Args:
+        corner: One of the `_CORNERS` anchors.
+        width: The mark width in figure fraction.
+        height: The mark height in figure fraction.
+        margin: The edge gap in figure fraction.
+
+    Returns:
+        tuple[float, float]: The bottom-left ``(x0, y0)`` of the mark's axes.
+    """
+    at_right = corner.endswith("right")
+    at_top = corner.startswith("upper")
+    x0 = (1.0 - margin - width) if at_right else margin
+    y0 = (1.0 - margin - height) if at_top else margin
+    return x0, y0
+
+
+def _stamp_shadow(
+    fig: "Figure", image: np.ndarray, x0: float, y0: float, width: float, height: float
+) -> "Axes":
+    """Draw a gaussian-blurred drop shadow beneath a mark on its own axes.
+
+    Builds the shadow from the mark's alpha channel: pad it (to give the blur
+    room), gaussian-blur it, tint it black, and place it in a slightly larger,
+    down-and-right-offset frameless axes under the mark so the mark separates
+    from a busy / dark canvas.
+
+    Args:
+        fig: The figure to draw on.
+        image: The RGBA ``uint8`` mark (its alpha drives the shadow shape).
+        x0: The mark's figure-fraction left edge.
+        y0: The mark's figure-fraction bottom edge.
+        width: The mark's figure-fraction width.
+        height: The mark's figure-fraction height.
+
+    Returns:
+        Axes: The frameless axes the shadow was drawn on.
+    """
+    img_h, img_w = image.shape[:2]
+    pad = max(1, int(round(_SHADOW_PAD * max(img_h, img_w))))
+    alpha = np.pad(image[..., 3], pad, mode="constant", constant_values=0)
+    blurred = np.asarray(
+        Image.fromarray(alpha).filter(ImageFilter.GaussianBlur(pad * _SHADOW_BLUR_FRAC))
+    )
+    shadow = np.zeros(blurred.shape + (4,), dtype=np.uint8)
+    shadow[..., 3] = (blurred.astype(np.float64) * _SHADOW_ALPHA).astype(np.uint8)
+
+    # The mark occupies (img_w, img_h) centred within the padded (pad_w, pad_h),
+    # so scale the mark's rect by the same ratio to keep the shadow aligned, then
+    # nudge it down-and-right for the drop-shadow offset.
+    pad_h, pad_w = shadow.shape[:2]
+    shadow_w = width * pad_w / img_w
+    shadow_h = height * pad_h / img_h
+    shadow_x = x0 - (shadow_w - width) / 2.0 + _SHADOW_OFFSET * width
+    shadow_y = y0 - (shadow_h - height) / 2.0 - _SHADOW_OFFSET * height
+
+    sax = fig.add_axes(
+        (shadow_x, shadow_y, shadow_w, shadow_h), frameon=False, zorder=_SHADOW_ZORDER
+    )
+    sax.imshow(shadow, aspect="auto", interpolation="antialiased")
+    sax.axis("off")
+    sax.set_in_layout(False)
+    return sax

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -93,7 +93,9 @@ def stamp_mark(
         shadow: Whether to composite a gaussian-blurred halo behind the mark so
             it separates from a busy or dark canvas. Defaults to ``True``.
         blur: Halo blur sigma, as a fraction of the mark's own **unpadded**
-            width. Defaults to `DEFAULT_BLUR`. Ignored when ``shadow=False``.
+            width. Defaults to `DEFAULT_BLUR`. Must be non-negative (validated
+            even when ``shadow=False``, where it is otherwise unused); ``0`` is
+            treated as no halo.
 
     Returns:
         Axes: The frameless inset axes the mark was drawn on, so the caller can
@@ -117,8 +119,10 @@ def stamp_mark(
         finalization (stamping first then calling `tight_layout()` warns), and
         after the final `set_size_inches`. Placement holds across dpi but not
         across a later figure-size change. Saving with `bbox_inches="tight"`
-        crops surrounding whitespace and so changes the mark's relative margin /
-        size; a plain ``dpi=`` save preserves them.
+        changes the mark's relative margin / size -- it crops surrounding
+        whitespace, and a halo tucked near an edge (whose grown axes overflows
+        the figure) can even *extend* the tight bbox outward; a plain ``dpi=``
+        save preserves the placement.
 
         `frac` always sizes the **mark itself**, never the canvas it is
         composited on. The halo needs a transparent pad of

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -167,6 +167,11 @@ def stamp_mark(
 
     image = _as_rgba(path)
     img_h, img_w = image.shape[:2]
+    if img_h == 0 or img_w == 0:
+        raise ValueError(
+            f"the mark image has a zero-size dimension {image.shape[:2]}; "
+            "it must have a positive height and width."
+        )
     fig_w_in, fig_h_in = fig.get_size_inches()
 
     width = float(frac)

--- a/src/cleopatra/styling/watermark.py
+++ b/src/cleopatra/styling/watermark.py
@@ -158,7 +158,9 @@ def _as_rgba(path: "str | os.PathLike | np.ndarray") -> np.ndarray:
         when the input is RGB.
 
     Raises:
-        ValueError: If an array input is not ``(H, W, 3)`` or ``(H, W, 4)``.
+        ValueError: If an array input is not ``(H, W, 3)`` / ``(H, W, 4)``, is a
+            non-``uint8`` integer array, or is a float array with values outside
+            ``[0, 1]``.
     """
     if isinstance(path, np.ndarray):
         arr = np.asarray(path)
@@ -167,9 +169,23 @@ def _as_rgba(path: "str | os.PathLike | np.ndarray") -> np.ndarray:
                 f"an image array must be (H, W, 3) or (H, W, 4); got shape {arr.shape}."
             )
         if np.issubdtype(arr.dtype, np.floating):
+            # A float image is the ``0-1`` contract; reject clearly out-of-range
+            # values rather than silently clipping (e.g. a ``0-255`` float array
+            # would otherwise flatten to all-white).
+            if arr.size and (arr.min() < -1e-6 or arr.max() > 1.0 + 1e-6):
+                raise ValueError(
+                    "a float image array must hold values in [0, 1]; got range "
+                    f"[{float(arr.min()):.4g}, {float(arr.max()):.4g}]. "
+                    "For 0-255 data pass a uint8 array."
+                )
             arr = (np.clip(arr, 0.0, 1.0) * 255).round().astype(np.uint8)
-        else:
-            arr = arr.astype(np.uint8, copy=False)
+        elif arr.dtype != np.uint8:
+            # Any other integer dtype (uint16, int32, bool, ...) would truncate
+            # mod 256 under a bare uint8 cast and silently garble the mark.
+            raise ValueError(
+                f"an integer image array must be uint8 (0-255); got dtype {arr.dtype}. "
+                "Convert / rescale it to uint8 (or pass a float 0-1 array) first."
+            )
         if arr.shape[2] == 3:
             opaque = np.full(arr.shape[:2] + (1,), 255, dtype=np.uint8)
             arr = np.concatenate([arr, opaque], axis=2)

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -220,6 +220,30 @@ class TestStampMark:
             )
             plt.close(figure)
 
+    def test_undistorted_with_halo(self):
+        """The mark keeps its aspect ratio even under the asymmetric halo pad.
+
+        Test scenario:
+            The halo pads by a fixed pixel count, so a non-square mark gets an
+            asymmetric grow (``grow_w != grow_h``). Render with the halo and
+            measure the red mark's painted width and height; their ratio must
+            still equal the image's 40:80 aspect -- the mark is not stretched.
+        """
+        figure = plt.figure(figsize=(8.0, 6.0), facecolor="white")
+        mark = np.zeros((40, 80, 4), dtype=np.uint8)
+        mark[..., 0] = 255
+        mark[..., 3] = 255
+        stamp_mark(figure, mark, frac=0.25, corner="lower left", margin=0.15, shadow=True)
+        figure.canvas.draw()
+        rgba = np.asarray(figure.canvas.buffer_rgba())
+        red = (rgba[..., 0] > 200) & (rgba[..., 1] < 60) & (rgba[..., 2] < 60)
+        h_px = np.ptp(np.where(red.any(axis=1))[0]) + 1
+        w_px = np.ptp(np.where(red.any(axis=0))[0]) + 1
+        assert abs((h_px / w_px) - (40 / 80)) < 0.02, (
+            f"mark distorted under the halo: h/w={h_px / w_px:.4f}, expected {40 / 80}"
+        )
+        plt.close(figure)
+
     def test_halo_is_centred_not_offset(self):
         """The halo spreads symmetrically, with no light direction implied.
 
@@ -437,6 +461,28 @@ class TestStampMark:
         arr[0, 0, 0] = np.nan
         with pytest.raises(ValueError, match="finite"):
             stamp_mark(fig, arr, shadow=False)
+
+    def test_float_rgb_array_accepted(self, fig):
+        """A float ``0-1`` **RGB** ``(H, W, 3)`` array is accepted (opaque alpha).
+
+        Test scenario:
+            Only float RGBA was covered; a float RGB array must also render, with
+            an opaque alpha added internally.
+        """
+        rgb = np.full((30, 60, 3), 0.5, dtype=np.float32)
+        ax = stamp_mark(fig, rgb, shadow=False)
+        assert ax.images, "float RGB array should produce a drawn image"
+
+    def test_bool_array_rejected(self, fig):
+        """A ``bool`` array is rejected with a clear message, not silently cast.
+
+        Test scenario:
+            A bool array is not ``uint8``; it must raise the non-float/uint8
+            error rather than being truncated.
+        """
+        b = np.ones((20, 20, 4), dtype=bool)
+        with pytest.raises(ValueError, match="uint8"):
+            stamp_mark(fig, b, shadow=False)
 
     @pytest.mark.parametrize("bad", [np.zeros((10, 10)), np.zeros((10, 10, 2))])
     def test_bad_array_shape_raises(self, fig, bad):

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -1,0 +1,265 @@
+"""Tests for the figure watermark / brand-mark helper -- issue #312.
+
+Covers `cleopatra.styling.watermark.stamp_mark`: corner placement in
+figure-fraction coordinates, dpi-invariant sizing, undistorted aspect, the
+optional gaussian-blurred drop shadow, image-input handling (RGBA/RGB arrays,
+float arrays, file paths), and input validation.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from PIL import Image
+
+from cleopatra.styling.watermark import _CORNERS, stamp_mark
+
+
+@pytest.fixture
+def fig():
+    """Provide a 8x6-inch figure with one populated subplot.
+
+    Returns:
+        matplotlib.figure.Figure: A figure carrying a small imshow so the mark
+        is drawn over real content.
+    """
+    figure = plt.figure(figsize=(8.0, 6.0))
+    figure.add_subplot(111).imshow(np.zeros((10, 10)))
+    yield figure
+    plt.close(figure)
+
+
+@pytest.fixture
+def logo():
+    """Provide a 40x80 (h x w) opaque white RGBA logo array.
+
+    Returns:
+        np.ndarray: A ``(40, 80, 4)`` ``uint8`` RGBA array (aspect 0.5).
+    """
+    arr = np.zeros((40, 80, 4), dtype=np.uint8)
+    arr[..., :3] = 255
+    arr[..., 3] = 255
+    return arr
+
+
+class TestStampMark:
+    """Tests for `stamp_mark`."""
+
+    @pytest.mark.parametrize(
+        "corner, at_right, at_top",
+        [
+            ("lower right", True, False),
+            ("lower left", False, False),
+            ("upper right", True, True),
+            ("upper left", False, True),
+        ],
+    )
+    def test_places_in_each_corner(self, fig, logo, corner, at_right, at_top):
+        """The mark lands in the requested corner, in figure-fraction coords.
+
+        Args:
+            fig: Figure fixture.
+            logo: RGBA logo fixture.
+            corner: The corner anchor under test.
+            at_right: Whether that corner is on the right edge.
+            at_top: Whether that corner is on the top edge.
+
+        Test scenario:
+            For each corner the returned axes' bounds match the width/height
+            derived from `frac` and the image + figure aspect, offset from the
+            correct edges by `margin`.
+        """
+        frac, margin = 0.11, 0.025
+        ax = stamp_mark(fig, logo, frac=frac, corner=corner, margin=margin, shadow=False)
+        x0, y0, w, h = (float(v) for v in ax.get_position().bounds)
+
+        exp_w = frac
+        exp_h = frac * (40 / 80) * (8.0 / 6.0)
+        exp_x = (1.0 - margin - exp_w) if at_right else margin
+        exp_y = (1.0 - margin - exp_h) if at_top else margin
+        assert np.allclose([x0, y0, w, h], [exp_x, exp_y, exp_w, exp_h]), (
+            f"{corner}: got {(x0, y0, w, h)}, expected {(exp_x, exp_y, exp_w, exp_h)}"
+        )
+
+    def test_size_holds_across_dpi(self, fig, logo):
+        """The mark's figure-fraction position is unchanged by dpi.
+
+        Test scenario:
+            Because the mark is an inset axes in figure-fraction coordinates,
+            its bounds are identical at 100 and 300 dpi -- so it stays
+            proportional across an MP4 master, a web copy, and a GIF.
+        """
+        ax = stamp_mark(fig, logo, shadow=False)
+        fig.set_dpi(100)
+        at_100 = tuple(ax.get_position().bounds)
+        fig.set_dpi(300)
+        at_300 = tuple(ax.get_position().bounds)
+        assert np.allclose(at_100, at_300), f"position changed with dpi: {at_100} vs {at_300}"
+
+    def test_image_is_undistorted(self, fig, logo):
+        """The on-figure mark keeps the image's aspect ratio.
+
+        Test scenario:
+            The rendered width:height in inches equals the source image's
+            width:height (0.5 here), even though the figure itself is not
+            square -- so a logo is never stretched.
+        """
+        ax = stamp_mark(fig, logo, shadow=False)
+        box = ax.get_position()
+        w_in = box.width * 8.0
+        h_in = box.height * 6.0
+        assert np.isclose(h_in / w_in, 40 / 80), f"aspect distorted: {h_in / w_in} != {40 / 80}"
+
+    def test_shadow_adds_a_second_axes(self, fig, logo):
+        """`shadow=True` draws the shadow on its own axes beneath the mark.
+
+        Test scenario:
+            Stamping with a shadow adds two axes (shadow + mark), and the
+            shadow's zorder is below the mark's.
+        """
+        n_before = len(fig.axes)
+        ax = stamp_mark(fig, logo, shadow=True)
+        assert len(fig.axes) - n_before == 2, "shadow should add a mark axes and a shadow axes"
+        others = [a for a in fig.axes if a is not ax and a.get_zorder() >= 1_000_000]
+        assert others, "no shadow axes found"
+        assert others[0].get_zorder() < ax.get_zorder(), "shadow must sit beneath the mark"
+
+    def test_no_shadow_adds_single_axes(self, fig, logo):
+        """`shadow=False` draws only the mark axes.
+
+        Test scenario:
+            Without a shadow exactly one axes is added.
+        """
+        n_before = len(fig.axes)
+        stamp_mark(fig, logo, shadow=False)
+        assert len(fig.axes) - n_before == 1, "no-shadow stamp should add exactly one axes"
+
+    def test_returns_frameless_axes_above_content(self, fig, logo):
+        """The mark axes is frameless, off, and above ordinary content.
+
+        Test scenario:
+            The returned axes has its frame off (no white box), no visible
+            axis, and a very high zorder so it draws on top of the plot.
+        """
+        ax = stamp_mark(fig, logo, shadow=False)
+        assert not ax.get_frame_on(), "mark axes must be frameless (no background box)"
+        assert not ax.axison, "mark axes must have its axis turned off"
+        assert ax.get_zorder() >= 1_000_000, "mark must sit above ordinary figure content"
+
+    def test_unknown_corner_raises(self, fig, logo):
+        """An unrecognised corner raises a clear `ValueError` naming the input.
+
+        Test scenario:
+            ``corner="middle"`` is rejected before any drawing, and the message
+            names the bad value.
+        """
+        with pytest.raises(ValueError, match=r"corner must be one of.*'middle'"):
+            stamp_mark(fig, logo, corner="middle")
+
+    @pytest.mark.parametrize("frac", [0.0, -0.1, 1.5])
+    def test_invalid_frac_raises(self, fig, logo, frac):
+        """A `frac` outside ``(0, 1]`` raises `ValueError`.
+
+        Args:
+            fig: Figure fixture.
+            logo: RGBA logo fixture.
+            frac: The out-of-range fraction under test.
+
+        Test scenario:
+            Zero, negative, and above-one fractions are all rejected.
+        """
+        with pytest.raises(ValueError, match="frac must be in"):
+            stamp_mark(fig, logo, frac=frac)
+
+    @pytest.mark.parametrize("margin", [-0.01, 1.0, 1.5])
+    def test_invalid_margin_raises(self, fig, logo, margin):
+        """A `margin` outside ``[0, 1)`` raises `ValueError`.
+
+        Args:
+            fig: Figure fixture.
+            logo: RGBA logo fixture.
+            margin: The out-of-range margin under test.
+
+        Test scenario:
+            Negative and >= 1 margins are rejected.
+        """
+        with pytest.raises(ValueError, match="margin must be in"):
+            stamp_mark(fig, logo, margin=margin)
+
+    def test_rgb_array_gets_opaque_alpha(self, fig):
+        """A 3-channel RGB array is accepted and stamped opaque.
+
+        Test scenario:
+            An ``(H, W, 3)`` array renders without error -- an opaque alpha is
+            added internally -- producing a normal mark axes.
+        """
+        rgb = np.full((30, 30, 3), 128, dtype=np.uint8)
+        ax = stamp_mark(fig, rgb, shadow=False)
+        assert ax.images, "RGB array should produce a drawn image"
+
+    def test_float_array_accepted(self, fig):
+        """A float ``0-1`` RGBA array is accepted (scaled to ``uint8``).
+
+        Test scenario:
+            A float image in ``[0, 1]`` renders without error.
+        """
+        rgba = np.ones((30, 60, 4), dtype=np.float32)
+        ax = stamp_mark(fig, rgba, shadow=False)
+        assert ax.images, "float array should produce a drawn image"
+
+    @pytest.mark.parametrize("bad", [np.zeros((10, 10)), np.zeros((10, 10, 2))])
+    def test_bad_array_shape_raises(self, fig, bad):
+        """A non-``(H, W, 3|4)`` array raises `ValueError`.
+
+        Args:
+            fig: Figure fixture.
+            bad: An array with an unsupported shape.
+
+        Test scenario:
+            2-D and 2-channel arrays are rejected with a shape message.
+        """
+        with pytest.raises(ValueError, match="must be"):
+            stamp_mark(fig, bad, shadow=False)
+
+    def test_file_path_input(self, fig, tmp_path, logo):
+        """A PNG file path is loaded via PIL and stamped.
+
+        Args:
+            fig: Figure fixture.
+            tmp_path: pytest temp directory.
+            logo: RGBA logo fixture, written to disk.
+
+        Test scenario:
+            Writing the logo to a PNG and passing its path produces the same
+            placement as passing the array directly.
+        """
+        png = tmp_path / "logo.png"
+        Image.fromarray(logo).save(png)
+        ax_path = stamp_mark(fig, str(png), shadow=False)
+        assert ax_path.images, "file-path input should produce a drawn image"
+        assert np.allclose(
+            ax_path.get_position().bounds, (0.865, 0.025, 0.11, 0.11 * 0.5 * (8.0 / 6.0))
+        ), f"file-path placement wrong: {ax_path.get_position().bounds}"
+
+    def test_frac_controls_width(self, fig, logo):
+        """A larger `frac` yields a proportionally wider mark.
+
+        Test scenario:
+            Doubling `frac` doubles the mark's figure-fraction width.
+        """
+        small = stamp_mark(fig, logo, frac=0.1, shadow=False).get_position().width
+        big = stamp_mark(fig, logo, frac=0.2, shadow=False).get_position().width
+        assert np.isclose(big, 2 * small), f"frac should scale width linearly: {big} vs {small}"
+
+    def test_corners_constant_exposes_four_anchors(self):
+        """`_CORNERS` lists exactly the four documented anchors.
+
+        Test scenario:
+            The accepted-corner set matches the documented four.
+        """
+        assert set(_CORNERS) == {"lower right", "lower left", "upper right", "upper left"}

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -448,17 +448,22 @@ class TestStampMark:
         with pytest.raises(ValueError, match=r"\[0, 1\]"):
             stamp_mark(fig, f255, shadow=False)
 
-    def test_nan_float_array_rejected(self, fig):
-        """A float array with a ``NaN`` is rejected, not silently cast to 0.
+    @pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+    def test_non_finite_float_array_rejected(self, fig, bad):
+        """A float array with ``NaN``/``inf`` is rejected, not silently cast.
+
+        Args:
+            fig: Figure fixture.
+            bad: The non-finite value to plant.
 
         Test scenario:
-            A ``NaN`` makes ``min``/``max`` ``NaN``, whose comparisons are all
-            ``False``, so without a finiteness check it would slip past the
-            range guard and cast to 0 with a `RuntimeWarning`. It must raise a
-            `ValueError` about finite values instead.
+            ``NaN`` makes ``min``/``max`` ``NaN`` (all comparisons ``False``),
+            and ``inf`` would fail the cast too, so without a finiteness check
+            they slip past the range guard and cast with a `RuntimeWarning`. All
+            three must raise a `ValueError` about finite values instead.
         """
         arr = np.ones((20, 20, 4), dtype=np.float32)
-        arr[0, 0, 0] = np.nan
+        arr[0, 0, 0] = bad
         with pytest.raises(ValueError, match="finite"):
             stamp_mark(fig, arr, shadow=False)
 

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -498,6 +498,18 @@ class TestStampMark:
         with pytest.raises(ValueError, match="must be"):
             stamp_mark(fig, bad, shadow=False)
 
+    def test_zero_size_image_rejected(self, fig):
+        """A zero-size image dimension raises clearly, not a matplotlib error.
+
+        Test scenario:
+            A ``(0, W, C)`` array passes the shape check but has no pixels;
+            `stamp_mark` rejects it up front rather than surfacing a confusing
+            matplotlib-internal reduction error.
+        """
+        empty = np.zeros((0, 10, 4), dtype=np.uint8)
+        with pytest.raises(ValueError, match="zero-size"):
+            stamp_mark(fig, empty, shadow=False)
+
     def test_file_path_input(self, fig, tmp_path, logo):
         """A PNG file path is loaded via PIL and stamped.
 

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -231,6 +231,30 @@ class TestStampMark:
         ax = stamp_mark(fig, rgba, shadow=False)
         assert ax.images, "float array should produce a drawn image"
 
+    def test_uint16_array_rejected(self, fig):
+        """A non-``uint8`` integer array is rejected, not truncated mod 256.
+
+        Test scenario:
+            A ``uint16`` image (value 1000 would become 232 under a bare
+            ``uint8`` cast) raises a `ValueError` naming the dtype instead of
+            silently garbling the mark.
+        """
+        u16 = np.full((20, 20, 4), 1000, dtype=np.uint16)
+        with pytest.raises(ValueError, match="uint8"):
+            stamp_mark(fig, u16, shadow=False)
+
+    def test_out_of_range_float_array_rejected(self, fig):
+        """A float array outside ``[0, 1]`` is rejected, not clipped to white.
+
+        Test scenario:
+            A ``0-255`` float array (common way to hold an image) raises a
+            `ValueError` about the ``[0, 1]`` contract rather than flattening to
+            all-white.
+        """
+        f255 = np.full((20, 20, 4), 128.0, dtype=np.float32)
+        with pytest.raises(ValueError, match=r"\[0, 1\]"):
+            stamp_mark(fig, f255, shadow=False)
+
     @pytest.mark.parametrize("bad", [np.zeros((10, 10)), np.zeros((10, 10, 2))])
     def test_bad_array_shape_raises(self, fig, bad):
         """A non-``(H, W, 3|4)`` array raises `ValueError`.

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -401,6 +401,20 @@ class TestStampMark:
         with pytest.raises(ValueError, match=r"\[0, 1\]"):
             stamp_mark(fig, f255, shadow=False)
 
+    def test_nan_float_array_rejected(self, fig):
+        """A float array with a ``NaN`` is rejected, not silently cast to 0.
+
+        Test scenario:
+            A ``NaN`` makes ``min``/``max`` ``NaN``, whose comparisons are all
+            ``False``, so without a finiteness check it would slip past the
+            range guard and cast to 0 with a `RuntimeWarning`. It must raise a
+            `ValueError` about finite values instead.
+        """
+        arr = np.ones((20, 20, 4), dtype=np.float32)
+        arr[0, 0, 0] = np.nan
+        with pytest.raises(ValueError, match="finite"):
+            stamp_mark(fig, arr, shadow=False)
+
     @pytest.mark.parametrize("bad", [np.zeros((10, 10)), np.zeros((10, 10, 2))])
     def test_bad_array_shape_raises(self, fig, bad):
         """A non-``(H, W, 3|4)`` array raises `ValueError`.

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -231,6 +231,16 @@ class TestStampMark:
         ax = stamp_mark(fig, rgba, shadow=False)
         assert ax.images, "float array should produce a drawn image"
 
+    def test_missing_path_raises(self, fig, tmp_path):
+        """A non-existent file path raises `FileNotFoundError`.
+
+        Test scenario:
+            Passing a path that does not exist surfaces a clear
+            `FileNotFoundError` at stamp time, not a confusing later failure.
+        """
+        with pytest.raises(FileNotFoundError):
+            stamp_mark(fig, str(tmp_path / "does_not_exist.png"), shadow=False)
+
     def test_uint16_array_rejected(self, fig):
         """A non-``uint8`` integer array is rejected, not truncated mod 256.
 

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -180,6 +180,18 @@ class TestStampMark:
             f"haloed axes should be frac*{grow:.3f}={frac * grow:.4f}, got {haloed:.4f}"
         )
 
+    def test_blur_zero_skips_the_halo(self, fig, logo):
+        """`blur=0` with `shadow=True` skips the invisible halo, so no bbox growth.
+
+        Test scenario:
+            A zero-sigma halo is invisible but would still pad the canvas by a
+            pixel and inflate the axes bbox. With `blur=0` the composite is
+            skipped, so the axes measures exactly `frac` -- like `shadow=False`.
+        """
+        frac = 0.2
+        haloed = stamp_mark(fig, logo, frac=frac, shadow=True, blur=0.0).get_position().width
+        assert np.isclose(haloed, frac), f"blur=0 should not grow the axes: {haloed} != {frac}"
+
     def test_mark_painted_extent_is_frac(self):
         """The **mark's own painted width** is `frac` of the figure, halo or not.
 

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -115,6 +115,25 @@ class TestStampMark:
         h_in = box.height * 6.0
         assert np.isclose(h_in / w_in, 40 / 80), f"aspect distorted: {h_in / w_in} != {40 / 80}"
 
+    def test_tall_logo_stays_on_canvas(self, fig):
+        """A portrait logo is sized by height and never overflows the figure.
+
+        Test scenario:
+            A 10:1 tall logo would, if `frac` only sized the width, derive a
+            height above 1 and land off-canvas. `frac` instead caps the mark's
+            longer (height) side, so the mark stays within ``[0, 1]`` in both
+            dimensions and keeps its aspect ratio.
+        """
+        tall = np.zeros((400, 40, 4), dtype=np.uint8)
+        tall[..., :3] = 255
+        tall[..., 3] = 255
+        ax = stamp_mark(fig, tall, frac=0.5, corner="upper left", shadow=False)
+        x0, y0, w, h = (float(v) for v in ax.get_position().bounds)
+        assert 0.0 <= x0 and x0 + w <= 1.0, f"mark overflows horizontally: {(x0, w)}"
+        assert 0.0 <= y0 and y0 + h <= 1.0, f"mark overflows vertically: {(y0, h)}"
+        assert np.isclose(max(w, h), 0.5), f"longer side should equal frac: {(w, h)}"
+        assert np.isclose((h * 6.0) / (w * 8.0), 400 / 40), f"tall logo distorted: {(w, h)}"
+
     def test_shadow_adds_a_second_axes(self, fig, logo):
         """`shadow=True` draws the shadow on its own axes beneath the mark.
 

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -306,7 +306,7 @@ class TestStampMark:
             f"horizontal margin should be 0.025: {x0 + w}"
         )
 
-    @pytest.mark.parametrize("bad", ["0.1", (0.1, 0.2, 0.3), (0.1,)])
+    @pytest.mark.parametrize("bad", ["0.1", (0.1, 0.2, 0.3), (0.1,), None])
     def test_malformed_margin_raises(self, fig, logo, bad):
         """A margin that is neither a scalar nor an ``(x, y)`` pair raises.
 
@@ -316,7 +316,8 @@ class TestStampMark:
             bad: A malformed margin value.
 
         Test scenario:
-            Strings and wrong-length sequences are rejected with a clear message.
+            Strings, wrong-length sequences, and a non-iterable non-number
+            (``None``) are all rejected with a clear message.
         """
         with pytest.raises(ValueError, match="margin must be"):
             stamp_mark(fig, logo, margin=bad)

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -334,6 +334,17 @@ class TestStampMark:
         with pytest.raises(ValueError, match="margin must be"):
             stamp_mark(fig, logo, margin=bad)
 
+    def test_margin_plus_size_off_canvas_raises(self, fig, logo):
+        """A margin that leaves no room for the mark raises, not silent overflow.
+
+        Test scenario:
+            `frac` and `margin` are each in range, but `margin=0.95` +
+            `frac=0.11` sums past 1, which would place the mark off the opposite
+            edge. `stamp_mark` raises a clear `ValueError` instead.
+        """
+        with pytest.raises(ValueError, match="exceeds the figure"):
+            stamp_mark(fig, logo, frac=0.11, margin=0.95, shadow=False)
+
     def test_negative_blur_raises(self, fig, logo):
         """A negative `blur` raises `ValueError`.
 

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -135,8 +135,10 @@ class TestStampMark:
         tall[..., 3] = 255
         ax = stamp_mark(fig, tall, frac=0.5, corner="upper left", shadow=False)
         x0, y0, w, h = (float(v) for v in ax.get_position().bounds)
-        assert 0.0 <= x0 and x0 + w <= 1.0, f"mark overflows horizontally: {(x0, w)}"
-        assert 0.0 <= y0 and y0 + h <= 1.0, f"mark overflows vertically: {(y0, h)}"
+        assert 0.0 <= x0, f"mark overflows the left edge: x0={x0}"
+        assert x0 + w <= 1.0, f"mark overflows the right edge: {(x0, w)}"
+        assert 0.0 <= y0, f"mark overflows the bottom edge: y0={y0}"
+        assert y0 + h <= 1.0, f"mark overflows the top edge: {(y0, h)}"
         assert np.isclose(max(w, h), 0.5), f"longer side should equal frac: {(w, h)}"
         assert np.isclose((h * 6.0) / (w * 8.0), 400 / 40), (
             f"tall logo distorted: {(w, h)}"
@@ -158,8 +160,11 @@ class TestStampMark:
         )
         drawn = ax.images[0].get_array()
         assert drawn.shape[2] == 4, "the composited mark should carry alpha"
-        assert drawn.shape[0] > logo.shape[0] and drawn.shape[1] > logo.shape[1], (
-            f"halo canvas should exceed the mark: {drawn.shape} vs {logo.shape}"
+        assert drawn.shape[0] > logo.shape[0], (
+            f"halo canvas height should exceed the mark: {drawn.shape} vs {logo.shape}"
+        )
+        assert drawn.shape[1] > logo.shape[1], (
+            f"halo canvas width should exceed the mark: {drawn.shape} vs {logo.shape}"
         )
 
     def test_halo_grows_the_axes_so_the_mark_keeps_its_size(self, fig, logo):
@@ -265,9 +270,8 @@ class TestStampMark:
         dark_cols = np.where(darkened.any(axis=0))[0]
         left = red_cols.min() - dark_cols.min()
         right = dark_cols.max() - red_cols.max()
-        assert left > 0 and right > 0, (
-            f"halo should reach past both sides: {(left, right)}"
-        )
+        assert left > 0, f"halo should reach past the left side: {(left, right)}"
+        assert right > 0, f"halo should reach past the right side: {(left, right)}"
         assert abs(left - right) <= 2, (
             f"halo is off-centre: {left}px left vs {right}px right"
         )

--- a/tests/test_watermark.py
+++ b/tests/test_watermark.py
@@ -2,7 +2,7 @@
 
 Covers `cleopatra.styling.watermark.stamp_mark`: corner placement in
 figure-fraction coordinates, dpi-invariant sizing, undistorted aspect, the
-optional gaussian-blurred drop shadow, image-input handling (RGBA/RGB arrays,
+optional gaussian-blurred halo, image-input handling (RGBA/RGB arrays,
 float arrays, file paths), and input validation.
 """
 
@@ -17,7 +17,7 @@ import numpy as np
 import pytest
 from PIL import Image
 
-from cleopatra.styling.watermark import _CORNERS, stamp_mark
+from cleopatra.styling.watermark import _CORNERS, _HALO_SIGMAS, DEFAULT_BLUR, stamp_mark
 
 
 @pytest.fixture
@@ -75,7 +75,9 @@ class TestStampMark:
             correct edges by `margin`.
         """
         frac, margin = 0.11, 0.025
-        ax = stamp_mark(fig, logo, frac=frac, corner=corner, margin=margin, shadow=False)
+        ax = stamp_mark(
+            fig, logo, frac=frac, corner=corner, margin=margin, shadow=False
+        )
         x0, y0, w, h = (float(v) for v in ax.get_position().bounds)
 
         exp_w = frac
@@ -99,7 +101,9 @@ class TestStampMark:
         at_100 = tuple(ax.get_position().bounds)
         fig.set_dpi(300)
         at_300 = tuple(ax.get_position().bounds)
-        assert np.allclose(at_100, at_300), f"position changed with dpi: {at_100} vs {at_300}"
+        assert np.allclose(at_100, at_300), (
+            f"position changed with dpi: {at_100} vs {at_300}"
+        )
 
     def test_image_is_undistorted(self, fig, logo):
         """The on-figure mark keeps the image's aspect ratio.
@@ -113,7 +117,9 @@ class TestStampMark:
         box = ax.get_position()
         w_in = box.width * 8.0
         h_in = box.height * 6.0
-        assert np.isclose(h_in / w_in, 40 / 80), f"aspect distorted: {h_in / w_in} != {40 / 80}"
+        assert np.isclose(h_in / w_in, 40 / 80), (
+            f"aspect distorted: {h_in / w_in} != {40 / 80}"
+        )
 
     def test_tall_logo_stays_on_canvas(self, fig):
         """A portrait logo is sized by height and never overflows the figure.
@@ -132,21 +138,104 @@ class TestStampMark:
         assert 0.0 <= x0 and x0 + w <= 1.0, f"mark overflows horizontally: {(x0, w)}"
         assert 0.0 <= y0 and y0 + h <= 1.0, f"mark overflows vertically: {(y0, h)}"
         assert np.isclose(max(w, h), 0.5), f"longer side should equal frac: {(w, h)}"
-        assert np.isclose((h * 6.0) / (w * 8.0), 400 / 40), f"tall logo distorted: {(w, h)}"
+        assert np.isclose((h * 6.0) / (w * 8.0), 400 / 40), (
+            f"tall logo distorted: {(w, h)}"
+        )
 
-    def test_shadow_adds_a_second_axes(self, fig, logo):
-        """`shadow=True` draws the shadow on its own axes beneath the mark.
+    def test_shadow_composites_into_one_axes(self, fig, logo):
+        """`shadow=True` composites the halo into the mark's own axes.
 
         Test scenario:
-            Stamping with a shadow adds two axes (shadow + mark), and the
-            shadow's zorder is below the mark's.
+            The halo and mark are alpha-composited into a single image before
+            placement, so only one axes is added -- one resample keeps the halo
+            in register with the mark's soft edges, which two independently
+            resampled axes would not guarantee.
         """
         n_before = len(fig.axes)
         ax = stamp_mark(fig, logo, shadow=True)
-        assert len(fig.axes) - n_before == 2, "shadow should add a mark axes and a shadow axes"
-        others = [a for a in fig.axes if a is not ax and a.get_zorder() >= 1_000_000]
-        assert others, "no shadow axes found"
-        assert others[0].get_zorder() < ax.get_zorder(), "shadow must sit beneath the mark"
+        assert len(fig.axes) - n_before == 1, (
+            "halo should be composited, not drawn on its own axes"
+        )
+        drawn = ax.images[0].get_array()
+        assert drawn.shape[2] == 4, "the composited mark should carry alpha"
+        assert drawn.shape[0] > logo.shape[0] and drawn.shape[1] > logo.shape[1], (
+            f"halo canvas should exceed the mark: {drawn.shape} vs {logo.shape}"
+        )
+
+    def test_halo_grows_the_axes_so_the_mark_keeps_its_size(self, fig, logo):
+        """The axes rect grows by the halo pad, leaving the mark at `frac`.
+
+        Test scenario:
+            The padded canvas is ``1 + 2 * _HALO_SIGMAS * blur`` times the
+            mark's width. The axes rect is grown by exactly that, so the mark
+            itself still measures `frac` -- without the compensation it would
+            render at 1/grow (about 72 %) of the requested size.
+        """
+        frac = 0.2
+        plain = stamp_mark(fig, logo, frac=frac, shadow=False).get_position().width
+        haloed = stamp_mark(fig, logo, frac=frac, shadow=True).get_position().width
+        grow = 1.0 + 2.0 * _HALO_SIGMAS * DEFAULT_BLUR
+        assert np.isclose(plain, frac), f"unhaloed mark should measure frac: {plain}"
+        assert np.isclose(haloed, frac * grow, rtol=0.02), (
+            f"haloed axes should be frac*{grow:.3f}={frac * grow:.4f}, got {haloed:.4f}"
+        )
+
+    def test_mark_painted_extent_is_frac(self):
+        """The **mark's own painted width** is `frac` of the figure, halo or not.
+
+        Test scenario:
+            This is the invariant the padding can silently break: render the
+            figure and measure the red mark's actual extent in pixels. Sizing
+            the padded canvas to `frac` instead would put the visible mark at
+            roughly 7.9 % for a requested 11 %, while the axes bbox still looked
+            correct.
+        """
+        for shadow in (False, True):
+            figure = plt.figure(figsize=(8.0, 6.0), facecolor="white")
+            mark = np.zeros((40, 80, 4), dtype=np.uint8)
+            mark[..., 0] = 255  # opaque pure red, distinct from the black halo
+            mark[..., 3] = 255
+            stamp_mark(
+                figure, mark, frac=0.25, corner="lower left", margin=0.15, shadow=shadow
+            )
+            figure.canvas.draw()
+            rgba = np.asarray(figure.canvas.buffer_rgba())
+            red = (rgba[..., 0] > 200) & (rgba[..., 1] < 60) & (rgba[..., 2] < 60)
+            cols = np.where(red.any(axis=0))[0]
+            painted = (cols.max() - cols.min() + 1) / rgba.shape[1]
+            assert abs(painted - 0.25) < 0.01, (
+                f"shadow={shadow}: mark painted at {painted:.4f} of the figure, expected 0.25"
+            )
+            plt.close(figure)
+
+    def test_halo_is_centred_not_offset(self):
+        """The halo spreads symmetrically, with no light direction implied.
+
+        Test scenario:
+            A drop shadow offset down-and-right would put more darkening on one
+            side of the mark than the other. Measure the halo's reach beyond the
+            mark on the left and the right; they should match.
+        """
+        figure = plt.figure(figsize=(8.0, 6.0), facecolor="white")
+        mark = np.zeros((40, 80, 4), dtype=np.uint8)
+        mark[..., 0] = 255
+        mark[..., 3] = 255
+        stamp_mark(figure, mark, frac=0.3, corner="lower left", margin=0.3, shadow=True)
+        figure.canvas.draw()
+        rgba = np.asarray(figure.canvas.buffer_rgba())
+        red = (rgba[..., 0] > 200) & (rgba[..., 1] < 60) & (rgba[..., 2] < 60)
+        darkened = rgba[..., :3].min(axis=2) < 250  # halo or mark, vs the white canvas
+        red_cols = np.where(red.any(axis=0))[0]
+        dark_cols = np.where(darkened.any(axis=0))[0]
+        left = red_cols.min() - dark_cols.min()
+        right = dark_cols.max() - red_cols.max()
+        assert left > 0 and right > 0, (
+            f"halo should reach past both sides: {(left, right)}"
+        )
+        assert abs(left - right) <= 2, (
+            f"halo is off-centre: {left}px left vs {right}px right"
+        )
+        plt.close(figure)
 
     def test_no_shadow_adds_single_axes(self, fig, logo):
         """`shadow=False` draws only the mark axes.
@@ -156,7 +245,9 @@ class TestStampMark:
         """
         n_before = len(fig.axes)
         stamp_mark(fig, logo, shadow=False)
-        assert len(fig.axes) - n_before == 1, "no-shadow stamp should add exactly one axes"
+        assert len(fig.axes) - n_before == 1, (
+            "no-shadow stamp should add exactly one axes"
+        )
 
     def test_returns_frameless_axes_above_content(self, fig, logo):
         """The mark axes is frameless, off, and above ordinary content.
@@ -168,7 +259,9 @@ class TestStampMark:
         ax = stamp_mark(fig, logo, shadow=False)
         assert not ax.get_frame_on(), "mark axes must be frameless (no background box)"
         assert not ax.axison, "mark axes must have its axis turned off"
-        assert ax.get_zorder() >= 1_000_000, "mark must sit above ordinary figure content"
+        assert ax.get_zorder() >= 1_000_000, (
+            "mark must sit above ordinary figure content"
+        )
 
     def test_unknown_corner_raises(self, fig, logo):
         """An unrecognised corner raises a clear `ValueError` naming the input.
@@ -194,6 +287,48 @@ class TestStampMark:
         """
         with pytest.raises(ValueError, match="frac must be in"):
             stamp_mark(fig, logo, frac=frac)
+
+    def test_margin_accepts_an_xy_pair(self, fig, logo):
+        """`margin` takes an ``(x, y)`` pair, not just one scalar.
+
+        Test scenario:
+            The showcase tucks the mark hard into the corner vertically while
+            keeping a horizontal gap, so a scalar cannot express its placement.
+            ``margin=(0.025, 0.0)`` puts the mark flush with the bottom edge and
+            0.025 in from the right.
+        """
+        ax = stamp_mark(
+            fig, logo, corner="lower right", margin=(0.025, 0.0), shadow=False
+        )
+        x0, y0, w, _ = (float(v) for v in ax.get_position().bounds)
+        assert np.isclose(y0, 0.0), f"vertical margin 0 should sit flush: {y0}"
+        assert np.isclose(x0 + w, 1.0 - 0.025), (
+            f"horizontal margin should be 0.025: {x0 + w}"
+        )
+
+    @pytest.mark.parametrize("bad", ["0.1", (0.1, 0.2, 0.3), (0.1,)])
+    def test_malformed_margin_raises(self, fig, logo, bad):
+        """A margin that is neither a scalar nor an ``(x, y)`` pair raises.
+
+        Args:
+            fig: Figure fixture.
+            logo: RGBA logo fixture.
+            bad: A malformed margin value.
+
+        Test scenario:
+            Strings and wrong-length sequences are rejected with a clear message.
+        """
+        with pytest.raises(ValueError, match="margin must be"):
+            stamp_mark(fig, logo, margin=bad)
+
+    def test_negative_blur_raises(self, fig, logo):
+        """A negative `blur` raises `ValueError`.
+
+        Test scenario:
+            Blur is a sigma, so it cannot be negative.
+        """
+        with pytest.raises(ValueError, match="blur must be non-negative"):
+            stamp_mark(fig, logo, blur=-0.1)
 
     @pytest.mark.parametrize("margin", [-0.01, 1.0, 1.5])
     def test_invalid_margin_raises(self, fig, logo, margin):
@@ -296,7 +431,8 @@ class TestStampMark:
         ax_path = stamp_mark(fig, str(png), shadow=False)
         assert ax_path.images, "file-path input should produce a drawn image"
         assert np.allclose(
-            ax_path.get_position().bounds, (0.865, 0.025, 0.11, 0.11 * 0.5 * (8.0 / 6.0))
+            ax_path.get_position().bounds,
+            (0.865, 0.025, 0.11, 0.11 * 0.5 * (8.0 / 6.0)),
         ), f"file-path placement wrong: {ax_path.get_position().bounds}"
 
     def test_frac_controls_width(self, fig, logo):
@@ -307,7 +443,9 @@ class TestStampMark:
         """
         small = stamp_mark(fig, logo, frac=0.1, shadow=False).get_position().width
         big = stamp_mark(fig, logo, frac=0.2, shadow=False).get_position().width
-        assert np.isclose(big, 2 * small), f"frac should scale width linearly: {big} vs {small}"
+        assert np.isclose(big, 2 * small), (
+            f"frac should scale width linearly: {big} vs {small}"
+        )
 
     def test_corners_constant_exposes_four_anchors(self):
         """`_CORNERS` lists exactly the four documented anchors.
@@ -315,4 +453,9 @@ class TestStampMark:
         Test scenario:
             The accepted-corner set matches the documented four.
         """
-        assert set(_CORNERS) == {"lower right", "lower left", "upper right", "upper left"}
+        assert set(_CORNERS) == {
+            "lower right",
+            "lower left",
+            "upper right",
+            "upper left",
+        }


### PR DESCRIPTION
# Description

Adds `cleopatra.styling.watermark.stamp_mark` — a one-call helper that places a logo / watermark image onto a
finished matplotlib `Figure`, so anything published or shared can carry a mark without re-rolling the same
inset-axes glue in every notebook (issue #312 found ~110 lines copied verbatim across two earthlens notebooks,
where a lost `stamp_logo(fig)` call once shipped clips unbranded).

```python
from cleopatra.styling.watermark import stamp_mark

fig = plt.figure(figsize=(12, 8))
...
stamp_mark(fig, "brand/logo.png")     # instead of ~110 copied lines per notebook
```

**Design.** The mark is drawn on a frameless inset axes in **figure-fraction coordinates** (`fig.add_axes`), the
dpi-independent counterpart of `Figure.figimage` (which is pixel-based). This is the crux of the request: the same
figure is often written at several dpi (an MP4 master, a smaller web copy, a GIF), and fraction-of-figure sizing
keeps the mark proportional across all of them.

- **Signature** — `stamp_mark(fig, path, *, frac=0.11, corner="lower right", margin=0.025, shadow=True,
  blur=0.065) -> Axes`.
- **Undistorted** — `frac` sets the width relative to the figure width; the height is derived from the image and
  figure aspect ratios, so a logo is never stretched (circles stay circular regardless of figure aspect).
- **Four corners** — `"lower right"` (default) / `"lower left"` / `"upper right"` / `"upper left"`, offset by
  `margin`; any other corner raises a `ValueError` naming the bad value. `margin` takes a scalar or an `(x, y)`
  pair, so a mark can tuck flush into a corner on one axis while keeping a gap on the other.
- **Optional halo** — a gaussian-blurred black copy of the mark's alpha, composited **behind** the mark so it
  separates from a busy / dark canvas. The blur uses **Pillow** (already a hard cleopatra dependency), so **no new
  dependency and no SciPy**.
- **Input** — a file path (any format Pillow can open, read as RGBA) or an in-memory `(H, W, 3)` / `(H, W, 4)`
  array (`uint8` `0-255` or float `0-1`; RGB gains an opaque alpha).

In scope per `SCOPE.md` (a matplotlib-only convenience helper: `Figure` in → `Axes` out, no new heavy deps).
Single-image, corner-anchored marks only — text watermarks, tiled / repeated marks, and any licensing /
provenance semantics are deliberately **out of scope**, matching the issue.

## Three corrections from review

The halo mechanism was reworked after review on #312; the API above reflects the result.

- **Centred halo, not an offset drop shadow.** An offset implies a light direction nothing else in the frame has,
  and the mark is composited over arbitrary imagery — night ocean, sunlit cloud, a bright limb — where a symmetric
  spread reads the same whichever way the background falls. (The offset was also the mechanism pushing toward a
  pixel-denominated nudge, which would have reintroduced the dpi dependence this helper exists to remove.)
- **One composited image, not two axes.** Halo and mark are alpha-composited into a single RGBA canvas before
  placement. Two independently resampled axes could not keep the halo in register with the mark's soft edges,
  which for a lockup with a soft outline is the entire outline. The `over` operator is written as a private
  `_alpha_over`; it should delegate to `glyphs.base.compositing.alpha_over` once #306 lands rather than keeping
  two copies.
- **`frac` sizes the mark, not the canvas it sits on.** The halo needs a transparent pad of three sigmas per side
  to hold its own tail, making the composited canvas ~1.39x the mark's width at the default blur. The axes rect is
  grown by exactly that factor, so the **visible mark** still measures `frac`. Without the compensation a
  requested 11 % renders at about 7.9 % while the axes bounding box still looks correct — the failure mode that
  prompted the review.

`blur` is expressed as a fraction of the mark's own **unpadded** width, with the pad derived from it — taking
sigma off the padded width instead inflates the effective blur and leaves the pad too small for the tail it was
sized to contain.

# Issues
- Closes #312 — add a figure watermark / brand-mark helper

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

- [x] `tests/test_watermark.py` (35 tests) — corner placement asserted in figure-fraction coordinates
  (parametrized over all four corners), dpi-invariant sizing (bounds identical at 100 vs 300 dpi), undistorted
  aspect, RGB→RGBA and float-array handling, file-path input, and bad-shape / bad-corner / out-of-range
  `frac` / `margin` / `blur` validation.
- [x] **The mark's painted extent is measured in rendered pixels**, not inferred from the axes bbox — the figure
  is drawn and the mark's actual width read back off the canvas, with and without the halo. Removing the grow
  compensation makes this test fail at 0.1775 against an expected 0.25 (the 1/1.39 shortfall), so the guard
  demonstrably bites rather than passing vacuously.
- [x] Halo geometry — asserts the spread reaches equally past the mark on both sides (catching any return of a
  directional offset), and that the composited canvas exceeds the mark on every side.
- [x] `margin=(x, y)` placement, and rejection of malformed margins (strings, wrong-length sequences).
- [x] Doctest on `stamp_mark` (figure-coordinate bounds).
- [x] Full `test_watermark.py` + doctest — **36 passed**. Whole suite green — **2326 passed**.
- [x] Rendered a real figure with the mark in all four corners (halo on three, off on one) and visually confirmed
  undistorted placement and the centred halo.

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
