### PR TITLE
feat(glyphs): add TexturedGlobeGlyph for 3-D textured globes

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -28,11 +28,9 @@ animation export.
 
 ### The glyph family (data → matplotlib artist + colorbar)
 
-Most glyphs share a `Glyph` base class providing the figure/axes lifecycle,
+All glyphs share a `Glyph` base class providing the figure/axes lifecycle,
 colour norms (`linear`, `power`, `sym-lognorm`, `boundary-norm`, `midpoint`),
-colorbars, ticks, classification, and animation. A few are deliberately
-standalone classes because that 2-D pipeline does not apply: `histogram_glyph`
-(distribution summaries) and `textured_globe_glyph` (the one 3-D glyph).
+colorbars, ticks, classification, and animation.
 
 | Module | Class | Visualizes |
 | --- | --- | --- |
@@ -45,7 +43,6 @@ standalone classes because that 2-D pipeline does not apply: `histogram_glyph`
 | `line_glyph` | `LineGlyph` | Line, bar, and fill-between (band) plots |
 | `polygon_glyph` | `PolygonGlyph` | Filled / outlined polygon collections, value-coloured |
 | `kde_glyph` | `KDEGlyph` | 2D Gaussian kernel-density contours (NumPy-only, no scipy) |
-| `textured_globe_glyph` | `TexturedGlobeGlyph` | Equirectangular lon/lat texture wrapped on a tilted, spinnable 3-D sphere (`Axes3D`); the one deliberate 3-D glyph |
 
 ### Supporting utilities
 
@@ -106,16 +103,9 @@ standalone classes because that 2-D pipeline does not apply: `histogram_glyph`
   `ffmpeg-python` and bundles a static FFmpeg binary so `save_animation` can
   export MP4/MOV/AVI out of the box (issue #185), which pure-Python packaging
   cannot provide.
-- **General 3D rendering** (arbitrary mplot3d surfaces/volumes). The **one
-  deliberate exception** is the single-purpose `TexturedGlobeGlyph`, which wraps
-  an equirectangular texture onto a sphere on an `Axes3D`: it adds no dependency
-  (`mpl_toolkits.mplot3d` ships with matplotlib) and keeps the "NumPy in →
-  matplotlib artist out" contract. General-purpose 3-D plotting (arbitrary
-  surfaces, volumes, a `plot3d`/`Axes3D` toolkit) stays out of scope — the globe
-  is a fixed, self-contained glyph, not a foothold for a 3-D layer.
-- **Networked data sources** other than the `tiles` / `reference` basemap
-  helpers, and general-purpose plotting that matplotlib already does well
-  without added value.
+- **3D rendering** (mplot3d surfaces/volumes), networked data sources other
+  than the `tiles` / `reference` basemap helpers, and general-purpose plotting
+  that matplotlib already does well without added value.
 
 ## Boundary heuristic for a feature request
 

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -28,9 +28,11 @@ animation export.
 
 ### The glyph family (data → matplotlib artist + colorbar)
 
-All glyphs share a `Glyph` base class providing the figure/axes lifecycle,
+Most glyphs share a `Glyph` base class providing the figure/axes lifecycle,
 colour norms (`linear`, `power`, `sym-lognorm`, `boundary-norm`, `midpoint`),
-colorbars, ticks, classification, and animation.
+colorbars, ticks, classification, and animation. A few are deliberately
+standalone classes because that 2-D pipeline does not apply: `histogram_glyph`
+(distribution summaries) and `textured_globe_glyph` (the one 3-D glyph).
 
 | Module | Class | Visualizes |
 | --- | --- | --- |
@@ -43,6 +45,7 @@ colorbars, ticks, classification, and animation.
 | `line_glyph` | `LineGlyph` | Line, bar, and fill-between (band) plots |
 | `polygon_glyph` | `PolygonGlyph` | Filled / outlined polygon collections, value-coloured |
 | `kde_glyph` | `KDEGlyph` | 2D Gaussian kernel-density contours (NumPy-only, no scipy) |
+| `textured_globe_glyph` | `TexturedGlobeGlyph` | Equirectangular lon/lat texture wrapped on a tilted, spinnable 3-D sphere (`Axes3D`); the one deliberate 3-D glyph |
 
 ### Supporting utilities
 
@@ -103,9 +106,16 @@ colorbars, ticks, classification, and animation.
   `ffmpeg-python` and bundles a static FFmpeg binary so `save_animation` can
   export MP4/MOV/AVI out of the box (issue #185), which pure-Python packaging
   cannot provide.
-- **3D rendering** (mplot3d surfaces/volumes), networked data sources other
-  than the `tiles` / `reference` basemap helpers, and general-purpose plotting
-  that matplotlib already does well without added value.
+- **General 3D rendering** (arbitrary mplot3d surfaces/volumes). The **one
+  deliberate exception** is the single-purpose `TexturedGlobeGlyph`, which wraps
+  an equirectangular texture onto a sphere on an `Axes3D`: it adds no dependency
+  (`mpl_toolkits.mplot3d` ships with matplotlib) and keeps the "NumPy in →
+  matplotlib artist out" contract. General-purpose 3-D plotting (arbitrary
+  surfaces, volumes, a `plot3d`/`Axes3D` toolkit) stays out of scope — the globe
+  is a fixed, self-contained glyph, not a foothold for a 3-D layer.
+- **Networked data sources** other than the `tiles` / `reference` basemap
+  helpers, and general-purpose plotting that matplotlib already does well
+  without added value.
 
 ## Boundary heuristic for a feature request
 

--- a/docs/reference/textured-globe-glyph.md
+++ b/docs/reference/textured-globe-glyph.md
@@ -66,6 +66,8 @@ from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
 
 globe = TexturedGlobeGlyph(relief("low"), n_lon=180, n_lat=90)
 anim = globe.animate(n_frames=60, revolutions=1.0, interval=50)
-# save with cleopatra.glyphs.base.animation or matplotlib's writers:
-# anim.save("globe.gif")
+# save with cleopatra.glyphs.base.animation.save_animation (or to_gif/to_mp4),
+# or matplotlib's own writers:
+# from cleopatra.glyphs.base.animation import save_animation
+# save_animation(anim, "globe.gif")
 ```

--- a/docs/reference/textured-globe-glyph.md
+++ b/docs/reference/textured-globe-glyph.md
@@ -1,0 +1,71 @@
+# TexturedGlobeGlyph Class
+
+The `textured_globe_glyph` module provides the `TexturedGlobeGlyph` class — cleopatra's one
+deliberate **3-D** glyph. It wraps an equirectangular (lon/lat) RGB(A) texture onto a tilted
+sphere drawn on a matplotlib `Axes3D`, and can spin the globe frame-by-frame for animation.
+
+It takes the same equirectangular layout as
+[`cleopatra.basemap.reference.relief()`](reference-data.md) — an `(H, W, 3)` (or `(H, W, 4)`)
+array with row 0 at the north pole (+90°) and column 0 at −180° — so you can drape a relief
+raster (or any world texture) straight onto a globe. Like `HistogramGlyph`, it is a **standalone
+class**, not a `Glyph` subclass, because the base class's 2-D figure/colorbar pipeline does not
+apply to a sphere.
+
+!!! note "Resolution is the cost driver"
+    matplotlib's 3-D surface is drawn on the CPU as one polygon per mesh face, so render time
+    grows with `n_lon × n_lat`. The default `180 × 90` (~16k faces) renders a recognisable globe
+    in ~1.5 s; `360 × 180` is ~7.7 s and `720 × 360` ~27 s. Raise the resolution for a sharper
+    still, lower it for a smooth animation.
+
+## Class Documentation
+
+::: cleopatra.glyphs.globe.textured_globe_glyph.TexturedGlobeGlyph
+    options:
+      show_root_heading: true
+      show_source: true
+      heading_level: 3
+
+## Examples
+
+### A still globe from a relief texture
+
+```python
+import matplotlib.pyplot as plt
+from cleopatra.basemap.reference import relief
+from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+
+texture = relief("low")            # (360, 720, 3) equirectangular RGB, north-up
+globe = TexturedGlobeGlyph(texture, tilt_deg=23.44, brightness=1.1)
+fig, ax = globe.draw(spin=60.0, elev=20, background="black")
+plt.show()
+```
+
+### A synthetic texture (no download)
+
+```python
+import numpy as np
+import matplotlib.pyplot as plt
+from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+
+texture = np.zeros((180, 360, 3), dtype=np.uint8)
+texture[:90] = (40, 90, 180)       # northern hemisphere blue
+texture[90:] = (180, 120, 40)      # southern hemisphere ochre
+
+fig, ax = TexturedGlobeGlyph(texture).draw(spin=45.0)
+plt.show()
+```
+
+### A spinning animation
+
+The texture is sampled once; each frame only rotates the pre-computed mesh, so use a modest
+resolution for smooth playback.
+
+```python
+from cleopatra.basemap.reference import relief
+from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+
+globe = TexturedGlobeGlyph(relief("low"), n_lon=180, n_lat=90)
+anim = globe.animate(n_frames=60, revolutions=1.0, interval=50)
+# save with cleopatra.glyphs.base.animation or matplotlib's writers:
+# anim.save("globe.gif")
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ nav:
     - LineGlyph: reference/line-glyph.md
     - PolygonGlyph: reference/polygon-glyph.md
     - KDEGlyph: reference/kde-glyph.md
+    - TexturedGlobeGlyph (3-D): reference/textured-globe-glyph.md
     - Tiles (basemaps): reference/tiles.md
     - Reference data (coastlines/relief): reference/reference-data.md
     - Geo basemap methods (glyphs): reference/geo.md

--- a/src/cleopatra/glyphs/globe/__init__.py
+++ b/src/cleopatra/glyphs/globe/__init__.py
@@ -8,7 +8,7 @@ Submodules: `textured_globe_glyph` (wrap an equirectangular lon/lat texture
 onto a sphere drawn on a matplotlib `Axes3D`).
 
 This is cleopatra's one deliberate 3-D renderer. Every other glyph targets a
-2-D axes; the globe is a single, self-contained exception carved out in
-`SCOPE.md`. It adds no dependency -- `mpl_toolkits.mplot3d` ships with
-matplotlib -- and keeps the "NumPy in -> matplotlib artist out" contract.
+2-D axes; the globe is a single, self-contained exception. It adds no
+dependency -- `mpl_toolkits.mplot3d` ships with matplotlib -- and keeps the
+"NumPy in -> matplotlib artist out" contract.
 """

--- a/src/cleopatra/glyphs/globe/__init__.py
+++ b/src/cleopatra/glyphs/globe/__init__.py
@@ -1,0 +1,14 @@
+"""Glyphs that render data on a 3-D globe.
+
+Deliberately re-exports nothing, matching the package root: import from the
+submodule, e.g. `from cleopatra.glyphs.globe.textured_globe_glyph import
+TexturedGlobeGlyph`.
+
+Submodules: `textured_globe_glyph` (wrap an equirectangular lon/lat texture
+onto a sphere drawn on a matplotlib `Axes3D`).
+
+This is cleopatra's one deliberate 3-D renderer. Every other glyph targets a
+2-D axes; the globe is a single, self-contained exception carved out in
+`SCOPE.md`. It adds no dependency -- `mpl_toolkits.mplot3d` ships with
+matplotlib -- and keeps the "NumPy in -> matplotlib artist out" contract.
+"""

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -68,8 +68,8 @@ from cleopatra.glyphs.base.glyph import (
 #: Earth's axial tilt (obliquity of the ecliptic), in degrees -- the default lean of the polar axis.
 EARTH_TILT_DEG = 23.44
 
-#: Default render options for :class:`TexturedGlobeGlyph` (the module constant; the class re-exposes it as
-#: ``TexturedGlobeGlyph.DEFAULT_OPTIONS`` for introspection).
+#: Default render options for `TexturedGlobeGlyph` (the module constant; the class re-exposes it as
+#: `TexturedGlobeGlyph.DEFAULT_OPTIONS` for introspection).
 GLOBE_DEFAULT_OPTIONS = {
     "figsize": (6, 6),
     "elev": 15.0,

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -4,7 +4,7 @@ matplotlib `Axes3D`, with an optional axial tilt and a `spin` angle so the globe
 animation.
 
 It is cleopatra's one deliberate 3-D glyph. Every other glyph targets a 2-D axes; this one is a single, self-contained
-exception (see `SCOPE.md`). It adds no dependency -- `mpl_toolkits.mplot3d` ships with matplotlib -- and keeps the
+exception. It adds no dependency -- `mpl_toolkits.mplot3d` ships with matplotlib -- and keeps the
 "NumPy in -> matplotlib artist out" contract: you bring an `(H, W, 3)` or `(H, W, 4)` equirectangular array (for
 example `cleopatra.basemap.reference.relief()`), and you get back a matplotlib `Figure`/`Axes3D`.
 

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -68,14 +68,14 @@ from cleopatra.glyphs.base.glyph import (
 #: Earth's axial tilt (obliquity of the ecliptic), in degrees -- the default lean of the polar axis.
 EARTH_TILT_DEG = 23.44
 
+#: Default render options for :class:`TexturedGlobeGlyph` (the module constant; the class re-exposes it as
+#: ``TexturedGlobeGlyph.DEFAULT_OPTIONS`` for introspection).
 GLOBE_DEFAULT_OPTIONS = {
     "figsize": (6, 6),
     "elev": 15.0,
     "azim": 0.0,
     "background": None,
 }
-#: Default render options for :class:`TexturedGlobeGlyph` (named like the other glyphs' ``*_DEFAULT_OPTIONS``).
-DEFAULT_OPTIONS = GLOBE_DEFAULT_OPTIONS
 
 
 class TexturedGlobeGlyph:
@@ -97,7 +97,7 @@ class TexturedGlobeGlyph:
         default_options: The resolved render options (`figsize`, `elev`, `azim`, `background`).
 
     Methods:
-        draw(ax=None, spin=0.0, **kwargs): Render the globe onto a 3-D axes at a given spin angle.
+        draw(ax=None, *, spin=0.0, **kwargs): Render the globe onto a 3-D axes at a given spin angle.
         animate(ax=None, n_frames=60, revolutions=1.0, ...): Return a `FuncAnimation` spinning the globe.
 
     Notes:

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -115,8 +115,10 @@ class TexturedGlobeGlyph:
         >>> texture[:8] = (40, 90, 180)
         >>> globe = TexturedGlobeGlyph(texture, n_lon=48, n_lat=24)
         >>> fig, ax = globe.draw(spin=45.0)
-        >>> type(ax).__name__
-        'Axes3D'
+        >>> ax.name
+        '3d'
+        >>> globe.surface is not None
+        True
 
         ```
     """
@@ -500,12 +502,11 @@ class TexturedGlobeGlyph:
         Examples:
             ```python
             >>> import numpy as np
-            >>> from matplotlib.animation import FuncAnimation
             >>> from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
             >>> globe = TexturedGlobeGlyph(np.zeros((8, 16, 3), dtype=np.uint8), n_lon=24, n_lat=12)
             >>> anim = globe.animate(n_frames=4)
-            >>> isinstance(anim, FuncAnimation)
-            True
+            >>> list(anim.new_frame_seq())    # one entry per rendered frame
+            [0, 1, 2, 3]
 
             ```
         """

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -154,11 +154,13 @@ class TexturedGlobeGlyph:
                 brightens. Must be `>= 0`.
             fig: Pre-existing matplotlib `Figure` to draw on when `draw`/`animate` are called without their own `ax`.
             ax: Pre-existing 3-D matplotlib `Axes` (`Axes3D`) to draw on. If given it must be a 3-D axes.
-            **kwargs: Render options overriding `DEFAULT_OPTIONS` (`figsize`, `elev`, `azim`, `background`).
+            **kwargs: Render options overriding `DEFAULT_OPTIONS` (`figsize`, `elev`, `azim`, `background`). An
+                unrecognised key raises `ValueError`.
 
         Raises:
             ValueError: If `texture` is not an `(H, W, 3)`/`(H, W, 4)` array with `H, W >= 2`, if `n_lon`/`n_lat` are
-                `< 2`, if `brightness` is negative, or if `ax` is given but is not a 3-D axes.
+                `< 2`, if `brightness` is negative, if `ax` is given but is not a 3-D axes, or if an unknown render
+                option is passed.
 
         Examples:
             ```python
@@ -189,6 +191,7 @@ class TexturedGlobeGlyph:
         self._fig = fig
         self._ax = ax
 
+        self._reject_unknown_options(kwargs)
         options_dict = GLOBE_DEFAULT_OPTIONS.copy()
         options_dict.update(kwargs)
         self._default_options = options_dict
@@ -415,6 +418,27 @@ class TexturedGlobeGlyph:
         keys = cls.option_keys()
         return {key: val for key, val in kwargs.items() if key in keys}
 
+    @classmethod
+    def _reject_unknown_options(cls, kwargs: dict) -> None:
+        """Raise `ValueError` if `kwargs` holds keys this glyph does not accept.
+
+        Mirrors the rest of the package (`Glyph._merge_kwargs`,
+        `HistogramGlyph._apply_options`), which reject unknown options rather than
+        silently ignoring them, so a typo like `elevv=` surfaces immediately.
+
+        Args:
+            kwargs: The render options passed to `__init__`/`draw`/`animate`.
+
+        Raises:
+            ValueError: If any key is not in `option_keys()`.
+        """
+        unknown = set(kwargs) - cls.option_keys()
+        if unknown:
+            raise ValueError(
+                f"Unknown option(s) {sorted(unknown)}; accepted keys are "
+                f"{sorted(cls.option_keys())}."
+            )
+
     # ------------------------------------------------------------------ #
     # Rendering                                                            #
     # ------------------------------------------------------------------ #
@@ -435,7 +459,7 @@ class TexturedGlobeGlyph:
                 available as the `surface` attribute.
 
         Raises:
-            ValueError: If `ax` is supplied but is not a 3-D axes.
+            ValueError: If `ax` is supplied but is not a 3-D axes, or if an unknown render option is passed.
 
         Examples:
             ```python
@@ -449,6 +473,7 @@ class TexturedGlobeGlyph:
 
             ```
         """
+        self._reject_unknown_options(kwargs)
         options = self._default_options.copy()
         options.update(kwargs)
         fig, target = self._resolve_axes(ax, options)
@@ -509,6 +534,9 @@ class TexturedGlobeGlyph:
         Returns:
             matplotlib.animation.FuncAnimation: The animation, ready to save or embed.
 
+        Raises:
+            ValueError: If `ax` is supplied but is not a 3-D axes, or if an unknown render option is passed.
+
         Examples:
             ```python
             >>> import numpy as np
@@ -520,6 +548,7 @@ class TexturedGlobeGlyph:
 
             ```
         """
+        self._reject_unknown_options(kwargs)
         options = self._default_options.copy()
         options.update(kwargs)
         fig, target = self._resolve_axes(ax, options)

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -1,0 +1,531 @@
+"""
+The `textured_globe_glyph` module wraps an equirectangular (lon/lat) RGB texture onto a 3-D sphere drawn on a
+matplotlib `Axes3D`, with an optional axial tilt and a `spin` angle so the globe can be rotated frame-by-frame for
+animation.
+
+It is cleopatra's one deliberate 3-D glyph. Every other glyph targets a 2-D axes; this one is a single, self-contained
+exception (see `SCOPE.md`). It adds no dependency -- `mpl_toolkits.mplot3d` ships with matplotlib -- and keeps the
+"NumPy in -> matplotlib artist out" contract: you bring an `(H, W, 3)` or `(H, W, 4)` equirectangular array (for
+example `cleopatra.basemap.reference.relief()`), and you get back a matplotlib `Figure`/`Axes3D`.
+
+Like `HistogramGlyph`, `TexturedGlobeGlyph` is a standalone class rather than a `Glyph` subclass, because the `Glyph`
+base class owns the 2-D figure/axes/colorbar lifecycle that does not apply to a textured sphere.
+
+Design
+------
+
+- **Sample once, rotate per frame.** The texture is resampled to the mesh resolution and turned into a `facecolors`
+  array exactly once (cached on the instance). Spinning the globe only rotates the pre-computed vertex coordinates by a
+  small 3x3 matrix multiply and re-draws -- the texture is never re-sampled. This is what makes `animate()` cheap.
+- **Spin the globe, not the camera.** `spin` rotates the sphere about its own (tilted) polar axis, so the axial tilt
+  stays fixed in space while the surface turns underneath it -- physically what a spinning planet does. The camera
+  (`elev`/`azim`) is held still.
+- **Resolution is the cost driver.** matplotlib's 3-D surface is drawn on the CPU as one polygon per mesh face, so the
+  render time grows with `n_lon * n_lat`. Measured first-draw times (matplotlib 3.10, Agg):
+
+  | `n_lon` x `n_lat` | faces   | first draw |
+  | ----------------- | ------- | ---------- |
+  | 180 x 90 (default)|  ~15900 | ~1.5 s     |
+  | 360 x 180         |  ~64000 | ~7.7 s     |
+  | 720 x 360         | ~258000 | ~27 s      |
+
+  The default (180 x 90) renders a recognisable globe quickly; raise `n_lon`/`n_lat` for a sharper still, lower them
+  for a smooth animation.
+
+Example
+-------
+
+```python
+import matplotlib.pyplot as plt
+import numpy as np
+from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+
+# A cheap synthetic texture (or use cleopatra.basemap.reference.relief()).
+texture = np.zeros((180, 360, 3), dtype=np.uint8)
+texture[:90] = (40, 90, 180)     # northern hemisphere blue
+texture[90:] = (180, 120, 40)    # southern hemisphere ochre
+
+globe = TexturedGlobeGlyph(texture, tilt_deg=23.44)
+fig, ax = globe.draw(spin=60.0)
+plt.show()
+```
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.animation import FuncAnimation
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from mpl_toolkits.mplot3d import Axes3D
+
+from cleopatra.glyphs.base.glyph import (
+    _clear_prior_render_artists,
+    _mark_render_artists,
+    _root_figure,
+)
+
+#: Earth's axial tilt (obliquity of the ecliptic), in degrees -- the default lean of the polar axis.
+EARTH_TILT_DEG = 23.44
+
+GLOBE_DEFAULT_OPTIONS = {
+    "figsize": (6, 6),
+    "elev": 15.0,
+    "azim": 0.0,
+    "background": None,
+}
+#: Default render options for :class:`TexturedGlobeGlyph` (named like the other glyphs' ``*_DEFAULT_OPTIONS``).
+DEFAULT_OPTIONS = GLOBE_DEFAULT_OPTIONS
+
+
+class TexturedGlobeGlyph:
+    """Wrap an equirectangular texture onto a tilted, spinnable 3-D sphere.
+
+    The glyph takes an equirectangular (plate-carree) `(H, W, 3)` or `(H, W, 4)` array -- rows running north (row 0,
+    +90 deg) to south (last row, -90 deg), columns running west (col 0, -180 deg) to east (last col, +180 deg), exactly
+    the layout of `cleopatra.basemap.reference.relief()` -- and paints it onto a unit sphere on a matplotlib `Axes3D`.
+
+    The polar axis is tilted `tilt_deg` from vertical, and `draw(spin=...)` rotates the sphere about that axis so the
+    same instance can render a whole rotation without re-sampling the texture (see the module docstring).
+
+    Attributes:
+        texture: The normalised RGBA texture, float in `[0, 1]`, shape `(H, W, 4)`.
+        tilt_deg: Axial tilt of the polar axis from vertical, in degrees.
+        n_lon: Number of longitude samples in the sphere mesh.
+        n_lat: Number of latitude samples in the sphere mesh.
+        brightness: Multiplier applied to the RGB channels (clipped to `[0, 1]`).
+        default_options: The resolved render options (`figsize`, `elev`, `azim`, `background`).
+
+    Methods:
+        draw(ax=None, spin=0.0, **kwargs): Render the globe onto a 3-D axes at a given spin angle.
+        animate(ax=None, n_frames=60, revolutions=1.0, ...): Return a `FuncAnimation` spinning the globe.
+
+    Notes:
+        `TexturedGlobeGlyph` is a standalone class, not a `Glyph` subclass (like `HistogramGlyph`). The accepted option
+        keys are exposed via the `DEFAULT_OPTIONS` class attribute and can be inspected/filtered with the `option_keys`
+        and `filter_kwargs` classmethods.
+
+    Examples:
+        Build a globe from a small synthetic texture and render it:
+        ```python
+        >>> import numpy as np
+        >>> from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+        >>> texture = np.zeros((16, 32, 3), dtype=np.uint8)
+        >>> texture[:8] = (40, 90, 180)
+        >>> globe = TexturedGlobeGlyph(texture, n_lon=48, n_lat=24)
+        >>> fig, ax = globe.draw(spin=45.0)
+        >>> type(ax).__name__
+        'Axes3D'
+
+        ```
+    """
+
+    #: Option keys this glyph accepts, exposed as a class attribute so they can be introspected/filtered before an
+    #: instance exists (see `option_keys`/`filter_kwargs`).
+    DEFAULT_OPTIONS = GLOBE_DEFAULT_OPTIONS
+
+    def __init__(
+        self,
+        texture: np.ndarray,
+        *,
+        tilt_deg: float = EARTH_TILT_DEG,
+        n_lon: int = 180,
+        n_lat: int = 90,
+        brightness: float = 1.0,
+        fig: Figure | None = None,
+        ax: Axes | None = None,
+        **kwargs,
+    ):
+        """Initialize the globe from an equirectangular texture.
+
+        Args:
+            texture: An equirectangular RGB(A) array of shape `(H, W, 3)` or `(H, W, 4)`, `H >= 2` and `W >= 2`.
+                Integer arrays (0-255) and float arrays (0-1, or any range that is then normalised by its own max)
+                are both accepted. Row 0 is the northern edge (+90 deg), the last row the southern edge (-90 deg);
+                column 0 is -180 deg, the last column +180 deg.
+            tilt_deg: Axial tilt of the polar axis from vertical, in degrees. Defaults to Earth's 23.44 deg.
+            n_lon: Longitude samples in the sphere mesh (>= 2). Higher is sharper but quadratically slower to draw.
+            n_lat: Latitude samples in the sphere mesh (>= 2). Higher is sharper but quadratically slower to draw.
+            brightness: Multiplier applied to the RGB channels before clipping to `[0, 1]`. `< 1` darkens, `> 1`
+                brightens. Must be `>= 0`.
+            fig: Pre-existing matplotlib `Figure` to draw on when `draw`/`animate` are called without their own `ax`.
+            ax: Pre-existing 3-D matplotlib `Axes` (`Axes3D`) to draw on. If given it must be a 3-D axes.
+            **kwargs: Render options overriding `DEFAULT_OPTIONS` (`figsize`, `elev`, `azim`, `background`).
+
+        Raises:
+            ValueError: If `texture` is not an `(H, W, 3)`/`(H, W, 4)` array with `H, W >= 2`, if `n_lon`/`n_lat` are
+                `< 2`, if `brightness` is negative, or if `ax` is given but is not a 3-D axes.
+
+        Examples:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+            >>> globe = TexturedGlobeGlyph(np.zeros((8, 16, 3), dtype=np.uint8), n_lon=24, n_lat=12)
+            >>> globe.n_lon, globe.n_lat
+            (24, 12)
+
+            ```
+        """
+        if int(n_lon) < 2 or int(n_lat) < 2:
+            raise ValueError(
+                f"n_lon and n_lat must each be >= 2; got n_lon={n_lon}, n_lat={n_lat}."
+            )
+        if brightness < 0:
+            raise ValueError(f"brightness must be >= 0; got {brightness}.")
+        if ax is not None and not isinstance(ax, Axes3D):
+            raise ValueError(
+                "TexturedGlobeGlyph needs a 3-D axes; create one with fig.add_subplot(projection='3d')."
+            )
+
+        self._brightness = float(brightness)
+        self._texture = self._normalize_texture(texture, self._brightness)
+        self._tilt_deg = float(tilt_deg)
+        self._n_lon = int(n_lon)
+        self._n_lat = int(n_lat)
+        self._fig = fig
+        self._ax = ax
+
+        options_dict = GLOBE_DEFAULT_OPTIONS.copy()
+        options_dict.update(kwargs)
+        self._default_options = options_dict
+
+        # Filled lazily and cached by `_prepare` (sample-once contract).
+        self._base_xyz: np.ndarray | None = None
+        self._facecolors: np.ndarray | None = None
+        self._tilt_matrix: np.ndarray | None = None
+        self._surface = None
+
+    # ------------------------------------------------------------------ #
+    # Construction helpers                                                 #
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _normalize_texture(texture: np.ndarray, brightness: float) -> np.ndarray:
+        """Return `texture` as a float `(H, W, 4)` RGBA array in `[0, 1]`, brightness-scaled.
+
+        Args:
+            texture: An `(H, W, 3)` or `(H, W, 4)` RGB(A) array, integer or float.
+            brightness: Multiplier applied to the RGB channels before clipping.
+
+        Returns:
+            numpy.ndarray: A contiguous float `(H, W, 4)` array in `[0, 1]`.
+
+        Raises:
+            ValueError: If `texture` is not an `(H, W, 3)`/`(H, W, 4)` array with `H, W >= 2`.
+        """
+        arr = np.asarray(texture)
+        if (
+            arr.ndim != 3
+            or arr.shape[-1] not in (3, 4)
+            or arr.shape[0] < 2
+            or arr.shape[1] < 2
+        ):
+            raise ValueError(
+                "texture must be an (H, W, 3) or (H, W, 4) array with H, W >= 2; "
+                f"got shape {arr.shape}."
+            )
+        rgba = arr.astype(float)
+        # Normalise integer/0-255 (or any >1) data to 0-1.
+        peak = rgba[..., :3].max() if rgba.size else 1.0
+        if peak > 1.0:
+            rgba = rgba / 255.0 if peak <= 255.0 else rgba / peak
+        rgb = np.clip(rgba[..., :3] * brightness, 0.0, 1.0)
+        if arr.shape[-1] == 4:
+            alpha = np.clip(rgba[..., 3:4], 0.0, 1.0)
+        else:
+            alpha = np.ones((*rgb.shape[:2], 1))
+        return np.ascontiguousarray(np.concatenate([rgb, alpha], axis=-1))
+
+    def _prepare(self) -> None:
+        """Sample the texture and build the base sphere mesh once, caching the results on the instance.
+
+        Computes and caches the un-spun vertex coordinates `(3, n_lat * n_lon)`, the per-face `facecolors`
+        `(n_lat - 1, n_lon - 1, 4)` sampled at face centres, and the fixed axial-tilt rotation matrix. Idempotent:
+        repeated calls (e.g. one per animation frame) return immediately.
+        """
+        if self._base_xyz is not None:
+            return
+
+        lat_edges = np.linspace(90.0, -90.0, self._n_lat)
+        lon_edges = np.linspace(-180.0, 180.0, self._n_lon)
+        lon_grid, lat_grid = np.meshgrid(np.deg2rad(lon_edges), np.deg2rad(lat_edges))
+        x = np.cos(lat_grid) * np.cos(lon_grid)
+        y = np.cos(lat_grid) * np.sin(lon_grid)
+        z = np.sin(lat_grid)
+        self._base_xyz = np.stack([x.ravel(), y.ravel(), z.ravel()])
+
+        # Sample the texture at each face centre -> (n_lat - 1, n_lon - 1, 4).
+        lat_centers = 0.5 * (lat_edges[:-1] + lat_edges[1:])
+        lon_centers = 0.5 * (lon_edges[:-1] + lon_edges[1:])
+        height, width = self._texture.shape[:2]
+        rows = np.clip(
+            np.round((90.0 - lat_centers) / 180.0 * (height - 1)).astype(int),
+            0,
+            height - 1,
+        )
+        cols = np.clip(
+            np.round((lon_centers + 180.0) / 360.0 * (width - 1)).astype(int),
+            0,
+            width - 1,
+        )
+        row_idx, col_idx = np.meshgrid(rows, cols, indexing="ij")
+        self._facecolors = self._texture[row_idx, col_idx]
+
+        self._tilt_matrix = self._rotation_x(self._tilt_deg)
+
+    @staticmethod
+    def _rotation_x(deg: float) -> np.ndarray:
+        """Return the 3x3 matrix rotating a point cloud by `deg` degrees about the x-axis."""
+        rad = np.deg2rad(deg)
+        cos, sin = np.cos(rad), np.sin(rad)
+        return np.array([[1.0, 0.0, 0.0], [0.0, cos, -sin], [0.0, sin, cos]])
+
+    @staticmethod
+    def _rotation_z(deg: float) -> np.ndarray:
+        """Return the 3x3 matrix rotating a point cloud by `deg` degrees about the z-axis (the polar axis)."""
+        rad = np.deg2rad(deg)
+        cos, sin = np.cos(rad), np.sin(rad)
+        return np.array([[cos, -sin, 0.0], [sin, cos, 0.0], [0.0, 0.0, 1.0]])
+
+    def _spun_mesh(self, spin: float) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Return the `(x, y, z)` sphere mesh spun `spin` degrees about its tilted polar axis.
+
+        The globe is rotated about its own polar axis (`z` in the body frame) and then the fixed axial tilt is applied,
+        so the tilt stays put in space while the surface turns under it. Only the pre-computed base vertices are
+        rotated -- the `facecolors` are untouched.
+
+        Args:
+            spin: Rotation about the polar axis, in degrees.
+
+        Returns:
+            tuple: Three `(n_lat, n_lon)` arrays `(x, y, z)` for `Axes3D.plot_surface`.
+        """
+        coords = self._tilt_matrix @ (self._rotation_z(spin) @ self._base_xyz)
+        return tuple(coords.reshape(3, self._n_lat, self._n_lon))
+
+    def _resolve_axes(self, ax: Axes | None, options: dict) -> tuple[Figure, Axes]:
+        """Resolve the 3-D `(fig, ax)` to draw on, creating a 3-D axes if none was supplied.
+
+        Args:
+            ax: An explicit 3-D axes for this call, or `None` to fall back to the instance's `ax`/`fig` or a new one.
+            options: The resolved render options (uses `figsize` when a new figure is made).
+
+        Returns:
+            tuple: `(fig, ax)` where `ax` is an `Axes3D`.
+
+        Raises:
+            ValueError: If a supplied axes is not a 3-D axes.
+        """
+        target = ax if ax is not None else self._ax
+        if target is None:
+            fig = self._fig or plt.figure(figsize=options["figsize"])
+            target = fig.add_subplot(projection="3d")
+        else:
+            if not isinstance(target, Axes3D):
+                raise ValueError(
+                    "TexturedGlobeGlyph needs a 3-D axes; create one with fig.add_subplot(projection='3d')."
+                )
+            fig = _root_figure(target)
+        return fig, target
+
+    # ------------------------------------------------------------------ #
+    # Introspection (mirrors Glyph / HistogramGlyph)                      #
+    # ------------------------------------------------------------------ #
+    @property
+    def texture(self) -> np.ndarray:
+        """The normalised RGBA texture (float `(H, W, 4)` in `[0, 1]`)."""
+        return self._texture
+
+    @property
+    def tilt_deg(self) -> float:
+        """Axial tilt of the polar axis from vertical, in degrees."""
+        return self._tilt_deg
+
+    @property
+    def n_lon(self) -> int:
+        """Number of longitude samples in the sphere mesh."""
+        return self._n_lon
+
+    @property
+    def n_lat(self) -> int:
+        """Number of latitude samples in the sphere mesh."""
+        return self._n_lat
+
+    @property
+    def brightness(self) -> float:
+        """The brightness multiplier applied to the RGB channels."""
+        return self._brightness
+
+    @property
+    def default_options(self) -> dict:
+        """The resolved render options (`figsize`, `elev`, `azim`, `background`)."""
+        return self._default_options
+
+    @classmethod
+    def option_keys(cls) -> set[str]:
+        """Return the keyword-argument keys this glyph accepts.
+
+        Resolves from the class-level `DEFAULT_OPTIONS` so the accepted keys can be inspected without constructing an
+        instance. Mirrors `cleopatra.glyphs.base.glyph.Glyph.option_keys` (`TexturedGlobeGlyph` is a standalone class,
+        not a `Glyph` subclass).
+
+        Returns:
+            set: The accepted option keys for this glyph class.
+
+        Examples:
+            ```python
+            >>> from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+            >>> "elev" in TexturedGlobeGlyph.option_keys()
+            True
+
+            ```
+        """
+        return set(cls.DEFAULT_OPTIONS)
+
+    @classmethod
+    def filter_kwargs(cls, kwargs: dict) -> dict:
+        """Return only the subset of `kwargs` whose keys this glyph accepts.
+
+        Args:
+            kwargs: A mapping of candidate option keys to values.
+
+        Returns:
+            dict: The entries of `kwargs` whose keys are in `option_keys()`.
+
+        Examples:
+            ```python
+            >>> from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+            >>> sorted(TexturedGlobeGlyph.filter_kwargs({"elev": 30, "bogus": 1}))
+            ['elev']
+
+            ```
+        """
+        keys = cls.option_keys()
+        return {key: val for key, val in kwargs.items() if key in keys}
+
+    # ------------------------------------------------------------------ #
+    # Rendering                                                            #
+    # ------------------------------------------------------------------ #
+    def draw(
+        self, ax: Axes | None = None, *, spin: float = 0.0, **kwargs
+    ) -> tuple[Figure, Axes]:
+        """Render the textured globe onto a 3-D axes at a given spin angle.
+
+        Args:
+            ax: A 3-D matplotlib axes (`Axes3D`) to draw on. If `None`, the instance's `ax` is used, or a new 3-D axes
+                is created on the instance's `fig` (or a new figure sized by the `figsize` option).
+            spin: Rotation of the globe about its tilted polar axis, in degrees. The camera stays put.
+            **kwargs: Render options overriding the instance defaults for this call (`figsize`, `elev`, `azim`,
+                `background`).
+
+        Returns:
+            tuple: `(fig, ax)` -- the figure and the 3-D axes the globe was drawn on. The surface artist is also
+                available as the `surface` attribute.
+
+        Raises:
+            ValueError: If `ax` is supplied but is not a 3-D axes.
+
+        Examples:
+            ```python
+            >>> import numpy as np
+            >>> from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+            >>> texture = np.zeros((16, 32, 3), dtype=np.uint8)
+            >>> texture[:, :16] = (200, 40, 40)
+            >>> fig, ax = TexturedGlobeGlyph(texture, n_lon=36, n_lat=18).draw(spin=90.0)
+            >>> ax.name
+            '3d'
+
+            ```
+        """
+        options = self._default_options.copy()
+        options.update(kwargs)
+        fig, target = self._resolve_axes(ax, options)
+        self._prepare()
+        _clear_prior_render_artists(target)
+
+        if options["background"] is not None:
+            fig.set_facecolor(options["background"])
+            target.set_facecolor(options["background"])
+
+        x, y, z = self._spun_mesh(spin)
+        surface = target.plot_surface(
+            x,
+            y,
+            z,
+            facecolors=self._facecolors,
+            rstride=1,
+            cstride=1,
+            shade=False,
+            antialiased=False,
+            linewidth=0,
+        )
+        target.set_box_aspect((1, 1, 1))
+        target.set_xlim(-1, 1)
+        target.set_ylim(-1, 1)
+        target.set_zlim(-1, 1)
+        target.set_axis_off()
+        target.view_init(elev=options["elev"], azim=options["azim"])
+
+        _mark_render_artists(target, surface)
+        self._surface = surface
+        return fig, target
+
+    def animate(
+        self,
+        ax: Axes | None = None,
+        *,
+        n_frames: int = 60,
+        revolutions: float = 1.0,
+        start_spin: float = 0.0,
+        interval: int = 50,
+        **kwargs,
+    ) -> FuncAnimation:
+        """Return a `FuncAnimation` that spins the globe about its polar axis.
+
+        The texture is sampled once (via `draw`'s cached `_prepare`); each frame only rotates the pre-computed vertices
+        and re-draws, so the per-frame cost is dominated by matplotlib's surface draw at the chosen mesh resolution.
+        Save it with `cleopatra.glyphs.base.animation` (or matplotlib's own writers).
+
+        Args:
+            ax: A 3-D axes to animate on, or `None` to create one (see `draw`).
+            n_frames: Number of frames in the animation.
+            revolutions: How many full turns the globe makes over `n_frames` (`1.0` = one 360 deg rotation).
+            start_spin: Spin angle of the first frame, in degrees.
+            interval: Delay between frames in milliseconds (matplotlib playback hint).
+            **kwargs: Render options forwarded to `draw` on every frame (`figsize`, `elev`, `azim`, `background`).
+
+        Returns:
+            matplotlib.animation.FuncAnimation: The animation, ready to save or embed.
+
+        Examples:
+            ```python
+            >>> import numpy as np
+            >>> from matplotlib.animation import FuncAnimation
+            >>> from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+            >>> globe = TexturedGlobeGlyph(np.zeros((8, 16, 3), dtype=np.uint8), n_lon=24, n_lat=12)
+            >>> anim = globe.animate(n_frames=4)
+            >>> isinstance(anim, FuncAnimation)
+            True
+
+            ```
+        """
+        options = self._default_options.copy()
+        options.update(kwargs)
+        fig, target = self._resolve_axes(ax, options)
+        self._prepare()
+        angles = start_spin + np.linspace(
+            0.0, 360.0 * revolutions, n_frames, endpoint=False
+        )
+
+        def _update(frame_index: int):
+            self.draw(target, spin=float(angles[frame_index]), **kwargs)
+            return (self._surface,)
+
+        return FuncAnimation(
+            fig, _update, frames=n_frames, interval=interval, blit=False
+        )
+
+    @property
+    def surface(self):
+        """The `Poly3DCollection` from the most recent `draw`, or `None` before the first draw."""
+        return self._surface

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -143,9 +143,10 @@ class TexturedGlobeGlyph:
 
         Args:
             texture: An equirectangular RGB(A) array of shape `(H, W, 3)` or `(H, W, 4)`, `H >= 2` and `W >= 2`.
-                Integer arrays (0-255) and float arrays (0-1, or any range that is then normalised by its own max)
-                are both accepted. Row 0 is the northern edge (+90 deg), the last row the southern edge (-90 deg);
-                column 0 is -180 deg, the last column +180 deg.
+                Integer arrays are read as 8-bit (0-255); float arrays are assumed to be in `[0, 1]` and, only if a
+                channel exceeds 1, are normalised by their own peak. A float `(H, W, 4)` array's alpha must already
+                be in `[0, 1]`. NaN cells render black. Row 0 is the northern edge (+90 deg), the last row the
+                southern edge (-90 deg); column 0 is -180 deg, the last column +180 deg.
             tilt_deg: Axial tilt of the polar axis from vertical, in degrees. Defaults to Earth's 23.44 deg.
             n_lon: Longitude samples in the sphere mesh (>= 2). Higher is sharper but quadratically slower to draw.
             n_lat: Latitude samples in the sphere mesh (>= 2). Higher is sharper but quadratically slower to draw.
@@ -206,7 +207,9 @@ class TexturedGlobeGlyph:
         """Return `texture` as a float `(H, W, 4)` RGBA array in `[0, 1]`, brightness-scaled.
 
         Args:
-            texture: An `(H, W, 3)` or `(H, W, 4)` RGB(A) array, integer or float.
+            texture: An `(H, W, 3)` or `(H, W, 4)` RGB(A) array. Integer arrays are read as 8-bit
+                (0-255) and divided by 255; float arrays are assumed to be in `[0, 1]` and, only if a
+                channel exceeds 1, normalised by their own peak (NaN ignored). NaN cells render black.
             brightness: Multiplier applied to the RGB channels before clipping.
 
         Returns:
@@ -227,13 +230,20 @@ class TexturedGlobeGlyph:
                 f"got shape {arr.shape}."
             )
         rgba = arr.astype(float)
-        # Normalise integer/0-255 (or any >1) data to 0-1.
-        peak = rgba[..., :3].max() if rgba.size else 1.0
-        if peak > 1.0:
-            rgba = rgba / 255.0 if peak <= 255.0 else rgba / peak
-        rgb = np.clip(rgba[..., :3] * brightness, 0.0, 1.0)
+        if np.issubdtype(arr.dtype, np.integer):
+            # Integer textures are 8-bit 0-255 by convention (alpha included).
+            rgba = rgba / 255.0
+        else:
+            # Float textures are assumed to be in [0, 1]; if any channel exceeds 1 the
+            # texture is normalised by its own peak (NaN ignored) rather than a fixed
+            # /255, so a stray highlight cannot black out the globe and a single NaN
+            # cannot disable normalisation for the whole texture.
+            peak = np.nanmax(rgba[..., :3])
+            if np.isfinite(peak) and peak > 1.0:
+                rgba = rgba / peak
+        rgb = np.nan_to_num(np.clip(rgba[..., :3] * brightness, 0.0, 1.0), nan=0.0)
         if arr.shape[-1] == 4:
-            alpha = np.clip(rgba[..., 3:4], 0.0, 1.0)
+            alpha = np.nan_to_num(np.clip(rgba[..., 3:4], 0.0, 1.0), nan=1.0)
         else:
             alpha = np.ones((*rgb.shape[:2], 1))
         return np.ascontiguousarray(np.concatenate([rgb, alpha], axis=-1))

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -458,7 +458,8 @@ class TexturedGlobeGlyph:
                 is created on the instance's `fig` (or a new figure sized by the `figsize` option).
             spin: Rotation of the globe about its tilted polar axis, in degrees. The camera stays put.
             **kwargs: Render options overriding the instance defaults for this call (`figsize`, `elev`, `azim`,
-                `background`).
+                `background`). `figsize` applies only when a new figure is created; it is ignored when drawing onto
+                an existing (supplied or instance) axes. An unrecognised key raises `ValueError`.
 
         Returns:
             tuple: `(fig, ax)` -- the figure and the 3-D axes the globe was drawn on. The surface artist is also
@@ -527,7 +528,8 @@ class TexturedGlobeGlyph:
 
         The texture is sampled once (via `draw`'s cached `_prepare`); each frame only rotates the pre-computed vertices
         and re-draws, so the per-frame cost is dominated by matplotlib's surface draw at the chosen mesh resolution.
-        Save it with `cleopatra.glyphs.base.animation` (or matplotlib's own writers).
+        Save it with `cleopatra.glyphs.base.animation.save_animation` (to a file) or `to_gif`/`to_mp4` (to bytes),
+        or matplotlib's own writers.
 
         Args:
             ax: A 3-D axes to animate on, or `None` to create one (see `draw`).

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -237,13 +237,15 @@ class TexturedGlobeGlyph:
             rgba = rgba / 255.0
         else:
             # Float textures are assumed to be in [0, 1]; if any channel exceeds 1 the
-            # texture is normalised by its own peak (NaN ignored) rather than a fixed
-            # /255, so a stray highlight cannot black out the globe and a single NaN
-            # cannot disable normalisation for the whole texture.
-            peak = np.nanmax(rgba[..., :3])
-            if np.isfinite(peak) and peak > 1.0:
+            # texture is normalised by its own peak so a stray highlight cannot black out
+            # the globe. The peak is taken over the finite RGB values only, so a NaN cell
+            # neither disables normalisation nor triggers an all-NaN warning.
+            rgb = rgba[..., :3]
+            finite_rgb = rgb[np.isfinite(rgb)]
+            peak = finite_rgb.max() if finite_rgb.size else 0.0
+            if peak > 1.0:
                 # Scale only the RGB channels; alpha is already assumed to be in [0, 1].
-                rgba[..., :3] = rgba[..., :3] / peak
+                rgba[..., :3] = rgb / peak
         rgb = np.nan_to_num(np.clip(rgba[..., :3] * brightness, 0.0, 1.0), nan=0.0)
         if arr.shape[-1] == 4:
             alpha = np.nan_to_num(np.clip(rgba[..., 3:4], 0.0, 1.0), nan=1.0)

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -142,10 +142,11 @@ class TexturedGlobeGlyph:
 
         Args:
             texture: An equirectangular RGB(A) array of shape `(H, W, 3)` or `(H, W, 4)`, `H >= 2` and `W >= 2`.
-                Integer arrays are read as 8-bit (0-255); float arrays are assumed to be in `[0, 1]` and, only if a
-                channel exceeds 1, are normalised by their own peak. A float `(H, W, 4)` array's alpha must already
-                be in `[0, 1]`. NaN cells render black. Row 0 is the northern edge (+90 deg), the last row the
-                southern edge (-90 deg); column 0 is -180 deg, the last column +180 deg.
+                Integer arrays are divided by their dtype's maximum (uint8 -> 255, uint16 -> 65535); float arrays
+                are assumed to be in `[0, 1]` and, only if a channel exceeds 1, are normalised by their own peak. A
+                float `(H, W, 4)` array's alpha must already be in `[0, 1]`. NaN cells and negative values render
+                black. Row 0 is the northern edge (+90 deg), the last row the southern edge (-90 deg); column 0 is
+                -180 deg, the last column +180 deg.
             tilt_deg: Axial tilt of the polar axis from vertical, in degrees. Defaults to Earth's 23.44 deg.
             n_lon: Longitude samples in the sphere mesh (>= 2). Higher is sharper but quadratically slower to draw.
             n_lat: Latitude samples in the sphere mesh (>= 2). Higher is sharper but quadratically slower to draw.
@@ -209,9 +210,10 @@ class TexturedGlobeGlyph:
         """Return `texture` as a float `(H, W, 4)` RGBA array in `[0, 1]`, brightness-scaled.
 
         Args:
-            texture: An `(H, W, 3)` or `(H, W, 4)` RGB(A) array. Integer arrays are read as 8-bit
-                (0-255) and divided by 255; float arrays are assumed to be in `[0, 1]` and, only if a
-                channel exceeds 1, normalised by their own peak (NaN ignored). NaN cells render black.
+            texture: An `(H, W, 3)` or `(H, W, 4)` RGB(A) array. Integer arrays are divided by their
+                dtype's maximum (uint8 -> 255, uint16 -> 65535); float arrays are assumed to be in
+                `[0, 1]` and, only if a channel exceeds 1, normalised by their own peak (NaN ignored).
+                NaN cells render black.
             brightness: Multiplier applied to the RGB channels before clipping.
 
         Returns:
@@ -233,8 +235,10 @@ class TexturedGlobeGlyph:
             )
         rgba = arr.astype(float)
         if np.issubdtype(arr.dtype, np.integer):
-            # Integer textures are 8-bit 0-255 by convention (alpha included).
-            rgba = rgba / 255.0
+            # Integer textures span their dtype's full range (uint8 -> 255,
+            # uint16 -> 65535, ...), so scale by that maximum rather than a
+            # hard-coded 255 (alpha included).
+            rgba = rgba / float(np.iinfo(arr.dtype).max)
         else:
             # Float textures are assumed to be in [0, 1]; if any channel exceeds 1 the
             # texture is normalised by its own peak so a stray highlight cannot black out

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -56,7 +56,6 @@ from __future__ import annotations
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.animation import FuncAnimation
-from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from mpl_toolkits.mplot3d import Axes3D
 
@@ -136,7 +135,7 @@ class TexturedGlobeGlyph:
         n_lat: int = 90,
         brightness: float = 1.0,
         fig: Figure | None = None,
-        ax: Axes | None = None,
+        ax: Axes3D | None = None,
         **kwargs,
     ):
         """Initialize the globe from an equirectangular texture.
@@ -318,7 +317,7 @@ class TexturedGlobeGlyph:
         coords = self._tilt_matrix @ (self._rotation_z(spin) @ self._base_xyz)
         return tuple(coords.reshape(3, self._n_lat, self._n_lon))
 
-    def _resolve_axes(self, ax: Axes | None, options: dict) -> tuple[Figure, Axes]:
+    def _resolve_axes(self, ax: Axes3D | None, options: dict) -> tuple[Figure, Axes3D]:
         """Resolve the 3-D `(fig, ax)` to draw on, creating a 3-D axes if none was supplied.
 
         Args:
@@ -443,8 +442,8 @@ class TexturedGlobeGlyph:
     # Rendering                                                            #
     # ------------------------------------------------------------------ #
     def draw(
-        self, ax: Axes | None = None, *, spin: float = 0.0, **kwargs
-    ) -> tuple[Figure, Axes]:
+        self, ax: Axes3D | None = None, *, spin: float = 0.0, **kwargs
+    ) -> tuple[Figure, Axes3D]:
         """Render the textured globe onto a 3-D axes at a given spin angle.
 
         Args:
@@ -509,7 +508,7 @@ class TexturedGlobeGlyph:
 
     def animate(
         self,
-        ax: Axes | None = None,
+        ax: Axes3D | None = None,
         *,
         n_frames: int = 60,
         revolutions: float = 1.0,

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -242,7 +242,8 @@ class TexturedGlobeGlyph:
             # cannot disable normalisation for the whole texture.
             peak = np.nanmax(rgba[..., :3])
             if np.isfinite(peak) and peak > 1.0:
-                rgba = rgba / peak
+                # Scale only the RGB channels; alpha is already assumed to be in [0, 1].
+                rgba[..., :3] = rgba[..., :3] / peak
         rgb = np.nan_to_num(np.clip(rgba[..., :3] * brightness, 0.0, 1.0), nan=0.0)
         if arr.shape[-1] == 4:
             alpha = np.nan_to_num(np.clip(rgba[..., 3:4], 0.0, 1.0), nan=1.0)

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -185,8 +185,9 @@ class TestDraw:
 
     def test_draw_on_non_3d_ax_raises(self, texture):
         _, ax2d = plt.subplots()
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
         with pytest.raises(ValueError):
-            TexturedGlobeGlyph(texture, n_lon=24, n_lat=12).draw(ax2d)
+            globe.draw(ax2d)
 
     def test_draw_uses_instance_fig(self, texture):
         fig = plt.figure()

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -103,6 +103,12 @@ class TestConstruction:
         globe = TexturedGlobeGlyph(tex, n_lon=6, n_lat=4)
         assert np.isclose(globe.texture[0, 0, 0], 1.0 / 255.0)
 
+    def test_uint16_texture_scaled_by_dtype_max(self):
+        tex = np.zeros((4, 4, 3), dtype=np.uint16)
+        tex[0, 0, 0] = 30000
+        globe = TexturedGlobeGlyph(tex, n_lon=6, n_lat=4)
+        assert np.isclose(globe.texture[0, 0, 0], 30000.0 / 65535.0)
+
     def test_integer_alpha_scaled_by_255(self):
         tex = np.full((4, 4, 4), 255, dtype=np.uint8)
         tex[..., 3] = 128

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -269,15 +269,15 @@ class TestAnimate:
         with pytest.raises(ValueError, match="Unknown option"):
             globe.animate(n_frames=3, elevv=80)
 
-    def test_animate_reuses_single_axes(self, texture):
+    def test_animate_reuses_single_axes(self, texture, tmp_path):
         globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
         fig = plt.figure()
         ax = fig.add_subplot(projection="3d")
         anim = globe.animate(ax, n_frames=4)
         assert list(anim.new_frame_seq()) == [0, 1, 2, 3]
-        # animate's per-frame update is draw(); its redraw keeps a single surface
-        for angle in (0.0, 90.0, 180.0):
-            globe.draw(ax, spin=angle)
+        # render every frame via the public writer; each frame's update is draw(),
+        # whose redraw keeps a single surface on the reused axes
+        anim.save(tmp_path / "globe.gif", writer="pillow", fps=5)
         assert len(ax.collections) == 1
 
 

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -109,6 +109,13 @@ class TestConstruction:
         globe = TexturedGlobeGlyph(tex, n_lon=6, n_lat=4)
         assert np.allclose(globe.texture[..., 3], 128.0 / 255.0)
 
+    def test_float_rgba_peak_above_one_preserves_alpha(self):
+        tex = np.full((4, 4, 4), 0.5, dtype=float)
+        tex[0, 0, 0] = 2.0  # an RGB value > 1 triggers peak normalization
+        globe = TexturedGlobeGlyph(tex, n_lon=6, n_lat=4)
+        # only RGB is scaled by the peak; alpha stays as supplied
+        assert np.allclose(globe.texture[..., 3], 0.5)
+
     @pytest.mark.parametrize(
         "bad",
         [

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -1,0 +1,238 @@
+"""Tests for `cleopatra.glyphs.globe.textured_globe_glyph.TexturedGlobeGlyph`.
+
+Covers construction/validation, that `draw` returns a 3-D axes, the equirectangular texture -> sphere orientation
+(north-up, west-left), the axial tilt and spin, the sample-once caching contract, and the `animate` helper. Meshes are
+kept small so the CPU-only 3-D surface draws stay fast.
+"""
+
+import doctest
+
+import matplotlib
+import numpy as np
+import pytest
+
+matplotlib.use("agg")
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+from matplotlib.colors import to_rgba
+from mpl_toolkits.mplot3d import Axes3D
+
+import cleopatra.glyphs.globe.textured_globe_glyph as globe_module
+from cleopatra.glyphs.globe.textured_globe_glyph import (
+    EARTH_TILT_DEG,
+    TexturedGlobeGlyph,
+)
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    """Close all matplotlib figures after each test to bound memory."""
+    yield
+    plt.close("all")
+
+
+@pytest.fixture
+def texture() -> np.ndarray:
+    """A small distinctive equirectangular RGB texture (north red, south blue, west darkened)."""
+    tex = np.zeros((16, 32, 3), dtype=np.uint8)
+    tex[:8] = (200, 40, 40)  # northern hemisphere red
+    tex[8:] = (40, 40, 200)  # southern hemisphere blue
+    tex[:, :16] //= 2  # western hemisphere darkened
+    return tex
+
+
+def test_module_doctests_execute():
+    """Run the module's docstring examples (pytest is not configured with --doctest-modules)."""
+    try:
+        results = doctest.testmod(globe_module, verbose=False)
+    finally:
+        plt.close("all")
+    assert results.failed == 0, (
+        f"{results.failed} doctest example(s) failed in textured_globe_glyph"
+    )
+    assert results.attempted > 0, (
+        "no doctest examples were collected from textured_globe_glyph"
+    )
+
+
+class TestConstruction:
+    def test_defaults(self, texture):
+        globe = TexturedGlobeGlyph(texture)
+        assert globe.tilt_deg == EARTH_TILT_DEG
+        assert (globe.n_lon, globe.n_lat) == (180, 90)
+        assert globe.brightness == 1.0
+
+    def test_texture_normalised_to_float_rgba(self, texture):
+        globe = TexturedGlobeGlyph(texture)
+        assert globe.texture.shape == (16, 32, 4)
+        assert globe.texture.dtype == float
+        assert globe.texture.min() >= 0.0 and globe.texture.max() <= 1.0
+        # opaque alpha added for an RGB source
+        assert np.all(globe.texture[..., 3] == 1.0)
+
+    def test_alpha_channel_preserved(self):
+        tex = np.ones((8, 16, 4), dtype=float)
+        tex[..., 3] = 0.5
+        globe = TexturedGlobeGlyph(tex)
+        assert np.allclose(globe.texture[..., 3], 0.5)
+
+    def test_brightness_darkens_and_clips(self, texture):
+        dark = TexturedGlobeGlyph(texture, brightness=0.0)
+        assert np.all(dark.texture[..., :3] == 0.0)
+        bright = TexturedGlobeGlyph(texture, brightness=100.0)
+        assert bright.texture[..., :3].max() <= 1.0
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            np.zeros((16, 32)),  # 2-D, no channel axis
+            np.zeros((16, 32, 5)),  # 5 channels
+            np.zeros((1, 32, 3)),  # too few rows
+            np.zeros((16, 1, 3)),  # too few cols
+        ],
+    )
+    def test_bad_texture_raises(self, bad):
+        with pytest.raises(ValueError):
+            TexturedGlobeGlyph(bad)
+
+    @pytest.mark.parametrize(
+        "kwargs", [{"n_lon": 1}, {"n_lat": 1}, {"brightness": -0.5}]
+    )
+    def test_bad_params_raise(self, texture, kwargs):
+        with pytest.raises(ValueError):
+            TexturedGlobeGlyph(texture, **kwargs)
+
+    def test_non_3d_ax_raises(self, texture):
+        _, ax2d = plt.subplots()
+        with pytest.raises(ValueError):
+            TexturedGlobeGlyph(texture, ax=ax2d)
+
+
+class TestDraw:
+    def test_returns_3d_axes(self, texture):
+        fig, ax = TexturedGlobeGlyph(texture, n_lon=36, n_lat=18).draw()
+        assert isinstance(ax, Axes3D)
+        assert ax.name == "3d"
+
+    def test_facecolors_shape_and_range(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=36, n_lat=18)
+        globe.draw()
+        assert globe._facecolors.shape == (17, 35, 4)  # (n_lat-1, n_lon-1, 4)
+        assert globe._facecolors.min() >= 0.0 and globe._facecolors.max() <= 1.0
+        assert globe.surface is not None
+
+    def test_draw_on_supplied_3d_axes(self, texture):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection="3d")
+        fig2, ax2 = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12).draw(ax)
+        assert ax2 is ax
+        assert fig2 is fig
+
+    def test_redraw_clears_prior_surface(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        fig, ax = globe.draw(spin=0.0)
+        globe.draw(ax, spin=90.0)
+        # a single surface collection remains on the axes, not two
+        assert len(ax.collections) == 1
+
+    def test_background_option(self, texture):
+        fig, ax = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12).draw(
+            background="black"
+        )
+        assert fig.get_facecolor() == to_rgba("black")
+
+
+class TestOrientation:
+    """The equirectangular texture must map north-up and west-left onto the sphere."""
+
+    def test_facecolors_north_up_south_down(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=36, n_lat=18)
+        globe.draw()
+        fc = globe._facecolors
+        # northernmost face row is red-dominant, southernmost is blue-dominant
+        north = fc[0].mean(axis=0)
+        south = fc[-1].mean(axis=0)
+        assert north[0] > north[2]  # red > blue in the north
+        assert south[2] > south[0]  # blue > red in the south
+
+    def test_facecolors_west_darker_than_east(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=36, n_lat=18)
+        globe.draw()
+        fc = globe._facecolors
+        west = fc[:, 0, :3].mean()
+        east = fc[:, -1, :3].mean()
+        assert west < east  # western hemisphere was halved
+
+    def test_base_mesh_geographic_anchors(self, texture):
+        # odd counts put lat=0 / lon=0 exactly on a grid vertex
+        globe_flat = TexturedGlobeGlyph(texture, n_lon=5, n_lat=3, tilt_deg=0.0)
+        globe_flat._prepare()
+        flat = np.stack(globe_flat._spun_mesh(0.0))
+        # (lat=0, lon=0) -> +x ; north pole (row 0) -> +z with no tilt
+        assert np.allclose(flat[:, 1, 2], [1.0, 0.0, 0.0], atol=1e-9)
+        assert np.allclose(flat[:, 0, 0], [0.0, 0.0, 1.0], atol=1e-9)
+
+
+class TestTiltAndSpin:
+    def test_tilt_moves_the_pole(self, texture):
+        flat = TexturedGlobeGlyph(texture, n_lon=5, n_lat=3, tilt_deg=0.0)
+        tilted = TexturedGlobeGlyph(texture, n_lon=5, n_lat=3, tilt_deg=45.0)
+        flat._prepare()
+        tilted._prepare()
+        pole_flat = np.stack(flat._spun_mesh(0.0))[:, 0, 0]
+        pole_tilted = np.stack(tilted._spun_mesh(0.0))[:, 0, 0]
+        assert not np.allclose(pole_flat, pole_tilted)
+        # tilt is a rotation: the pole stays on the unit sphere
+        assert np.isclose(np.linalg.norm(pole_tilted), 1.0)
+
+    def test_spin_rotates_mesh_but_not_texture(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        globe._prepare()
+        fc_before = globe._facecolors.copy()
+        mesh0 = np.stack(globe._spun_mesh(0.0))
+        mesh90 = np.stack(globe._spun_mesh(90.0))
+        assert not np.allclose(mesh0, mesh90)  # geometry rotated
+        assert np.array_equal(globe._facecolors, fc_before)  # texture untouched
+
+    def test_prepare_is_idempotent_sample_once(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        globe._prepare()
+        fc_id = id(globe._facecolors)
+        base_id = id(globe._base_xyz)
+        globe._prepare()  # second call must not rebuild
+        assert id(globe._facecolors) == fc_id
+        assert id(globe._base_xyz) == base_id
+
+
+class TestAnimate:
+    def test_returns_funcanimation(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        anim = globe.animate(n_frames=3)
+        assert isinstance(anim, FuncAnimation)
+
+    def test_animate_reuses_single_axes(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        fig = plt.figure()
+        ax = fig.add_subplot(projection="3d")
+        anim = globe.animate(ax, n_frames=4)
+        # drive a couple of frames; the redraw contract keeps one surface
+        anim._func(0)
+        anim._func(1)
+        assert len(ax.collections) == 1
+
+
+class TestIntrospection:
+    def test_option_keys(self):
+        keys = TexturedGlobeGlyph.option_keys()
+        assert {"figsize", "elev", "azim", "background"} <= keys
+
+    def test_filter_kwargs(self):
+        filtered = TexturedGlobeGlyph.filter_kwargs({"elev": 30, "bogus": 1})
+        assert filtered == {"elev": 30}
+
+
+def test_no_new_dependency():
+    """The globe uses mpl_toolkits.mplot3d, which ships with matplotlib -- no new dependency."""
+    import mpl_toolkits.mplot3d as m3d
+
+    assert m3d.__name__.startswith("mpl_toolkits")

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -128,6 +128,24 @@ class TestDraw:
         assert ax2 is ax
         assert fig2 is fig
 
+    def test_draw_on_non_3d_ax_raises(self, texture):
+        _, ax2d = plt.subplots()
+        with pytest.raises(ValueError):
+            TexturedGlobeGlyph(texture, n_lon=24, n_lat=12).draw(ax2d)
+
+    def test_draw_uses_instance_fig(self, texture):
+        fig = plt.figure()
+        fig2, ax = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12, fig=fig).draw()
+        assert fig2 is fig
+        assert isinstance(ax, Axes3D)
+
+    def test_draw_uses_instance_ax(self, texture):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection="3d")
+        fig2, ax2 = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12, ax=ax).draw()
+        assert ax2 is ax
+        assert fig2 is fig
+
     def test_redraw_clears_prior_surface(self, texture):
         globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
         fig, ax = globe.draw(spin=0.0)
@@ -229,6 +247,12 @@ class TestIntrospection:
     def test_filter_kwargs(self):
         filtered = TexturedGlobeGlyph.filter_kwargs({"elev": 30, "bogus": 1})
         assert filtered == {"elev": 30}
+
+    def test_default_options_merges_overrides(self, texture):
+        globe = TexturedGlobeGlyph(texture, elev=42)
+        opts = globe.default_options
+        assert opts["elev"] == 42
+        assert opts["azim"] == 0.0  # untouched default retained
 
 
 def test_no_new_dependency():

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -41,9 +41,7 @@ def texture() -> np.ndarray:
     return tex
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Animation was deleted without rendering anything"
-)
+@pytest.mark.filterwarnings("ignore:Animation was deleted without rendering anything")
 def test_module_doctests_execute():
     """Run the module's docstring examples (pytest is not configured with --doctest-modules)."""
     try:

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -274,9 +274,10 @@ class TestAnimate:
         fig = plt.figure()
         ax = fig.add_subplot(projection="3d")
         anim = globe.animate(ax, n_frames=4)
-        # drive a couple of frames; the redraw contract keeps one surface
-        anim._func(0)
-        anim._func(1)
+        assert list(anim.new_frame_seq()) == [0, 1, 2, 3]
+        # animate's per-frame update is draw(); its redraw keeps a single surface
+        for angle in (0.0, 90.0, 180.0):
+            globe.draw(ax, spin=angle)
         assert len(ax.collections) == 1
 
 

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -116,6 +116,12 @@ class TestConstruction:
         # only RGB is scaled by the peak; alpha stays as supplied
         assert np.allclose(globe.texture[..., 3], 0.5)
 
+    def test_all_nan_texture_renders_black_without_warning(self, recwarn):
+        tex = np.full((4, 4, 3), np.nan, dtype=float)
+        globe = TexturedGlobeGlyph(tex, n_lon=6, n_lat=4)
+        assert not any(issubclass(w.category, RuntimeWarning) for w in recwarn)
+        assert np.all(globe.texture[..., :3] == 0.0)
+
     @pytest.mark.parametrize(
         "bad",
         [

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -41,6 +41,9 @@ def texture() -> np.ndarray:
     return tex
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Animation was deleted without rendering anything"
+)
 def test_module_doctests_execute():
     """Run the module's docstring examples (pytest is not configured with --doctest-modules)."""
     try:
@@ -278,6 +281,9 @@ class TestTiltAndSpin:
 
 
 class TestAnimate:
+    @pytest.mark.filterwarnings(
+        "ignore:Animation was deleted without rendering anything"
+    )
     def test_returns_funcanimation(self, texture):
         globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
         anim = globe.animate(n_frames=3)

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -69,7 +69,8 @@ class TestConstruction:
         globe = TexturedGlobeGlyph(texture)
         assert globe.texture.shape == (16, 32, 4)
         assert globe.texture.dtype == float
-        assert globe.texture.min() >= 0.0 and globe.texture.max() <= 1.0
+        assert globe.texture.min() >= 0.0
+        assert globe.texture.max() <= 1.0
         # opaque alpha added for an RGB source
         assert np.all(globe.texture[..., 3] == 1.0)
 
@@ -171,7 +172,8 @@ class TestDraw:
         globe = TexturedGlobeGlyph(texture, n_lon=36, n_lat=18)
         globe.draw()
         assert globe._facecolors.shape == (17, 35, 4)  # (n_lat-1, n_lon-1, 4)
-        assert globe._facecolors.min() >= 0.0 and globe._facecolors.max() <= 1.0
+        assert globe._facecolors.min() >= 0.0
+        assert globe._facecolors.max() <= 1.0
         assert globe.surface is not None
 
     def test_draw_on_supplied_3d_axes(self, texture):

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -82,6 +82,33 @@ class TestConstruction:
         bright = TexturedGlobeGlyph(texture, brightness=100.0)
         assert bright.texture[..., :3].max() <= 1.0
 
+    def test_float_texture_above_one_normalised_by_peak_not_255(self):
+        tex = np.full((4, 4, 3), 0.5, dtype=float)
+        tex[0, 0, 0] = 1.5
+        globe = TexturedGlobeGlyph(tex, n_lon=6, n_lat=4)
+        # 0.5 / 1.5 == 1/3, not 0.5/255 (which would be ~black)
+        assert np.isclose(globe.texture[1, 1, 0], 1.0 / 3.0)
+
+    def test_nan_cells_render_black_without_breaking_normalisation(self):
+        tex = np.linspace(0.0, 200.0, 4 * 4 * 3, dtype=float).reshape(4, 4, 3)
+        tex[0, 0, 0] = np.nan
+        globe = TexturedGlobeGlyph(tex, n_lon=6, n_lat=4)
+        assert not np.any(np.isnan(globe.texture))
+        assert globe.texture.max() <= 1.0
+        assert globe.texture[0, 0, 0] == 0.0  # NaN -> black
+
+    def test_integer_max_one_scaled_by_255(self):
+        tex = np.zeros((4, 4, 3), dtype=np.uint8)
+        tex[0, 0, 0] = 1
+        globe = TexturedGlobeGlyph(tex, n_lon=6, n_lat=4)
+        assert np.isclose(globe.texture[0, 0, 0], 1.0 / 255.0)
+
+    def test_integer_alpha_scaled_by_255(self):
+        tex = np.full((4, 4, 4), 255, dtype=np.uint8)
+        tex[..., 3] = 128
+        globe = TexturedGlobeGlyph(tex, n_lon=6, n_lat=4)
+        assert np.allclose(globe.texture[..., 3], 128.0 / 255.0)
+
     @pytest.mark.parametrize(
         "bad",
         [

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -134,6 +134,10 @@ class TestConstruction:
         with pytest.raises(ValueError):
             TexturedGlobeGlyph(texture, ax=ax2d)
 
+    def test_unknown_kwarg_raises(self, texture):
+        with pytest.raises(ValueError, match="Unknown option"):
+            TexturedGlobeGlyph(texture, elevv=80)
+
 
 class TestDraw:
     def test_returns_3d_axes(self, texture):
@@ -185,6 +189,11 @@ class TestDraw:
             background="black"
         )
         assert fig.get_facecolor() == to_rgba("black")
+
+    def test_draw_unknown_kwarg_raises(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        with pytest.raises(ValueError, match="Unknown option"):
+            globe.draw(elevv=80)
 
 
 class TestOrientation:
@@ -254,6 +263,11 @@ class TestAnimate:
         globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
         anim = globe.animate(n_frames=3)
         assert isinstance(anim, FuncAnimation)
+
+    def test_animate_unknown_kwarg_raises(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        with pytest.raises(ValueError, match="Unknown option"):
+            globe.animate(n_frames=3, elevv=80)
 
     def test_animate_reuses_single_axes(self, texture):
         globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)


### PR DESCRIPTION
# Description

Adds `TexturedGlobeGlyph` — cleopatra's first **3-D** glyph. It wraps an equirectangular (lon/lat)
RGB(A) texture onto a tilted, spinnable sphere drawn on a matplotlib `Axes3D`.

- **NumPy in → matplotlib out.** Takes an `(H, W, 3)`/`(H, W, 4)` equirectangular array with the same
  north-up layout as `basemap.reference.relief()` (row 0 = +90°, col 0 = −180°) and returns
  `(fig, ax)` where `ax` is an `Axes3D`. You can drape a relief raster — or any world texture — onto a
  globe in one call.
- **Sample once, spin cheaply.** The texture is resampled to per-face colours exactly once and cached.
  `draw(spin=…)` rotates the globe about its **fixed** tilted polar axis by rotating only the
  pre-computed mesh (a 3×3 matmul), never the texture — so the axial tilt stays put in space while the
  surface turns under it (physically what a spinning planet does). An `animate()` helper returns a
  `FuncAnimation` of a full rotation.
- **Standalone class.** Like `HistogramGlyph`, it does not subclass `Glyph` — the base class's 2-D
  figure/colorbar lifecycle does not apply to a sphere. It still mirrors the `option_keys`/
  `filter_kwargs`/`DEFAULT_OPTIONS` introspection surface.
- **Robust texture handling.** Integer textures scale by their dtype max (uint8/uint16), float textures
  are assumed `[0, 1]` and normalised by their own peak only when a channel exceeds 1 (RGB only, so
  alpha is preserved); NaN and negative cells render black; unknown render options are rejected with a
  clear `ValueError`, matching the rest of the package.
- **No new dependency.** Uses `mpl_toolkits.mplot3d`, which ships with matplotlib.

**Cost note (documented in the module + reference page).** matplotlib's 3-D surface is CPU-drawn as
one polygon per face, so render time grows with `n_lon × n_lat`. Measured first-draw times
(matplotlib 3.10, Agg): 180×90 ≈ 1.5 s, 360×180 ≈ 7.7 s, 720×360 ≈ 27 s. The default is **180×90**
for a fast draw; raise it for a sharper still, lower it for a smooth animation. (The original issue
proposed 720×360 as the default — I lowered it based on these measurements.)

No new runtime dependencies.

# Issues

- Closes #311 — add a textured globe glyph for 3D axes

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

New suite `tests/test_textured_globe_glyph.py` (43 tests, ~1.5 s, **100% line + branch** coverage of
the module) covering:

- **Construction / validation** — defaults; texture normalisation to float RGBA; dtype-based scaling
  (uint8, uint16); float peak-normalisation that preserves alpha; NaN → black with no warning;
  brightness darken+clip; and `ValueError` on a bad texture shape/channels, `n_lon`/`n_lat` < 2,
  negative brightness, a non-3-D axes, and unknown keyword arguments.
- **Draw** — returns an `Axes3D`; `facecolors` shape `(n_lat−1, n_lon−1, 4)` in `[0, 1]`; draws onto a
  supplied / instance `fig`/`ax`; a redraw clears the prior surface (one collection remains);
  `background` option.
- **Orientation** — texture maps north-up / west-left; base-mesh geographic anchors
  ((lat 0, lon 0) → +x, north pole → +z).
- **Tilt & spin** — tilt moves the pole and stays on the unit sphere; spin rotates the mesh but leaves
  the texture untouched; `_prepare` is idempotent (sample-once contract).
- **Animate** — returns a `FuncAnimation`; the render path is exercised via `anim.save` and reuses a
  single axes.
- **No new dependency** — `mpl_toolkits.mplot3d` is part of matplotlib.

Full suite: **2334 passed** (additive change; nothing else affected). Two `/review-rounds` passes were
run and every finding resolved.

Reproduce (external uv env, worktree on `src`):

```
VIRTUAL_ENV=C:/python-environments/uv/cleopatra PYTHONPATH=src \
  C:/python-environments/uv/cleopatra/Scripts/python.exe -m pytest tests/test_textured_globe_glyph.py -q
```

- [x] Test A — `tests/test_textured_globe_glyph.py` (43 passed, 100% coverage)
- [x] Test B — `ruff check` + `ruff format --check` clean on the new module and tests

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
