### PR TITLE
feat(glyphs): add directional lighting to TexturedGlobeGlyph

### DIFF
--- a/docs/reference/textured-globe-glyph.md
+++ b/docs/reference/textured-globe-glyph.md
@@ -67,8 +67,8 @@ evenly.
 from cleopatra.basemap.reference import relief
 from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
 
-globe = TexturedGlobeGlyph(relief("low"), sun=(1.0, 0.0, 0.3), ambient=0.13)
-fig, ax = globe.draw(spin=40.0, background="black")   # left half in daylight, right in night
+globe = TexturedGlobeGlyph(relief("low"), sun=(0.0, 1.0, 0.3), ambient=0.13)
+fig, ax = globe.draw(spin=40.0, background="black")   # side-lit: one half in daylight, the other in night
 ```
 
 ### A spinning animation

--- a/docs/reference/textured-globe-glyph.md
+++ b/docs/reference/textured-globe-glyph.md
@@ -55,17 +55,33 @@ fig, ax = TexturedGlobeGlyph(texture).draw(spin=45.0)
 plt.show()
 ```
 
+### A day/night terminator (directional lighting)
+
+Pass a `sun` unit vector (in world space: `+z` is north/up, `+x` faces the viewer at `spin=0`) to
+light the sphere from a direction. `ambient` is a floor so the night side stays legible. Lighting
+is applied per frame from the already-rotated vertices — no texture re-sampling — so a fixed `sun`
+with a spinning globe sweeps the terminator across the surface. `sun=None` (the default) renders
+evenly.
+
+```python
+from cleopatra.basemap.reference import relief
+from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+
+globe = TexturedGlobeGlyph(relief("low"), sun=(1.0, 0.0, 0.3), ambient=0.13)
+fig, ax = globe.draw(spin=40.0, background="black")   # left half in daylight, right in night
+```
+
 ### A spinning animation
 
 The texture is sampled once; each frame only rotates the pre-computed mesh, so use a modest
-resolution for smooth playback.
+resolution for smooth playback. Add `sun=...` for a lit globe whose terminator moves as it turns.
 
 ```python
 from cleopatra.basemap.reference import relief
 from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
 
 globe = TexturedGlobeGlyph(relief("low"), n_lon=180, n_lat=90)
-anim = globe.animate(n_frames=60, revolutions=1.0, interval=50)
+anim = globe.animate(n_frames=60, revolutions=1.0, interval=50, sun=(1.0, 0.0, 0.0))
 # save with cleopatra.glyphs.base.animation.save_animation (or to_gif/to_mp4),
 # or matplotlib's own writers:
 # from cleopatra.glyphs.base.animation import save_animation

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -378,7 +378,7 @@ class TexturedGlobeGlyph:
                 f"sun must be a 1-D length-3 finite (x, y, z) vector or None; got {sun!r}."
             )
         norm = float(np.sqrt(vec @ vec))
-        if norm == 0.0:
+        if norm <= 0.0:
             raise ValueError("sun must be a non-zero direction vector; got (0, 0, 0).")
         return vec / norm
 
@@ -421,8 +421,9 @@ class TexturedGlobeGlyph:
         nx = 0.25 * (x[:-1, :-1] + x[1:, :-1] + x[:-1, 1:] + x[1:, 1:])
         ny = 0.25 * (y[:-1, :-1] + y[1:, :-1] + y[:-1, 1:] + y[1:, 1:])
         nz = 0.25 * (z[:-1, :-1] + z[1:, :-1] + z[:-1, 1:] + z[1:, 1:])
-        norm = np.sqrt(nx * nx + ny * ny + nz * nz)
-        norm[norm == 0.0] = 1.0
+        # Floor the magnitude at a tiny epsilon to avoid division by zero on a
+        # degenerate quad (never hit on real meshes; min magnitude is ~1).
+        norm = np.maximum(np.sqrt(nx * nx + ny * ny + nz * nz), 1e-12)
         lit = np.clip((nx * sun[0] + ny * sun[1] + nz * sun[2]) / norm, 0.0, 1.0)
         factor = ambient + (1.0 - ambient) * lit
         lit_face = self._facecolors.copy()

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -53,6 +53,8 @@ plt.show()
 
 from __future__ import annotations
 
+from typing import Any
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.animation import FuncAnimation
@@ -82,8 +84,9 @@ GLOBE_DEFAULT_OPTIONS = {
 DEFAULT_AMBIENT = 0.13
 
 #: Sentinel for `draw`/`animate` lighting arguments meaning "inherit the instance default"
-#: (so an explicit `sun=None` can still turn lighting off for one call).
-_INHERIT = object()
+#: (so an explicit `sun=None` can still turn lighting off for one call). Typed `Any` so it is a
+#: valid default for the `tuple | None` / `float` lighting parameters.
+_INHERIT: Any = object()
 
 
 class TexturedGlobeGlyph:
@@ -176,7 +179,8 @@ class TexturedGlobeGlyph:
                 rendering. Need not be unit length -- it is normalised. Can be overridden per call in
                 `draw`/`animate`.
             ambient: Floor brightness (fraction in `[0, 1]`) the unlit side keeps under directional lighting, so the
-                night side is not pure black. Defaults to `0.13`. Ignored when `sun is None`.
+                night side is not pure black. Defaults to `0.13`. Always validated, but only affects the render
+                when `sun` is set.
             fig: Pre-existing matplotlib `Figure` to draw on when `draw`/`animate` are called without their own `ax`.
             ax: Pre-existing 3-D matplotlib `Axes` (`Axes3D`) to draw on. If given it must be a 3-D axes.
             **kwargs: Render options overriding `DEFAULT_OPTIONS` (`figsize`, `elev`, `azim`, `background`). An
@@ -368,10 +372,10 @@ class TexturedGlobeGlyph:
         """
         if sun is None:
             return None
-        vec = np.asarray(sun, dtype=float).ravel()
+        vec = np.asarray(sun, dtype=float)
         if vec.shape != (3,) or not np.all(np.isfinite(vec)):
             raise ValueError(
-                f"sun must be a length-3 finite (x, y, z) vector or None; got {sun!r}."
+                f"sun must be a 1-D length-3 finite (x, y, z) vector or None; got {sun!r}."
             )
         norm = float(np.sqrt(vec @ vec))
         if norm == 0.0:
@@ -409,6 +413,7 @@ class TexturedGlobeGlyph:
         Returns:
             numpy.ndarray: An `(n_lat - 1, n_lon - 1, 4)` facecolors array.
         """
+        assert self._facecolors is not None  # populated by _prepare() before any draw
         if sun is None:
             return self._facecolors
         x, y, z = spun_xyz
@@ -578,7 +583,7 @@ class TexturedGlobeGlyph:
             sun: Light direction for this call, overriding the instance's `sun`. A length-3 world-space vector, or
                 `None` to render evenly. Omitted (default) inherits the value passed to `__init__`.
             ambient: Ambient floor for this call, overriding the instance's `ambient`. Omitted inherits the
-                constructor value. Ignored when the effective `sun` is `None`.
+                constructor value. Always validated, but only affects the render when the effective `sun` is set.
             **kwargs: Render options overriding the instance defaults for this call (`figsize`, `elev`, `azim`,
                 `background`). `figsize` applies only when a new figure is created; it is ignored when drawing onto
                 an existing (supplied or instance) axes. An unrecognised key raises `ValueError`.
@@ -683,7 +688,8 @@ class TexturedGlobeGlyph:
             matplotlib.animation.FuncAnimation: The animation, ready to save or embed.
 
         Raises:
-            ValueError: If `ax` is supplied but is not a 3-D axes, or if an unknown render option is passed.
+            ValueError: If `ax` is supplied but is not a 3-D axes, if `sun`/`ambient` are invalid, or if an unknown
+                render option is passed. `sun`/`ambient` are validated eagerly here (not deferred to frame render).
 
         Examples:
             ```python
@@ -697,6 +703,12 @@ class TexturedGlobeGlyph:
             ```
         """
         self._reject_unknown_options(kwargs)
+        # Validate lighting eagerly (like draw), so a bad sun/ambient raises here at the
+        # animate() call rather than later from inside matplotlib's per-frame render loop.
+        if sun is not _INHERIT:
+            self._normalize_sun(sun)
+        if ambient is not _INHERIT:
+            self._validate_ambient(ambient)
         options = self._default_options.copy()
         options.update(kwargs)
         fig, target = self._resolve_axes(ax, options)

--- a/src/cleopatra/glyphs/globe/textured_globe_glyph.py
+++ b/src/cleopatra/glyphs/globe/textured_globe_glyph.py
@@ -77,6 +77,14 @@ GLOBE_DEFAULT_OPTIONS = {
     "background": None,
 }
 
+#: Default ambient floor for directional lighting -- the fraction of full brightness the
+#: unlit (night) side keeps so it stays legible rather than going pure black.
+DEFAULT_AMBIENT = 0.13
+
+#: Sentinel for `draw`/`animate` lighting arguments meaning "inherit the instance default"
+#: (so an explicit `sun=None` can still turn lighting off for one call).
+_INHERIT = object()
+
 
 class TexturedGlobeGlyph:
     """Wrap an equirectangular texture onto a tilted, spinnable 3-D sphere.
@@ -88,17 +96,26 @@ class TexturedGlobeGlyph:
     The polar axis is tilted `tilt_deg` from vertical, and `draw(spin=...)` rotates the sphere about that axis so the
     same instance can render a whole rotation without re-sampling the texture (see the module docstring).
 
+    The sphere can be lit from a direction: pass a `sun` unit vector (in world space) to shade a lambertian day/night
+    terminator, with an `ambient` floor so the unlit side stays legible rather than going black. Lighting is applied
+    per frame from the already-rotated vertices (one dot product), so the sample-once/rotate-per-frame design is kept
+    -- the texture is never re-sampled and the `facecolors` cache is never mutated. `sun=None` (the default) renders
+    evenly, byte-identical to an unlit globe; a fixed `sun` with a spinning globe sweeps the terminator across the
+    surface as it turns.
+
     Attributes:
         texture: The normalised RGBA texture, float in `[0, 1]`, shape `(H, W, 4)`.
         tilt_deg: Axial tilt of the polar axis from vertical, in degrees.
         n_lon: Number of longitude samples in the sphere mesh.
         n_lat: Number of latitude samples in the sphere mesh.
         brightness: Multiplier applied to the RGB channels (clipped to `[0, 1]`).
+        sun: The unit light direction in world space, or `None` for even lighting.
+        ambient: The ambient floor (fraction) kept on the unlit side.
         default_options: The resolved render options (`figsize`, `elev`, `azim`, `background`).
 
     Methods:
-        draw(ax=None, *, spin=0.0, **kwargs): Render the globe onto a 3-D axes at a given spin angle.
-        animate(ax=None, n_frames=60, revolutions=1.0, ...): Return a `FuncAnimation` spinning the globe.
+        draw(ax=None, *, spin=0.0, sun=..., ambient=..., **kwargs): Render the globe at a given spin angle.
+        animate(ax=None, n_frames=60, revolutions=1.0, sun=..., ...): Return a `FuncAnimation` spinning the globe.
 
     Notes:
         `TexturedGlobeGlyph` is a standalone class, not a `Glyph` subclass (like `HistogramGlyph`). The accepted option
@@ -134,6 +151,8 @@ class TexturedGlobeGlyph:
         n_lon: int = 180,
         n_lat: int = 90,
         brightness: float = 1.0,
+        sun: tuple[float, float, float] | None = None,
+        ambient: float = DEFAULT_AMBIENT,
         fig: Figure | None = None,
         ax: Axes3D | None = None,
         **kwargs,
@@ -152,6 +171,12 @@ class TexturedGlobeGlyph:
             n_lat: Latitude samples in the sphere mesh (>= 2). Higher is sharper but quadratically slower to draw.
             brightness: Multiplier applied to the RGB channels before clipping to `[0, 1]`. `< 1` darkens, `> 1`
                 brightens. Must be `>= 0`.
+            sun: Light direction as a length-3 `(x, y, z)` vector in world space (the same frame the globe is drawn
+                in: `+z` is up/north, `+x` toward the viewer at `spin=0`), or `None` (default) for even, unlit
+                rendering. Need not be unit length -- it is normalised. Can be overridden per call in
+                `draw`/`animate`.
+            ambient: Floor brightness (fraction in `[0, 1]`) the unlit side keeps under directional lighting, so the
+                night side is not pure black. Defaults to `0.13`. Ignored when `sun is None`.
             fig: Pre-existing matplotlib `Figure` to draw on when `draw`/`animate` are called without their own `ax`.
             ax: Pre-existing 3-D matplotlib `Axes` (`Axes3D`) to draw on. If given it must be a 3-D axes.
             **kwargs: Render options overriding `DEFAULT_OPTIONS` (`figsize`, `elev`, `azim`, `background`). An
@@ -159,8 +184,9 @@ class TexturedGlobeGlyph:
 
         Raises:
             ValueError: If `texture` is not an `(H, W, 3)`/`(H, W, 4)` array with `H, W >= 2`, if `n_lon`/`n_lat` are
-                `< 2`, if `brightness` is negative, if `ax` is given but is not a 3-D axes, or if an unknown render
-                option is passed.
+                `< 2`, if `brightness` is negative, if `sun` is not a length-3 finite non-zero vector (or `None`), if
+                `ambient` is outside `[0, 1]`, if `ax` is given but is not a 3-D axes, or if an unknown render option
+                is passed.
 
         Examples:
             ```python
@@ -188,6 +214,8 @@ class TexturedGlobeGlyph:
         self._tilt_deg = float(tilt_deg)
         self._n_lon = int(n_lon)
         self._n_lat = int(n_lat)
+        self._sun = self._normalize_sun(sun)
+        self._ambient = self._validate_ambient(ambient)
         self._fig = fig
         self._ax = ax
 
@@ -324,6 +352,80 @@ class TexturedGlobeGlyph:
         coords = self._tilt_matrix @ (self._rotation_z(spin) @ self._base_xyz)
         return tuple(coords.reshape(3, self._n_lat, self._n_lon))
 
+    @staticmethod
+    def _normalize_sun(sun: tuple[float, float, float] | None) -> np.ndarray | None:
+        """Validate a light direction and return it as a unit vector (or `None`).
+
+        Args:
+            sun: A length-3 `(x, y, z)` direction in world space, or `None` for even lighting. Need not be
+                unit length -- it is normalised here.
+
+        Returns:
+            numpy.ndarray | None: The unit-length light direction, or `None` when `sun` is `None`.
+
+        Raises:
+            ValueError: If `sun` is not a length-3 finite vector, or is the zero vector.
+        """
+        if sun is None:
+            return None
+        vec = np.asarray(sun, dtype=float).ravel()
+        if vec.shape != (3,) or not np.all(np.isfinite(vec)):
+            raise ValueError(
+                f"sun must be a length-3 finite (x, y, z) vector or None; got {sun!r}."
+            )
+        norm = float(np.sqrt(vec @ vec))
+        if norm == 0.0:
+            raise ValueError("sun must be a non-zero direction vector; got (0, 0, 0).")
+        return vec / norm
+
+    @staticmethod
+    def _validate_ambient(ambient: float) -> float:
+        """Return `ambient` as a float in `[0, 1]`, raising `ValueError` otherwise."""
+        amb = float(ambient)
+        if not 0.0 <= amb <= 1.0:
+            raise ValueError(f"ambient must be in [0, 1]; got {ambient}.")
+        return amb
+
+    def _lit_facecolors(
+        self,
+        spun_xyz: tuple[np.ndarray, np.ndarray, np.ndarray],
+        sun: np.ndarray | None,
+        ambient: float,
+    ) -> np.ndarray:
+        """Return the per-face colours scaled by a lambertian directional-light term.
+
+        With `sun is None` the cached `facecolors` are returned unchanged (byte-identical to an unlit render). With a
+        light direction, each face is dimmed toward `ambient` on the side facing away from the light, giving a
+        day/night terminator. The cache itself is never mutated -- a scaled copy is returned -- so the
+        sample-once/rotate-per-frame contract holds: only a dot product over the already-rotated vertices is done per
+        frame, no texture re-sampling.
+
+        Args:
+            spun_xyz: The `(x, y, z)` unit-sphere vertex arrays from `_spun_mesh(spin)`; for a unit sphere each
+                vertex position is its outward normal.
+            sun: A unit light direction in world space, or `None` for even lighting.
+            ambient: The floor brightness (fraction) kept on the unlit side.
+
+        Returns:
+            numpy.ndarray: An `(n_lat - 1, n_lon - 1, 4)` facecolors array.
+        """
+        if sun is None:
+            return self._facecolors
+        x, y, z = spun_xyz
+        # Per-face outward normal = mean of the quad's four corner vertices, renormalised.
+        nx = 0.25 * (x[:-1, :-1] + x[1:, :-1] + x[:-1, 1:] + x[1:, 1:])
+        ny = 0.25 * (y[:-1, :-1] + y[1:, :-1] + y[:-1, 1:] + y[1:, 1:])
+        nz = 0.25 * (z[:-1, :-1] + z[1:, :-1] + z[:-1, 1:] + z[1:, 1:])
+        norm = np.sqrt(nx * nx + ny * ny + nz * nz)
+        norm[norm == 0.0] = 1.0
+        lit = np.clip((nx * sun[0] + ny * sun[1] + nz * sun[2]) / norm, 0.0, 1.0)
+        factor = ambient + (1.0 - ambient) * lit
+        lit_face = self._facecolors.copy()
+        lit_face[..., :3] = np.clip(
+            self._facecolors[..., :3] * factor[..., None], 0.0, 1.0
+        )
+        return lit_face
+
     def _resolve_axes(self, ax: Axes3D | None, options: dict) -> tuple[Figure, Axes3D]:
         """Resolve the 3-D `(fig, ax)` to draw on, creating a 3-D axes if none was supplied.
 
@@ -376,6 +478,16 @@ class TexturedGlobeGlyph:
     def brightness(self) -> float:
         """The brightness multiplier applied to the RGB channels."""
         return self._brightness
+
+    @property
+    def sun(self) -> np.ndarray | None:
+        """The unit light direction in world space, or `None` for even (unlit) rendering."""
+        return self._sun
+
+    @property
+    def ambient(self) -> float:
+        """The ambient floor (fraction) kept on the unlit side under directional lighting."""
+        return self._ambient
 
     @property
     def default_options(self) -> dict:
@@ -449,7 +561,13 @@ class TexturedGlobeGlyph:
     # Rendering                                                            #
     # ------------------------------------------------------------------ #
     def draw(
-        self, ax: Axes3D | None = None, *, spin: float = 0.0, **kwargs
+        self,
+        ax: Axes3D | None = None,
+        *,
+        spin: float = 0.0,
+        sun: tuple[float, float, float] | None = _INHERIT,
+        ambient: float = _INHERIT,
+        **kwargs,
     ) -> tuple[Figure, Axes3D]:
         """Render the textured globe onto a 3-D axes at a given spin angle.
 
@@ -457,6 +575,10 @@ class TexturedGlobeGlyph:
             ax: A 3-D matplotlib axes (`Axes3D`) to draw on. If `None`, the instance's `ax` is used, or a new 3-D axes
                 is created on the instance's `fig` (or a new figure sized by the `figsize` option).
             spin: Rotation of the globe about its tilted polar axis, in degrees. The camera stays put.
+            sun: Light direction for this call, overriding the instance's `sun`. A length-3 world-space vector, or
+                `None` to render evenly. Omitted (default) inherits the value passed to `__init__`.
+            ambient: Ambient floor for this call, overriding the instance's `ambient`. Omitted inherits the
+                constructor value. Ignored when the effective `sun` is `None`.
             **kwargs: Render options overriding the instance defaults for this call (`figsize`, `elev`, `azim`,
                 `background`). `figsize` applies only when a new figure is created; it is ignored when drawing onto
                 an existing (supplied or instance) axes. An unrecognised key raises `ValueError`.
@@ -466,19 +588,29 @@ class TexturedGlobeGlyph:
                 available as the `surface` attribute.
 
         Raises:
-            ValueError: If `ax` is supplied but is not a 3-D axes, or if an unknown render option is passed.
+            ValueError: If `ax` is supplied but is not a 3-D axes, if `sun`/`ambient` are invalid, or if an unknown
+                render option is passed.
 
         Examples:
-            ```python
-            >>> import numpy as np
-            >>> from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
-            >>> texture = np.zeros((16, 32, 3), dtype=np.uint8)
-            >>> texture[:, :16] = (200, 40, 40)
-            >>> fig, ax = TexturedGlobeGlyph(texture, n_lon=36, n_lat=18).draw(spin=90.0)
-            >>> ax.name
-            '3d'
+            - Render a spun frame:
+                ```python
+                >>> import numpy as np
+                >>> from cleopatra.glyphs.globe.textured_globe_glyph import TexturedGlobeGlyph
+                >>> texture = np.zeros((16, 32, 3), dtype=np.uint8)
+                >>> texture[:, :16] = (200, 40, 40)
+                >>> fig, ax = TexturedGlobeGlyph(texture, n_lon=36, n_lat=18).draw(spin=90.0)
+                >>> ax.name
+                '3d'
 
-            ```
+                ```
+            - Light it from the `+x` direction for a day/night terminator:
+                ```python
+                >>> globe = TexturedGlobeGlyph(np.full((16, 32, 3), 200, np.uint8), n_lon=36, n_lat=18)
+                >>> fig, ax = globe.draw(sun=(1.0, 0.0, 0.0), ambient=0.15)
+                >>> ax.name
+                '3d'
+
+                ```
         """
         self._reject_unknown_options(kwargs)
         options = self._default_options.copy()
@@ -491,12 +623,14 @@ class TexturedGlobeGlyph:
             fig.set_facecolor(options["background"])
             target.set_facecolor(options["background"])
 
+        sun_vec = self._sun if sun is _INHERIT else self._normalize_sun(sun)
+        amb = self._ambient if ambient is _INHERIT else self._validate_ambient(ambient)
         x, y, z = self._spun_mesh(spin)
         surface = target.plot_surface(
             x,
             y,
             z,
-            facecolors=self._facecolors,
+            facecolors=self._lit_facecolors((x, y, z), sun_vec, amb),
             rstride=1,
             cstride=1,
             shade=False,
@@ -521,6 +655,8 @@ class TexturedGlobeGlyph:
         n_frames: int = 60,
         revolutions: float = 1.0,
         start_spin: float = 0.0,
+        sun: tuple[float, float, float] | None = _INHERIT,
+        ambient: float = _INHERIT,
         interval: int = 50,
         **kwargs,
     ) -> FuncAnimation:
@@ -536,6 +672,10 @@ class TexturedGlobeGlyph:
             n_frames: Number of frames in the animation.
             revolutions: How many full turns the globe makes over `n_frames` (`1.0` = one 360 deg rotation).
             start_spin: Spin angle of the first frame, in degrees.
+            sun: Light direction forwarded to `draw` on every frame (world space; overrides the instance's `sun`).
+                Held fixed while the globe spins, so the terminator sweeps across the surface. Omitted inherits the
+                constructor value; `None` renders evenly.
+            ambient: Ambient floor forwarded to `draw` on every frame. Omitted inherits the constructor value.
             interval: Delay between frames in milliseconds (matplotlib playback hint).
             **kwargs: Render options forwarded to `draw` on every frame (`figsize`, `elev`, `azim`, `background`).
 
@@ -566,7 +706,13 @@ class TexturedGlobeGlyph:
         )
 
         def _update(frame_index: int):
-            self.draw(target, spin=float(angles[frame_index]), **kwargs)
+            self.draw(
+                target,
+                spin=float(angles[frame_index]),
+                sun=sun,
+                ambient=ambient,
+                **kwargs,
+            )
             return (self._surface,)
 
         return FuncAnimation(

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -323,6 +323,103 @@ class TestIntrospection:
         assert opts["azim"] == 0.0  # untouched default retained
 
 
+class TestLighting:
+    def test_sun_defaults_to_none_even(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        assert globe.sun is None
+        globe._prepare()
+        # sun=None returns the cache unchanged -- byte-identical to a 0.33.0 unlit render
+        lit = globe._lit_facecolors(globe._spun_mesh(0.0), None, globe.ambient)
+        assert lit is globe._facecolors
+
+    def test_default_ambient(self, texture):
+        assert TexturedGlobeGlyph(texture).ambient == pytest.approx(0.13)
+
+    def test_sun_normalised_to_unit(self, texture):
+        globe = TexturedGlobeGlyph(texture, sun=(3.0, 0.0, 0.0))
+        assert np.allclose(globe.sun, [1.0, 0.0, 0.0])
+
+    def test_lighting_produces_terminator(self):
+        tex = np.full((8, 16, 3), 200, np.uint8)
+        globe = TexturedGlobeGlyph(tex, n_lon=48, n_lat=24)
+        globe._prepare()
+        lit = globe._lit_facecolors(
+            globe._spun_mesh(0.0), np.array([1.0, 0.0, 0.0]), 0.13
+        )
+        rgb = lit[..., :3]
+        assert (
+            rgb.min() < 0.5 * rgb.max()
+        )  # a real day/night range on a uniform texture
+
+    def test_ambient_floor_not_black(self):
+        tex = np.full((8, 16, 3), 200, np.uint8)
+        globe = TexturedGlobeGlyph(tex, n_lon=24, n_lat=12)
+        globe._prepare()
+        cache_max = float(globe._facecolors[..., :3].max())
+        lit = globe._lit_facecolors(
+            globe._spun_mesh(0.0), np.array([1.0, 0.0, 0.0]), 0.2
+        )
+        assert float(lit[..., :3].min()) == pytest.approx(0.2 * cache_max, abs=1e-6)
+
+    def test_lit_fraction_tracks_spin(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12, sun=(1.0, 0.0, 0.0))
+        globe._prepare()
+        lit0 = globe._lit_facecolors(globe._spun_mesh(0.0), globe.sun, globe.ambient)
+        lit180 = globe._lit_facecolors(
+            globe._spun_mesh(180.0), globe.sun, globe.ambient
+        )
+        assert not np.allclose(
+            lit0, lit180
+        )  # fixed sun, spinning globe -> terminator moves
+
+    def test_cache_not_mutated_by_lighting(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12, sun=(1.0, 0.0, 0.0))
+        globe._prepare()
+        before = globe._facecolors.copy()
+        globe.draw()
+        assert np.array_equal(
+            globe._facecolors, before
+        )  # no re-sample / mutation per frame
+
+    def test_draw_sun_none_disables_instance_light(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12, sun=(1.0, 0.0, 0.0))
+        globe._prepare()
+        lit = globe._lit_facecolors(globe._spun_mesh(0.0), None, globe.ambient)
+        assert lit is globe._facecolors
+
+    def test_draw_accepts_sun_on_init_and_per_call(self, texture):
+        fig, ax = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12, sun=(1, 0, 0)).draw()
+        assert ax.name == "3d"
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        globe.draw(sun=(0, 0, 1), ambient=0.25)
+        assert globe.surface is not None
+
+    def test_animate_forwards_sun(self, texture, tmp_path):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        fig = plt.figure()
+        ax = fig.add_subplot(projection="3d")
+        anim = globe.animate(ax, n_frames=3, sun=(1.0, 0.0, 0.0))
+        anim.save(tmp_path / "lit.gif", writer="pillow", fps=5)
+        assert len(ax.collections) == 1
+
+    @pytest.mark.parametrize(
+        "bad_sun", [(1.0, 0.0), (0.0, 0.0, 0.0), (np.nan, 0.0, 0.0), (1, 2, 3, 4)]
+    )
+    def test_bad_sun_raises(self, texture, bad_sun):
+        with pytest.raises(ValueError):
+            TexturedGlobeGlyph(texture, sun=bad_sun)
+
+    @pytest.mark.parametrize("bad_ambient", [-0.1, 1.5])
+    def test_bad_ambient_raises(self, texture, bad_ambient):
+        with pytest.raises(ValueError):
+            TexturedGlobeGlyph(texture, ambient=bad_ambient)
+
+    def test_draw_bad_sun_raises(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        with pytest.raises(ValueError):
+            globe.draw(sun=(0.0, 0.0, 0.0))
+
+
 def test_no_new_dependency():
     """The globe uses mpl_toolkits.mplot3d, which ships with matplotlib -- no new dependency."""
     import mpl_toolkits.mplot3d as m3d

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -465,16 +465,23 @@ class TestLighting:
             globe.animate(ax, n_frames=3, ambient=5.0)
 
     def test_world_space_sun_honoured_under_tilt(self):
-        # a uniform texture lit from +z (north): with a 45deg tilt the north cap is brighter than the south
+        # sun is world-space (+z), not body-space. With a 45deg tilt the geographic north
+        # cap leans toward +z (so north > south), but it is NOT the brightest region --
+        # an equatorial face pointing straight at world +z is. A body-space regression
+        # (dotting the un-tilted normals) would instead light the pole fully (north == peak).
         tex = np.full((16, 32, 3), 200, np.uint8)
         globe = TexturedGlobeGlyph(tex, n_lon=48, n_lat=24, tilt_deg=45.0)
         globe._prepare()
         lit = globe._lit_facecolors(
             globe._spun_mesh(0.0), np.array([0.0, 0.0, 1.0]), 0.1
         )
-        north = lit[0, :, :3].mean()
-        south = lit[-1, :, :3].mean()
-        assert north > south
+        north = float(lit[0, :, :3].mean())
+        south = float(lit[-1, :, :3].mean())
+        peak = float(lit[..., :3].max())
+        assert north > south  # tilt leans the north cap toward the light
+        assert (
+            north < peak - 0.1
+        )  # but the pole is not the peak -> world-space, not body-space
 
 
 def test_no_new_dependency():

--- a/tests/test_textured_globe_glyph.py
+++ b/tests/test_textured_globe_glyph.py
@@ -419,6 +419,63 @@ class TestLighting:
         with pytest.raises(ValueError):
             globe.draw(sun=(0.0, 0.0, 0.0))
 
+    @pytest.mark.parametrize("bad_sun", [[[1.0, 0.0, 0.0]], np.zeros((3, 1)), 1.0])
+    def test_non_1d_sun_raises(self, texture, bad_sun):
+        with pytest.raises(ValueError):
+            TexturedGlobeGlyph(texture, sun=bad_sun)
+
+    def test_ambient_nan_raises(self, texture):
+        with pytest.raises(ValueError):
+            TexturedGlobeGlyph(texture, ambient=float("nan"))
+
+    def test_ambient_zero_gives_black_night(self):
+        tex = np.full((8, 16, 3), 200, np.uint8)
+        globe = TexturedGlobeGlyph(tex, n_lon=24, n_lat=12)
+        globe._prepare()
+        lit = globe._lit_facecolors(
+            globe._spun_mesh(0.0), np.array([1.0, 0.0, 0.0]), 0.0
+        )
+        assert float(lit[..., :3].min()) == pytest.approx(
+            0.0, abs=1e-9
+        )  # night -> black
+
+    def test_ambient_one_equals_cache(self):
+        tex = np.full((8, 16, 3), 200, np.uint8)
+        globe = TexturedGlobeGlyph(tex, n_lon=24, n_lat=12)
+        globe._prepare()
+        lit = globe._lit_facecolors(
+            globe._spun_mesh(0.0), np.array([1.0, 0.0, 0.0]), 1.0
+        )
+        assert np.allclose(lit, globe._facecolors)  # no dimming at ambient=1
+
+    def test_animate_validates_sun_eagerly(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        fig = plt.figure()
+        ax = fig.add_subplot(projection="3d")
+        with pytest.raises(
+            ValueError
+        ):  # raised at the animate() call, not at frame render
+            globe.animate(ax, n_frames=3, sun=(0.0, 0.0, 0.0))
+
+    def test_animate_validates_ambient_eagerly(self, texture):
+        globe = TexturedGlobeGlyph(texture, n_lon=24, n_lat=12)
+        fig = plt.figure()
+        ax = fig.add_subplot(projection="3d")
+        with pytest.raises(ValueError):
+            globe.animate(ax, n_frames=3, ambient=5.0)
+
+    def test_world_space_sun_honoured_under_tilt(self):
+        # a uniform texture lit from +z (north): with a 45deg tilt the north cap is brighter than the south
+        tex = np.full((16, 32, 3), 200, np.uint8)
+        globe = TexturedGlobeGlyph(tex, n_lon=48, n_lat=24, tilt_deg=45.0)
+        globe._prepare()
+        lit = globe._lit_facecolors(
+            globe._spun_mesh(0.0), np.array([0.0, 0.0, 1.0]), 0.1
+        )
+        north = lit[0, :, :3].mean()
+        south = lit[-1, :, :3].mean()
+        assert north > south
+
 
 def test_no_new_dependency():
     """The globe uses mpl_toolkits.mplot3d, which ships with matplotlib -- no new dependency."""


### PR DESCRIPTION
# Description

Adds **directional lighting** to `TexturedGlobeGlyph` so the sphere can be lit from a direction —
shading a lambertian day/night terminator instead of reading as evenly illuminated. This is the
follow-up #311/0.33.0 did not cover, found while adopting the glyph downstream in earthlens (the
eclipse-geometry notebook had to keep a hand-rolled `textured_earth` because the terminator is its
actual subject).

- **`sun`** (a world-space `(x, y, z)` direction, auto-normalised to unit length) and **`ambient`**
  (floor so the night side stays legible, default `0.13`) on `__init__`, and **overridable per call**
  on `draw`/`animate` — mirroring how `spin` works, via a sentinel so an explicit `sun=None` can turn
  lighting off for one call.
- **Preserves the sample-once / rotate-per-frame design.** Lighting is applied per frame from the
  vertices `draw` already rotates (`_spun_mesh(spin)`, whose unit-sphere positions are the surface
  normals): a copy of the cached `facecolors` is scaled by
  `ambient + (1 - ambient)·clip(dot(normal, sun), 0, 1)`. The `facecolors` cache is never mutated and
  the texture is never re-sampled — so a fixed `sun` with a spinning globe sweeps the terminator across
  the surface.
- **`sun=None` (the default) is byte-identical to 0.33.0** — every current caller is unchanged.
- Per-face lighting detail: `facecolors` are per-face while mesh normals are per-vertex, so each quad's
  four corner normals are averaged to line the lit factor up with the faces.

**Frame:** `sun` is in the same world frame the globe is drawn in — `+z` up/north, `+x` toward the
viewer at `spin=0`. **Scope:** small, backward-compatible enhancement to the already-shipped globe
glyph — NumPy in → matplotlib out, no new dependency (a dot product). No specular/atmosphere/cast
shadows (out of scope, per the issue).

No new runtime dependencies.

# Issues

- Closes #319 — let TexturedGlobeGlyph light the sphere from a direction

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Dev changes (CI/pyproject.toml/docs/examples/testing)

# How Has This Been Tested?

New `TestLighting` cases in `tests/test_textured_globe_glyph.py` (60 tests total; **100% line + branch**
coverage of the module) covering the issue's Definition of Done:

- **`sun=None` byte-identical** — returns the cached `facecolors` by identity (unlit regression).
- **Terminator + ambient floor** — a uniform texture shows a real day/night range; the darkest lit face
  equals `ambient × cache` (night side not black).
- **Lit fraction tracks `spin`** — a fixed sun with the globe at spin 0 vs 180 gives different facecolors.
- **No re-sample / no mutation per frame** — the `facecolors` cache is unchanged after a lit `draw`.
- **`sun` on `__init__` and per-call override**; `draw(sun=None)` disables an instance light; `sun`
  auto-normalised; `animate(sun=...)` forwards per frame (rendered via the Pillow writer).
- **Validation** — bad `sun` (wrong length / zero / non-finite) and `ambient` outside `[0, 1]` raise.

Reproduce (external uv env, worktree on `src`):

```
VIRTUAL_ENV=C:/python-environments/uv/cleopatra PYTHONPATH=src \
  C:/python-environments/uv/cleopatra/Scripts/python.exe -m pytest tests/test_textured_globe_glyph.py -q
```

- [x] Test A — `tests/test_textured_globe_glyph.py` (60 passed, 100% coverage)
- [x] Test B — full suite `pytest tests/ -q` → 2532 passed; `ruff check` + `ruff format --check` clean;
  module doctests pass

# Checklist:

- [ ] updated version number in pyproject.toml
- [ ] added changes to History.rst
- [ ] updated the latest version in README file
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
